### PR TITLE
Add tag content_negotiation to ID9 and ID40

### DIFF
--- a/ucr/index.html
+++ b/ucr/index.html
@@ -692,6 +692,7 @@ Users need a way to view the aggregated collection level metadata and the associ
         <span class="tag class_quality">quality</span>
         <span class="tag class_referencing">referencing</span>
         <span class="tag class_roles">roles</span>
+	<span class="tag class_content_negotiation">content_negotiation</span>
       </p>
       <p class="stakeholders">
         <p>data consumer, data producer, data publisher</p>
@@ -2227,7 +2228,8 @@ Within Informatie Vlaanderen, a project is running of combining the two worlds i
       <p class="contributor">Rob Atkinson</p>
       <p class="tags">
         <span class="tag class_dcat">dcat</span>
-        <span class="tag class_profile">profile</span>    
+        <span class="tag class_profile">profile</span>
+	<span class="tag class_content_negotiation">content_negotiation</span>
       </p>
       <p class="stakeholders">
         <p>data publishers, search engines, data users</p>


### PR DESCRIPTION
Triggered by [Action 40](https://www.w3.org/2017/dxwg/track/actions/40). IMHO ID9 and ID40 are not only about profiles but also about content negotiation (although they can be hard to separate)