### PR TITLE
Added markup for bib references

### DIFF
--- a/ucr/index.html
+++ b/ucr/index.html
@@ -701,7 +701,7 @@ Users need a way to view the aggregated collection level metadata and the associ
         <p class="description">
           <p>The <a rel="nofollow" class="external text" href="https://ec.europa.eu/jrc/">European Commission's Joint Research Centre (JRC)</a> is a multidisciplinary research organization with the mission of supporting EU policies with independent evidence throughout the whole policy life-cycle. </p>
           <p>In order to provide a single access and discovery point to JRC data, in 2016 <a rel="nofollow" class="external text" href="http://data.jrc.ec.europa.eu/">a corporate data catalog</a> has been launched, where datasets are documented by using a modular metadata schema, consisting of a <i>core</i> profile, defining the elements that should be common to all metadata records, and a set of <i>domain-specific extensions</i>.</p>
-          <p>The reference metadata standard used is the <i>DCAT application profile for European data portals</i> [DCAT-AP] (the <i>de facto</i> EU standard metadata interchange format), and the related domain-specific extensions - namely, [GeoDCAT-AP], for geospatial metadata, and [StatDCAT-AP], for statistical metadata. The core profile of JRC metadata is however not using [DCAT-AP] as is, but it complements it with a number of metadata elements that have been identified as most relevant across scientific domains, and which are required in order to support data citation.</p>
+          <p>The reference metadata standard used is the <i>DCAT application profile for European data portals</i> [[DCAT-AP]] (the <i>de facto</i> EU standard metadata interchange format), and the related domain-specific extensions - namely, [[GeoDCAT-AP]], for geospatial metadata, and [[StatDCAT-AP]], for statistical metadata. The core profile of JRC metadata is however not using [[DCAT-AP]] as is, but it complements it with a number of metadata elements that have been identified as most relevant across scientific domains, and which are required in order to support data citation.</p>
           <p>More precisely, the most common, cross-domain requirements identified at JRC are following ones:</p>
           <ul>
         <li> Ability to indicate dataset authors.</li>
@@ -712,8 +712,8 @@ Users need a way to view the aggregated collection level metadata and the associ
       </ul>
         </p>
         <p class="existing_approaches">
-          <p>[VOCAB-DCAT] does not provide guidance on how to model this information. [DCAT-AP] and [GeoDCAT-AP] partially support these requirements - namely, the specification of dataset authors (<code>dcterms:creator</code> [DCTerms]), data lineage (<code>dcterms:provenance</code> [DCTerms]), and input data (<code>dcterms:source</code> [DCTerms]). For the two remaining requirements, the JRC metadata schema makes use of <code>dcterms:isReferencedBy</code> [DCTerms] (publications) and <code>vann:usageNote</code> [VANN] (usage notes).</p>
-          <p>These solutions allow a simplified description of the dataset <i>context</i>, that can be used for multiple purposes - as assessing the quality and fitness for use of a dataset, or identifying the dataset most commonly used as input data. Additional details could be provided by representing more precisely these relationship with "qualified" forms by using vocabularies as [PROV-O], [VOCAB-DQV], or [VOCAB-DUV]: for instance, the relationship between a dataset and input data can be complemented with the model used for processing them, and possibly with additional information on the data generation workflow.</p>
+          <p>[[VOCAB-DCAT]] does not provide guidance on how to model this information. [[DCAT-AP]] and [[GeoDCAT-AP]] partially support these requirements - namely, the specification of dataset authors (<code>dcterms:creator</code> [[DCTerms]]), data lineage (<code>dcterms:provenance</code> [[DCTerms]]), and input data (<code>dcterms:source</code> [[DCTerms]]). For the two remaining requirements, the JRC metadata schema makes use of <code>dcterms:isReferencedBy</code> [[DCTerms]] (publications) and <code>vann:usageNote</code> [[VANN]] (usage notes).</p>
+          <p>These solutions allow a simplified description of the dataset <i>context</i>, that can be used for multiple purposes - as assessing the quality and fitness for use of a dataset, or identifying the dataset most commonly used as input data. Additional details could be provided by representing more precisely these relationship with "qualified" forms by using vocabularies as [[PROV-O]], [[VOCAB-DQV]], or [[VOCAB-DUV]]: for instance, the relationship between a dataset and input data can be complemented with the model used for processing them, and possibly with additional information on the data generation workflow.</p>
         </p>
         <p class="links">
           <ul>
@@ -765,14 +765,14 @@ Users need a way to view the aggregated collection level metadata and the associ
       </ul>
         </p>
         <p class="existing_approaches">
-          <p><a rel="nofollow" class="external text" href="https://webgate.ec.europa.eu/CITnet/stash/projects/ODCKAN/repos/datacite-to-dcat-ap/">A study</a> has been carried out at the <a rel="nofollow" class="external text" href="https://ec.europa.eu/jrc/">European Commission's Joint Research Centre (JRC)</a>, in order to create mappings between [DataCite] (the current <i>de facto</i> standard for data citation) and [DCAT-AP]. </p>
-          <p>The results show that [DCAT-AP] covers most of the required [DataCite] metadata elements, but some of them are missing. In particular:</p>
+          <p><a rel="nofollow" class="external text" href="https://webgate.ec.europa.eu/CITnet/stash/projects/ODCKAN/repos/datacite-to-dcat-ap/">A study</a> has been carried out at the <a rel="nofollow" class="external text" href="https://ec.europa.eu/jrc/">European Commission's Joint Research Centre (JRC)</a>, in order to create mappings between [[DataCite]] (the current <i>de facto</i> standard for data citation) and [[DCAT-AP]]. </p>
+          <p>The results show that [[DCAT-AP]] covers most of the required [[DataCite]] metadata elements, but some of them are missing. In particular:</p>
           <ul>
-        <li> Mandatory elements:<ul><li> Dataset creator (but [GeoDCAT-AP] supports it)</li></ul></li>
-        <li> Recommended elements:<ul><li> [DCAT-AP] does not cover all the types of identifiers, dates, contributors and resources supported by [DataCite]</li></ul></li>
+        <li> Mandatory elements:<ul><li> Dataset creator (but [[GeoDCAT-AP]] supports it)</li></ul></li>
+        <li> Recommended elements:<ul><li> [[DCAT-AP]] does not cover all the types of identifiers, dates, contributors and resources supported by [[DataCite]]</li></ul></li>
         <li> Optional elements:<ul><li> Funding reference</li></ul></li>
       </ul>
-          <p>Guidance should be provided on how to model this information in order to enable data citation also in records represented with [VOCAB-DCAT] and related application profiles.</p>
+          <p>Guidance should be provided on how to model this information in order to enable data citation also in records represented with [[VOCAB-DCAT]] and related application profiles.</p>
         </p>
         <p class="links">
           <ul>
@@ -821,8 +821,8 @@ Users need a way to view the aggregated collection level metadata and the associ
         </p>
         <p class="existing_approaches">
           <p>When encoded as HTTP URIs, the usual approach to model primary and alternative identifiers is to use the former as the resource URI, whereas the latter are specified by using <code>owl:sameAs</code>. In this case, the information about the identifier type is not explicitly specified, and can be derived only from the URI syntax - although this is not always possible.</p>
-          <p>To model identifiers as literals, [VOCAB-DCAT] uses <code>dcterms:identifier</code>, but it makes no distinction between primary / alternative identifiers, or the identifier type. For alternative identifiers, [DCAT-AP] recommends class <code>adms:Identifier</code> [VOCAB-ADMS], which can be used to specify the identifier type, plus additional information - namely, the identifier scheme agency and the identifier issue date. It is worth noting that the <code>adms:Identifier</code> has the primary purpose of describing the identifier itself, which makes it less suitable for linking purposes.</p>
-          <p>Finally, a number of vocabularies have defined specific properties for modeling identifier types, as <code>prism:doi</code> [PRISM] and <code>bibo:doi</code> [BIBO] for DOIs. Moreover, starting from <a rel="nofollow" class="external text" href="http://schema.org/version/3.2/">version 3.2</a>, [SCHEMA-ORG] has defined a super-property <a rel="nofollow" class="external text" href="http://schema.org/identifier"><code>schema:identifier</code></a> for all the identifier-specific properties already used in [SCHEMA-ORG].</p>
+          <p>To model identifiers as literals, [[VOCAB-DCAT]] uses <code>dcterms:identifier</code>, but it makes no distinction between primary / alternative identifiers, or the identifier type. For alternative identifiers, [[DCAT-AP]] recommends class <code>adms:Identifier</code> [[VOCAB-ADMS]], which can be used to specify the identifier type, plus additional information - namely, the identifier scheme agency and the identifier issue date. It is worth noting that the <code>adms:Identifier</code> has the primary purpose of describing the identifier itself, which makes it less suitable for linking purposes.</p>
+          <p>Finally, a number of vocabularies have defined specific properties for modeling identifier types, as <code>prism:doi</code> [[PRISM]] and <code>bibo:doi</code> [[BIBO]] for DOIs. Moreover, starting from <a rel="nofollow" class="external text" href="http://schema.org/version/3.2/">version 3.2</a>, [[SCHEMA-ORG]] has defined a super-property <a rel="nofollow" class="external text" href="http://schema.org/identifier"><code>schema:identifier</code></a> for all the identifier-specific properties already used in [[SCHEMA-ORG]].</p>
           <p>An alternative approach is to denote the identifier type with an RDF datatype. In such a case, the same property can be used to specify the identifier - e.g., <code>dcterms:identifier</code>. This solution has the advantage of being able to easily identify all literals used as identifiers (you just have to lookup / search for the same property), whereas the datatype can be used to filter specific identifier types.</p>
           <p>KC: Note that the libraries/archives community has identifiers that are not (yet) actionable, like ISBNs, ISSNs. These can be coded as dcterms:identifier strings but the string itself is not unique. Not sure how these fit into the overall picture but perhaps we can task someone to bring a specific proposal.</p>
         </p>
@@ -863,8 +863,8 @@ Users need a way to view the aggregated collection level metadata and the associ
           <p>Data lineage is typically specified with a more or less detailed human-targeted documentation. In very few cases, this information is represented in a formal, machine-readable way, enabling a (semi)automated data processing workflow that can be used to re-run the experiment from which the data were produced.</p>
         </p>
         <p class="existing_approaches">
-          <p>[DCAT-AP] uses property <code>dcterms:provenance</code> [DCTerms] to specify a human-readable documentation of data lineage, that can be either embedded in metadata or described in a document linked from the metadata record itself. Moreover, <code>dcterms:source</code> can be used to refer to the input data.</p>
-          <p>[PROV-O] can be used in order to provide a machine-readable description of data lineage, but best practices on how to use it consistently are missing.</p>
+          <p>[[DCAT-AP]] uses property <code>dcterms:provenance</code> [[DCTerms]] to specify a human-readable documentation of data lineage, that can be either embedded in metadata or described in a document linked from the metadata record itself. Moreover, <code>dcterms:source</code> can be used to refer to the input data.</p>
+          <p>[[PROV-O]] can be used in order to provide a machine-readable description of data lineage, but best practices on how to use it consistently are missing.</p>
         </p>
         <p class="links">
           <ul>
@@ -901,14 +901,14 @@ Users need a way to view the aggregated collection level metadata and the associ
       <div class="expandOrCollapse" onclick="toggleVisibility(this)">&#x25B6; Full use case description (click to collapse):</div>
       <div class="visible">
         <p class="description">
-          <p>Each metadata standard has its own set of agent roles, and they all use their own vocabularies / code lists. E.g., the latest version (2014) of [ISO-19115] has <a rel="nofollow" class="external text" href="https://geo-ide.noaa.gov/wiki/index.php?title=ISO_19115_and_19115-2_CodeList_Dictionaries#CI_RoleCode">20 roles</a>, and [DataCite] even more.</p>
+          <p>Each metadata standard has its own set of agent roles, and they all use their own vocabularies / code lists. E.g., the latest version (2014) of [[ISO-19115-1]] has <a rel="nofollow" class="external text" href="https://geo-ide.noaa.gov/wiki/index.php?title=ISO_19115_and_19115-2_CodeList_Dictionaries#CI_RoleCode">20 roles</a>, and [[DataCite]] even more.</p>
           <p>Two of the main issues concern (a) how to ensure interoperability across roles defined in different standards, and (b) if it makes sense to support all of them across platforms. The latter point follows from a common issue in metadata standards supporting multiple roles, with overlapping semantics (e.g., the difference between a data distributor and a data publisher is not always clear). In these scenarios, whenever metadata are not created by specialists, roles frequently happen to be used inconsistently.</p>
           <p>As far as research data are concerned, agent roles are important to denote the type of contribution provided by each individual / organization in producing data. </p>
           <p>Moreover, in some cases, an additional requirement is to specify the temporal dimension of a role &#x2013; i.e., the time frame during which an individual / organisation played a given role - and, maybe, also other information &#x2013; e.g., the organisation where the individual held a given position while playing that role.</p>
         </p>
         <p class="existing_approaches">
-          <p>[DCTerms] defines a limited number of agent roles as properties. [VOCAB-DCAT] re-uses some of them (in particular, <code>dcterms:publisher</code>), plus it defines a new one, namely, <code>dcat:contactPoint</code>. [DCAT-AP] and [GeoDCAT-AP] provide guidance on the use of other [DCTerms] roles - in particular, <code>dcterms:creator</code>, <code>dcterms:rightsHolder</code>. Anyway, the role properties defined in [DCTerms] and [VOCAB-DCAT] model just a subset of the agent roles defined in other standards. Moreover, they cannot be used to associate a role with other information concerning its temporal / organizational context.</p>
-          <p>[PROV-O] could be used for this purpose by using a &#x201C;qualified attribution&#x201D;. This is, for instance, the approach used in [GeoDCAT-AP] to model agent roles defined in [ISO-19115] but not supported in [DCTerms] and [VOCAB-DCAT]:</p>
+          <p>[[DCTerms]] defines a limited number of agent roles as properties. [[VOCAB-DCAT]] re-uses some of them (in particular, <code>dcterms:publisher</code>), plus it defines a new one, namely, <code>dcat:contactPoint</code>. [[DCAT-AP]] and [[GeoDCAT-AP]] provide guidance on the use of other [[DCTerms]] roles - in particular, <code>dcterms:creator</code>, <code>dcterms:rightsHolder</code>. Anyway, the role properties defined in [[DCTerms]] and [[VOCAB-DCAT]] model just a subset of the agent roles defined in other standards. Moreover, they cannot be used to associate a role with other information concerning its temporal / organizational context.</p>
+          <p>[[PROV-O]] could be used for this purpose by using a &#x201C;qualified attribution&#x201D;. This is, for instance, the approach used in [[GeoDCAT-AP]] to model agent roles defined in [[ISO-19115-1]] but not supported in [[DCTerms]] and [[VOCAB-DCAT]]:</p>
           <pre>
 a:Dataset a dcat:Dataset; 
   prov:qualifiedAttribution [ a prov:Attribution&#xA0;;
@@ -917,7 +917,7 @@ a:Dataset a dcat:Dataset;
 # The agent playing that role
     prov:agent [ a foaf:Organization&#xA0;;
       foaf:name "European Union"@en ] ] .</pre>
-          <p>However, to address the different use cases, such &#x201C;qualified roles&#x201D; should be compatible with the corresponding non-qualified forms, and both should be mutually inferable. For instance, the example above in [GeoDCAT-AP] is considered as equivalent to:</p>
+          <p>However, to address the different use cases, such &#x201C;qualified roles&#x201D; should be compatible with the corresponding non-qualified forms, and both should be mutually inferable. For instance, the example above in [[GeoDCAT-AP]] is considered as equivalent to:</p>
           <pre>
 a:Dataset a dcat:Dataset;
   dcterms:rightsHolder [ a foaf:Organization&#xA0;;
@@ -964,10 +964,10 @@ a:Dataset a dcat:Dataset;
         <li> Compliance with given quality benchmarks, standards, specifications.</li>
         <li> Quality assessments based on data review / users' feedback.</li>
       </ul>
-          <p>In order to provide a mechanism for the consistent representation of data quality, the most frequently used data quality aspects should be identified, based on existing standards (e.g., [ISO-19115]) and practices. Such aspects should also be used to identify possible common modeling patterns.</p>
+          <p>In order to provide a mechanism for the consistent representation of data quality, the most frequently used data quality aspects should be identified, based on existing standards (e.g., [[ISO-19115-1]]) and practices. Such aspects should also be used to identify possible common modeling patterns.</p>
         </p>
         <p class="existing_approaches">
-          <p>Solutions for modeling data quality have been defined in [DCAT-AP], [GeoDCAT-AP], [StatDCAT-AP], [VOCAB-DQV], and [VOCAB-DUV]. They cover the following aspects:</p>
+          <p>Solutions for modeling data quality have been defined in [[DCAT-AP]], [[GeoDCAT-AP]], [[StatDCAT-AP]], [[VOCAB-DQV]], and [[VOCAB-DUV]]. They cover the following aspects:</p>
           <ul>
         <li> Metadata conformance with a metadata standard.</li>
         <li> Data conformance with a given data schema/model.</li>
@@ -978,7 +978,7 @@ a:Dataset a dcat:Dataset;
         <li> Data quality assessments expressed with quantitative test results.</li>
         <li> Data quality assessments via users&#x2019; feedback.</li>
       </ul>
-          <p>Notably, the first 4 aspects (those related to "conformance") follow a common pattern in that the reference vocabularies model all them by using property <code>dcterms:conformsTo</code> [DCTerms].</p>
+          <p>Notably, the first 4 aspects (those related to "conformance") follow a common pattern in that the reference vocabularies model all them by using property <code>dcterms:conformsTo</code> [[DCTerms]].</p>
         </p>
         <p class="links">
           <ul>
@@ -1013,17 +1013,17 @@ a:Dataset a dcat:Dataset;
       <div class="visible">
         <p class="description">
           <p>Understanding the level of precision and accuracy of a dataset is fundamental to verify its fitness for purpose. This is typically denoted in terms of spatial or temporal resolution, but other dimensions are also possible.</p>
-          <p>Some metadata standards include elements for specifying precision. For instance the latest version (2014) of [ISO-19115] supports the possibility of specifying spatial resolution in terms of scale (e.g., 1:1,000,000), distance - further split into horizontal ground distance, vertical distance, and angular distance - and level of detail. However, [VOCAB-DCAT] does not provide guidance on how to model this information. </p>
-          <p>Actually, for some time, [VOCAB-DCAT] included a property <a rel="nofollow" class="external text" href="https://www.w3.org/TR/2012/WD-vocab-dcat-20120405/#property--granularity"><code>dcat:granularity</code></a> to model precision, which was dropped in the final version of the vocabulary (see <a rel="nofollow" class="external text" href="https://www.w3.org/2011/gld/track/issues/10">ISSUE-10</a>, and, in particular, the <a rel="nofollow" class="external text" href="https://lists.w3.org/Archives/Public/public-gld-wg/2013Jan/0053.html">mail</a> proposing to drop this property).</p>
+          <p>Some metadata standards include elements for specifying precision. For instance the latest version (2014) of [[ISO-19115-1]] supports the possibility of specifying spatial resolution in terms of scale (e.g., 1:1,000,000), distance - further split into horizontal ground distance, vertical distance, and angular distance - and level of detail. However, [[VOCAB-DCAT]] does not provide guidance on how to model this information. </p>
+          <p>Actually, for some time, [[VOCAB-DCAT]] included a property <a rel="nofollow" class="external text" href="https://www.w3.org/TR/2012/WD-vocab-dcat-20120405/#property--granularity"><code>dcat:granularity</code></a> to model precision, which was dropped in the final version of the vocabulary (see <a rel="nofollow" class="external text" href="https://www.w3.org/2011/gld/track/issues/10">ISSUE-10</a>, and, in particular, the <a rel="nofollow" class="external text" href="https://lists.w3.org/Archives/Public/public-gld-wg/2013Jan/0053.html">mail</a> proposing to drop this property).</p>
         </p>
         <p class="existing_approaches">
-          <p>This issue was raised during the development of [VOCAB-DQV], and a solution has been proposed on how to model data precision in terms of spatial resolution - expressed as equivalent scale (e.g., 1:1,000,000) or distance (e.g., 1km) - and data accuracy as percentage - see [VOCAB-DQV], <a rel="nofollow" class="external text" href="https://www.w3.org/TR/vocab-dqv/#h-expressdatasetaccuracyprecision">Section 6.13 <i>Express dataset precision and accuracy</i></a>. Notably, the same approach can be followed to model temporal resolution. </p>
-          <p>[SDWBP] addresses this problem as well re-using the approach defined in [VOCAB-DQV], and, additionally, it provides an example on how to specify accuracy by stating conformance with a quality standard - see [SDWBP], <a rel="nofollow" class="external text" href="https://www.w3.org/TR/sdw-bp/#desc-accuracy">Best Practice 14: <i>Describe the positional accuracy of spatial data</i></a>.</p>
+          <p>This issue was raised during the development of [[VOCAB-DQV]], and a solution has been proposed on how to model data precision in terms of spatial resolution - expressed as equivalent scale (e.g., 1:1,000,000) or distance (e.g., 1km) - and data accuracy as percentage - see [[VOCAB-DQV]], <a rel="nofollow" class="external text" href="https://www.w3.org/TR/vocab-dqv/#h-expressdatasetaccuracyprecision">Section 6.13 <i>Express dataset precision and accuracy</i></a>. Notably, the same approach can be followed to model temporal resolution. </p>
+          <p>[[SDW-BP]] addresses this problem as well re-using the approach defined in [[VOCAB-DQV]], and, additionally, it provides an example on how to specify accuracy by stating conformance with a quality standard - see [[SDW-BP]], <a rel="nofollow" class="external text" href="https://www.w3.org/TR/sdw-bp/#desc-accuracy">Best Practice 14: <i>Describe the positional accuracy of spatial data</i></a>.</p>
         </p>
         <p class="links">
           <ul>
-        <li> [VOCAB-DQV], <a rel="nofollow" class="external text" href="https://www.w3.org/TR/vocab-dqv/#h-expressdatasetaccuracyprecision">Section 6.13 <i>Express dataset precision and accuracy</i></a></li>
-        <li> [SDWBP], <a rel="nofollow" class="external text" href="https://www.w3.org/TR/sdw-bp/#desc-accuracy">Best Practice 14: <i>Describe the positional accuracy of spatial data</i></a></li>
+        <li> [[VOCAB-DQV]], <a rel="nofollow" class="external text" href="https://www.w3.org/TR/vocab-dqv/#h-expressdatasetaccuracyprecision">Section 6.13 <i>Express dataset precision and accuracy</i></a></li>
+        <li> [[SDW-BP]], <a rel="nofollow" class="external text" href="https://www.w3.org/TR/sdw-bp/#desc-accuracy">Best Practice 14: <i>Describe the positional accuracy of spatial data</i></a></li>
         <li><a rel="nofollow" class="external text" href="https://www.w3.org/2016/11/sdsvoc/SDSVoc16_paper_25#modelling-service-api-based-data-access-problem-statement"><i>GeoDCAT-AP: Use cases and open issues</i>.</a> Smart Descriptions &amp; Smarter Vocabularies (SDSVoc). Amsterdam, 30 Nov - 1 Dec 2016.</li>
       </ul>
         </p>
@@ -1053,8 +1053,8 @@ a:Dataset a dcat:Dataset;
       <div class="visible">
         <p class="description">
           <p>One of the ways of expressing data quality is to verify whether a given dataset is (or not) conformant with a given quality standard / benchmark.</p>
-          <p>[ISO-19115] supports a way of modeling this information, by allowing to state whether a given dataset passed or not a given test result. Moreover, [INSPIRE-MD] extends this approach by supporting an additional possible result, namely, "not evaluated".</p>
-          <p>Another approach is provided by the [EARL] vocabulary, which provides a generic mechanisms to model test results. More precisely, [EARL] supports the following possible outcome values (quoting from <a rel="nofollow" class="external text" href="https://www.w3.org/TR/EARL10-Schema/#OutcomeValue">Section 2.7 <i>OutcomeValue Class</i></a>):</p>
+          <p>[[ISO-19115-1]] supports a way of modeling this information, by allowing to state whether a given dataset passed or not a given test result. Moreover, [[INSPIRE-MD]] extends this approach by supporting an additional possible result, namely, "not evaluated".</p>
+          <p>Another approach is provided by the [[EARL10]] vocabulary, which provides a generic mechanisms to model test results. More precisely, [[EARL10]] supports the following possible outcome values (quoting from <a rel="nofollow" class="external text" href="https://www.w3.org/TR/EARL10-Schema/#OutcomeValue">Section 2.7 <i>OutcomeValue Class</i></a>):</p>
           <blockquote>
         <dl>
           <dt>
@@ -1081,9 +1081,9 @@ a:Dataset a dcat:Dataset;
       </blockquote>
         </p>
         <p class="existing_approaches">
-          <p>[VOCAB-DQV] allows to specify data conformance with a reference quality standard / benchmark. However, this can model only one of the possible scenarios - i.e., when data are <i>conformant</i>. </p>
-          <p>[GeoDCAT-AP] provides an alternative and extended way of expressing "conformance" by using [PROV-O], allowing the specification of additional information about conformance tests (when this has been carried out, by whom, etc.), but also different conformance test results (namely, <i>conformant</i>, <i>not conformant</i>, <i>not evaluated</i>).</p>
-          <p>An example of the [GeoDCAT-AP] [PROV-O]-based representation of conformance is provided by the following code snippet:</p>
+          <p>[[VOCAB-DQV]] allows to specify data conformance with a reference quality standard / benchmark. However, this can model only one of the possible scenarios - i.e., when data are <i>conformant</i>. </p>
+          <p>[[GeoDCAT-AP]] provides an alternative and extended way of expressing "conformance" by using [[PROV-O]], allowing the specification of additional information about conformance tests (when this has been carried out, by whom, etc.), but also different conformance test results (namely, <i>conformant</i>, <i>not conformant</i>, <i>not evaluated</i>).</p>
+          <p>An example of the [[GeoDCAT-AP]] [[PROV-O]]-based representation of conformance is provided by the following code snippet:</p>
           <pre>
 a:Dataset a dcat:Dataset&#xA0;;
   prov:wasUsedBy a:TestingActivity .
@@ -1104,7 +1104,7 @@ a:ConformanceTest a prov:Plan&#xA0;;
                  Directive 2007/2/EC of the European Parliament and of the Council as regards 
                  interoperability of spatial data sets and services"@en
   dcterms:issued "2010-11-23"^^xsd:date .</pre>
-          <p>The example states that the reference dataset is conformant with the <i>Commission Regulation (EU) No 1089/2010 of 23 November 2010 implementing Directive 2007/2/EC of the European Parliament and of the Council as regards interoperability of spatial data sets and services</i>. Since this case corresponds to the scenario supported in [VOCAB-DQV], the [PROV-O]-based representation above is equivalent to:</p>
+          <p>The example states that the reference dataset is conformant with the <i>Commission Regulation (EU) No 1089/2010 of 23 November 2010 implementing Directive 2007/2/EC of the European Parliament and of the Council as regards interoperability of spatial data sets and services</i>. Since this case corresponds to the scenario supported in [[VOCAB-DQV]], the [[PROV-O]]-based representation above is equivalent to:</p>
           <pre>
 a:Dataset a dcat:Dataset&#xA0;;
   dcterms:conformsTo &lt;http://data.europa.eu/eli/reg/2014/1312/oj&gt; .
@@ -1150,7 +1150,7 @@ a:Dataset a dcat:Dataset&#xA0;;
           <p>Finally, whenever data are not publicly available, an explanation of a reason why they are closed should be provided - especially when these data are maintained by public authorities, or are the outcomes of public-funded research activities.</p>
         </p>
         <p class="existing_approaches">
-          <p>[DCAT-AP] models this information at the dataset level by using property <code>dcterms:accessRights</code> [DCTerms], and defines three possible values:</p>
+          <p>[[DCAT-AP]] models this information at the dataset level by using property <code>dcterms:accessRights</code> [[DCTerms]], and defines three possible values:</p>
           <blockquote>
         <dl>
           <dt>Public</dt>
@@ -1164,7 +1164,7 @@ a:Dataset a dcat:Dataset&#xA0;;
           <dd>Usage note/comment: This category may include resources that contain sensitive or personal information.</dd>
         </dl>
       </blockquote>
-          <p>In addition to this, the JRC extension to [DCAT-AP] uses property <code>dcterms:accessRights</code> also at the distribution level, with the following possible values:</p>
+          <p>In addition to this, the JRC extension to [[DCAT-AP]] uses property <code>dcterms:accessRights</code> also at the distribution level, with the following possible values:</p>
           <dl>
         <dt>no limitations</dt>
         <dd>The distribution can be anonymously accessed</dd>
@@ -1176,11 +1176,11 @@ a:Dataset a dcat:Dataset&#xA0;;
         </p>
         <p class="links">
           <ul>
-        <li><a rel="nofollow" class="external text" href="https://joinup.ec.europa.eu/asset/dcat_application_profile/issue/pr2-add-new-property-dataset-indicate-whether-dataset-public-re"><i>PR2 - Add new property to Dataset to indicate whether the Dataset is public, restricted or non-public</i>.</a> [DCAT-AP] issue tracker</li>
+        <li><a rel="nofollow" class="external text" href="https://joinup.ec.europa.eu/asset/dcat_application_profile/issue/pr2-add-new-property-dataset-indicate-whether-dataset-public-re"><i>PR2 - Add new property to Dataset to indicate whether the Dataset is public, restricted or non-public</i>.</a> [[DCAT-AP]] issue tracker</li>
         <li><a rel="nofollow" class="external text" href="https://www.w3.org/2013/share-psi/bp/cod/"><i>Best Practice: Categorise openness of data</i>.</a> Share-PSI 2.0 Best Practices. 25 July 2016</li>
         <li><a rel="nofollow" class="external text" href="https://theodi.org/data-spectrum"><i>The Data Spectrum</i>.</a> The ODI</li>
         <li> Leigh Dodds. <a rel="nofollow" class="external text" href="https://blog.ldodds.com/2015/11/25/how-can-open-data-publishers-monitor-usage/"><i>How can open data publishers monitor usage?</i>.</a> 25 November 2015</li>
-        <li> [DWBP], <a rel="nofollow" class="external text" href="https://www.w3.org/TR/dwbp/#DataUnavailabilityReference"><i>Best Practice 22: Provide an explanation for data that is not available</i></a></li>
+        <li> [[DWBP]], <a rel="nofollow" class="external text" href="https://www.w3.org/TR/dwbp/#DataUnavailabilityReference"><i>Best Practice 22: Provide an explanation for data that is not available</i></a></li>
         <li>
           <a rel="nofollow" class="external text" href="https://joinup.ec.europa.eu/asset/criterion_evidence_cv/home">EC Core Criterion and Core Evidence Vocabulary</a>
         </li>
@@ -1217,8 +1217,8 @@ a:Dataset a dcat:Dataset&#xA0;;
           <p>This concerns how to model dataset distributions available via services / APIs (e.g., a SPARQL endpoint), and not via direct file download. In such cases, it is necessary to know how to query the service / API to get the data. Moreover, an additional issue is that a service may provide access to more than one dataset. As a consequence, users do not know how to get access to the relevant subset of data accessible via a service / API.</p>
           <p>Although this is a domain-independent issue, it is a key one in the geospatial domain, where data are typically made accessible via services (e.g., a view or download service), that, to be used, require specific clients. In metadata, the link to such services is usually pointing to an XML document describing the service's "capabilities". This of course puzzles non-expert users, who expect instead to get the actual "data".</p>
           <p>Some catalogue platforms (as <a rel="nofollow" class="external text" href="http://geonetwork-opensource.org/">GeoNetwork</a> and, to some extent, <a rel="nofollow" class="external text" href="http://ckan.org/">CKAN</a>) are able to make this transparent for some services (typically, view services), but not for all. It would therefore be desirable to agree on a cross-domain and cross-platform approach to deal with this issue.</p>
-          <p>In [VOCAB-DCAT], the option of accessing data via a service / API is explicitly mentioned, recommending the use of <a rel="nofollow" class="external text" href="https://www.w3.org/TR/vocab-dcat/#Property:distribution_accessurl">dcat:accessURL</a> to point to it. However, this property is meant to be used, generically, for <i>indirect</i> data download, so it is not enough to know that the URL points to a service endpoint rather than to a download page.</p>
-          <p>Actually, for some time, [VOCAB-DCAT] included a class <code><a rel="nofollow" class="external text" href="https://www.w3.org/TR/2012/WD-vocab-dcat-20120405/#Class:_WebService">dcat:WebService</a></code> (subclass of <code>dcat:Distribution</code>) to specify that data is available via a service / API. Other subclasses of <code>dcat:Distribution</code> were also defined to specify direct data access (<code><a rel="nofollow" class="external text" href="https://www.w3.org/TR/2012/WD-vocab-dcat-20120405/#Class:_Download">dcat:Download</a></code>), and data access via an RSS/Atom feed (<code><a rel="nofollow" class="external text" href="https://www.w3.org/TR/2012/WD-vocab-dcat-20120405/#Class:_Feed">dcat:Feed</a></code>). All these subclasses were dropped in the final version of the vocabulary (see <a rel="nofollow" class="external text" href="https://www.w3.org/2011/gld/track/issues/8">ISSUE-8</a> / <a rel="nofollow" class="external text" href="https://www.w3.org/2011/gld/track/issues/9">ISSUE-9</a>, and related discussion).</p>
+          <p>In [[VOCAB-DCAT]], the option of accessing data via a service / API is explicitly mentioned, recommending the use of <a rel="nofollow" class="external text" href="https://www.w3.org/TR/vocab-dcat/#Property:distribution_accessurl">dcat:accessURL</a> to point to it. However, this property is meant to be used, generically, for <i>indirect</i> data download, so it is not enough to know that the URL points to a service endpoint rather than to a download page.</p>
+          <p>Actually, for some time, [[VOCAB-DCAT]] included a class <code><a rel="nofollow" class="external text" href="https://www.w3.org/TR/2012/WD-vocab-dcat-20120405/#Class:_WebService">dcat:WebService</a></code> (subclass of <code>dcat:Distribution</code>) to specify that data is available via a service / API. Other subclasses of <code>dcat:Distribution</code> were also defined to specify direct data access (<code><a rel="nofollow" class="external text" href="https://www.w3.org/TR/2012/WD-vocab-dcat-20120405/#Class:_Download">dcat:Download</a></code>), and data access via an RSS/Atom feed (<code><a rel="nofollow" class="external text" href="https://www.w3.org/TR/2012/WD-vocab-dcat-20120405/#Class:_Feed">dcat:Feed</a></code>). All these subclasses were dropped in the final version of the vocabulary (see <a rel="nofollow" class="external text" href="https://www.w3.org/2011/gld/track/issues/8">ISSUE-8</a> / <a rel="nofollow" class="external text" href="https://www.w3.org/2011/gld/track/issues/9">ISSUE-9</a>, and related discussion).</p>
         </p>
         <p class="existing_approaches">
           <p>A proposal to address this issue has been elaborated in the framework of <a rel="nofollow" class="external text" href="https://www.w3.org/2016/11/sdsvoc/SDSVoc16_paper_25#ref-DCAT-AP-IG">the <i>DCAT-AP implementation guidelines</i></a> (see issue <a rel="nofollow" class="external text" href="https://joinup.ec.europa.eu/asset/dcat_application_profile/issue/dt2-service-based-data-access"><i>DT2: Service-based data access</i></a>), where two main requirements have been identified:</p>
@@ -1231,7 +1231,7 @@ a:Dataset a dcat:Dataset&#xA0;;
         <li> Whether the access / download URL of a distribution points to data or to a service / API (<code>dcterms:type</code>).</li>
         <li> In the latter case, we include the specification the service/API conforms to (<code>dcterms:conformsTo</code>).</li>
       </ul>
-          <p>An example is provided by the following code snippet. Here, the distribution's access URL points to service, implemented by using the [WMS] standard of the Open Geospatial Consortium (OGC):</p>
+          <p>An example is provided by the following code snippet. Here, the distribution's access URL points to service, implemented by using the [[WMS]] standard of the Open Geospatial Consortium (OGC):</p>
           <pre>
 a:Dataset a dcat:Dataset; 
   dcat:distribution [ a dcat:Distribution&#xA0;;
@@ -1247,7 +1247,7 @@ a:Dataset a dcat:Dataset;
         </p>
         <p class="links">
           <ul>
-        <li><a rel="nofollow" class="external text" href="https://joinup.ec.europa.eu/asset/dcat_application_profile/issue/dt2-service-based-data-access"><i>DT2: Service-based data access</i>.</a> [DCAT-AP] issue tracker</li>
+        <li><a rel="nofollow" class="external text" href="https://joinup.ec.europa.eu/asset/dcat_application_profile/issue/dt2-service-based-data-access"><i>DT2: Service-based data access</i>.</a> [[DCAT-AP]] issue tracker</li>
         <li><a rel="nofollow" class="external text" href="https://www.w3.org/2016/11/sdsvoc/SDSVoc16_paper_27#modelling-service-api-based-data-access"><i>Using DCAT-AP for research data</i>.</a> Smart Descriptions &amp; Smarter Vocabularies (SDSVoc). Amsterdam, 30 Nov - 1 Dec 2016.</li>
       </ul>
         </p>
@@ -1282,13 +1282,13 @@ a:Dataset a dcat:Dataset;
       <div class="expandOrCollapse" onclick="toggleVisibility(this)">&#x25B6; Full use case description (click to collapse):</div>
       <div class="visible">
         <p class="description">
-          <p>In most cases, the relationships between datasets and related resources (e.g., author, publisher, contact point, publications / documentation, input data, model(s) / software used to create the dataset) can be specified with simple, binary properties available from widely used vocabularies - as [DCTerms] and [VOCAB-DCAT].</p>
-          <p>However, there may be the need of providing additional information concerning, e.g., the temporal context of a relationship, which requires the use of a more sophisticated representation, similar to the "qualified" forms used in [PROV-O]. </p>
-          <p>Besides [PROV-O], vocabularies as [VOCAB-DQV] and [VOCAB-DUV] can be used for this purpose. However, there is the need of providing guidance on how to use them consistently, since the lack of modeling patterns results in the difficulty of aggregating this information across metadata records and catalogs.</p>
-          <p>Moreover, it is important to define mappings between qualified and non-qualified forms (e.g., along the lines of what done in [PROV-DC]), not only to make it clear their semantic relationships (e.g., <code>dcterms:source</code> is the non-qualified form of <code>prov:qualifiedDerivation</code>), but also to enable metadata sharing and re-use across catalogs that may support only one of the two forms (qualified / non-qualified).</p>
+          <p>In most cases, the relationships between datasets and related resources (e.g., author, publisher, contact point, publications / documentation, input data, model(s) / software used to create the dataset) can be specified with simple, binary properties available from widely used vocabularies - as [[DCTerms]] and [[VOCAB-DCAT]].</p>
+          <p>However, there may be the need of providing additional information concerning, e.g., the temporal context of a relationship, which requires the use of a more sophisticated representation, similar to the "qualified" forms used in [[PROV-O]]. </p>
+          <p>Besides [[PROV-O]], vocabularies as [[VOCAB-DQV]] and [[VOCAB-DUV]] can be used for this purpose. However, there is the need of providing guidance on how to use them consistently, since the lack of modeling patterns results in the difficulty of aggregating this information across metadata records and catalogs.</p>
+          <p>Moreover, it is important to define mappings between qualified and non-qualified forms (e.g., along the lines of what done in [[PROV-DC]]), not only to make it clear their semantic relationships (e.g., <code>dcterms:source</code> is the non-qualified form of <code>prov:qualifiedDerivation</code>), but also to enable metadata sharing and re-use across catalogs that may support only one of the two forms (qualified / non-qualified).</p>
         </p>
         <p class="existing_approaches">
-          <p>[GeoDCAT-AP] makes use of both qualified and non-qualified forms to model <a rel="nofollow" class="external text" href="https://www.w3.org/2016/11/sdsvoc/SDSVoc16_paper_27#data-agent-roles">agent roles</a> and <a rel="nofollow" class="external text" href="https://www.w3.org/2016/11/sdsvoc/SDSVoc16_paper_25#modelling-data-quality">data quality conformance test results</a>.</p>
+          <p>[[GeoDCAT-AP]] makes use of both qualified and non-qualified forms to model <a rel="nofollow" class="external text" href="https://www.w3.org/2016/11/sdsvoc/SDSVoc16_paper_27#data-agent-roles">agent roles</a> and <a rel="nofollow" class="external text" href="https://www.w3.org/2016/11/sdsvoc/SDSVoc16_paper_25#modelling-data-quality">data quality conformance test results</a>.</p>
         </p>
         <p class="links">
           <ul>
@@ -1325,29 +1325,29 @@ a:Dataset a dcat:Dataset;
       <div class="expandOrCollapse" onclick="toggleVisibility(this)">&#x25B6; Full use case description (click to collapse):</div>
       <div class="visible">
         <p class="description">
-          <p>[VOCAB-DCAT] makes use of quite a general definition of dataset (quoting from [VOCAB-DCAT], <a rel="nofollow" class="external text" href="https://www.w3.org/TR/vocab-dcat/#class-dataset">Section 5.3 <i>Class: Dataset</i></a>: "A collection of data, published or curated by a single agent, and available for access or download in one or more formats."), which is meant to be used as broady as possible (as stated in <a rel="nofollow" class="external text" href="https://www.w3.org/2011/gld/track/issues/62">ISSUE-62</a>).</p>
-          <p>As such, it could be theoretically used to model a variety of resources - including documents, software, images and audio-visual content. However, the solution adopted in [VOCAB-DCAT] is not able to address the following scenarios:</p>
+          <p>[[VOCAB-DCAT]] makes use of quite a general definition of dataset (quoting from [[VOCAB-DCAT]], <a rel="nofollow" class="external text" href="https://www.w3.org/TR/vocab-dcat/#class-dataset">Section 5.3 <i>Class: Dataset</i></a>: "A collection of data, published or curated by a single agent, and available for access or download in one or more formats."), which is meant to be used as broady as possible (as stated in <a rel="nofollow" class="external text" href="https://www.w3.org/2011/gld/track/issues/62">ISSUE-62</a>).</p>
+          <p>As such, it could be theoretically used to model a variety of resources - including documents, software, images and audio-visual content. However, the solution adopted in [[VOCAB-DCAT]] is not able to address the following scenarios:</p>
           <ol>
         <li> Let's suppose that a data catalog includes records about data, as well as documents and software. If all are modeled just with <code>dcat:Dataset</code>, it is not possible for users to restrict their search to the specific type of resource they are interested in.</li>
         <li> In addition to this, let's suppose that the catalog includes also records about Web-based services (e.g., a SPARQL endpoint or any of the services used for geospatial data): can a service be considered a "dataset"? how should it be modeled?</li>
       </ol>
-          <p>These two scenarios are not hypothetical, but they reflect what is typically included, e.g., in catalogs following the [ISO-19115] or the [DataCite] standards, which model in different ways the documented resources, and both support records about services.</p>
+          <p>These two scenarios are not hypothetical, but they reflect what is typically included, e.g., in catalogs following the [[ISO-19115-1]] or the [[DataCite]] standards, which model in different ways the documented resources, and both support records about services.</p>
         </p>
         <p class="existing_approaches">
-          <p>[GeoDCAT-AP] provides a mechanism to model three out of the <a rel="nofollow" class="external text" href="https://geo-ide.noaa.gov/wiki/index.php?title=ISO_19115_and_19115-2_CodeList_Dictionaries#MD_ScopeCode">more than 20 resource types</a> supported in [ISO-19115] - namely, <a rel="nofollow" class="external text" href="http://inspire.ec.europa.eu/metadata-codelist/ResourceType/dataset">dataset</a>, <a rel="nofollow" class="external text" href="http://inspire.ec.europa.eu/metadata-codelist/ResourceType/series">dataset series</a>, and <a rel="nofollow" class="external text" href="http://inspire.ec.europa.eu/metadata-codelist/ResourceType/service">service</a>.</p>
+          <p>[[GeoDCAT-AP]] provides a mechanism to model three out of the <a rel="nofollow" class="external text" href="https://geo-ide.noaa.gov/wiki/index.php?title=ISO_19115_and_19115-2_CodeList_Dictionaries#MD_ScopeCode">more than 20 resource types</a> supported in [[ISO-19115-1]] - namely, <a rel="nofollow" class="external text" href="http://inspire.ec.europa.eu/metadata-codelist/ResourceType/dataset">dataset</a>, <a rel="nofollow" class="external text" href="http://inspire.ec.europa.eu/metadata-codelist/ResourceType/series">dataset series</a>, and <a rel="nofollow" class="external text" href="http://inspire.ec.europa.eu/metadata-codelist/ResourceType/service">service</a>.</p>
           <p>The adopted approach is as follows:</p>
           <ul>
         <li> Datasets and dataset series are modeled with <code>dcat:Dataset</code>.</li>
-        <li> The specific dataset "type" (dataset and dataset series) is denoted by using <code>dcterms:type</code> [DCTerms].</li>
-        <li> Services are modeled as <code>dcat:Catalog</code>, in case of a catalog service, and with <code>dctype:Service</code> [DCTerms] in all the other cases.</li>
+        <li> The specific dataset "type" (dataset and dataset series) is denoted by using <code>dcterms:type</code> [[DCTerms]].</li>
+        <li> Services are modeled as <code>dcat:Catalog</code>, in case of a catalog service, and with <code>dctype:Service</code> [[DCTerms]] in all the other cases.</li>
         <li> The type of service (discovery, download, view, etc.) is modeled by using <code>dcterms:type</code>.</li>
       </ul>
-          <p>A similar approach has been adopted in <a rel="nofollow" class="external text" href="https://webgate.ec.europa.eu/CITnet/stash/projects/ODCKAN/repos/datacite-to-dcat-ap/">the study</a> carried out by the <a rel="nofollow" class="external text" href="https://ec.europa.eu/jrc/">European Commission's Joint Research Centre (JRC)</a> to map [DataCite] to [DCAT-AP]. </p>
-          <p>The resource types supported in [DataCite] are 14. Most of them fall into the generic [VOCAB-DCAT] definition of "dataset", so they are modeled with <code>dcat:Dataset</code>. Moreover, the DCMI Type Vocabulary [DCTerms] is used to model both the dataset "type", and those resource types that cannot be modeled as datasets (events, physical objects, services).</p>
+          <p>A similar approach has been adopted in <a rel="nofollow" class="external text" href="https://webgate.ec.europa.eu/CITnet/stash/projects/ODCKAN/repos/datacite-to-dcat-ap/">the study</a> carried out by the <a rel="nofollow" class="external text" href="https://ec.europa.eu/jrc/">European Commission's Joint Research Centre (JRC)</a> to map [[DataCite]] to [[DCAT-AP]]. </p>
+          <p>The resource types supported in [[DataCite]] are 14. Most of them fall into the generic [[VOCAB-DCAT]] definition of "dataset", so they are modeled with <code>dcat:Dataset</code>. Moreover, the DCMI Type Vocabulary [[DCTerms]] is used to model both the dataset "type", and those resource types that cannot be modeled as datasets (events, physical objects, services).</p>
         </p>
         <p class="links">
           <ul>
-        <li> [GeoDCAT-AP]</li>
+        <li> [[GeoDCAT-AP]]</li>
         <li>
           <a rel="nofollow" class="external text" href="https://webgate.ec.europa.eu/CITnet/stash/projects/ODCKAN/repos/datacite-to-dcat-ap/">
             <i>DataCite to DCAT-AP Mapping</i>
@@ -1623,12 +1623,12 @@ is based on evaluation of DXWG use cases and <a rel="nofollow" class="external t
       <div class="expandOrCollapse" onclick="toggleVisibility(this)">&#x25B6; Full use case description (click to collapse):</div>
       <div class="visible">
         <p class="description">
-          <p>[VOCAB-DCAT] uses <code>dcterms:temporal</code> [DCTerms] to specify the temporal coverage of a dataset, but does not provide guidance on to specify the start / end date.</p>
-          <p>Actually, the only relevant example provided in [VOCAB-DCAT] makes use of a URI operated by reference.data.gov.uk, denoting a time interval modeled by using [OWL-TIME]. Such sophisticated representation could be relevant for some use cases, but it is quite cumbersome when the requirement is to specify simply a start / end date, and it makes it difficult to use temporal coverage as a filtering mechanism during the discovery phase.</p>
+          <p>[[VOCAB-DCAT]] uses <code>dcterms:temporal</code> [[DCTerms]] to specify the temporal coverage of a dataset, but does not provide guidance on to specify the start / end date.</p>
+          <p>Actually, the only relevant example provided in [[VOCAB-DCAT]] makes use of a URI operated by reference.data.gov.uk, denoting a time interval modeled by using [[OWL-TIME]]. Such sophisticated representation could be relevant for some use cases, but it is quite cumbersome when the requirement is to specify simply a start / end date, and it makes it difficult to use temporal coverage as a filtering mechanism during the discovery phase.</p>
         </p>
         <p class="existing_approaches">
-          <p>To address this issue, [VOCAB-ADMS] makes use of properties <code>schema:startDate</code> and <code>schema:endDate</code> [SCHEMA-ORG].</p>
-          <p>[DCAT-AP] follows the same approach.</p>
+          <p>To address this issue, [[VOCAB-ADMS]] makes use of properties <code>schema:startDate</code> and <code>schema:endDate</code> [[SCHEMA-ORG]].</p>
+          <p>[[DCAT-AP]] follows the same approach.</p>
           <p>(Alejandra Gonzalez-Beltran) Adding a few links to other existing approaches:</p>
           <p>- DATS: <a rel="nofollow" class="external free" href="https://docs.google.com/spreadsheets/d/1aHj_Qvlr7Sf4DlU4uc37PQEOPha8jTxMEdyL_Q7geLQ/edit#gid=0">https://docs.google.com/spreadsheets/d/1aHj_Qvlr7Sf4DlU4uc37PQEOPha8jTxMEdyL_Q7geLQ/edit#gid=0</a> 
 - DataCite: <a rel="nofollow" class="external free" href="http://schema.datacite.org/meta/kernel-4.0/doc/DataCite-MetadataKernel_v4.0.pdf">http://schema.datacite.org/meta/kernel-4.0/doc/DataCite-MetadataKernel_v4.0.pdf</a> 
@@ -1636,8 +1636,8 @@ is based on evaluation of DXWG use cases and <a rel="nofollow" class="external t
         </p>
         <p class="links">
           <ul>
-        <li> [VOCAB-ADMS], <a rel="nofollow" class="external text" href="https://www.w3.org/TR/vocab-adms/#period-of-time">Section 5.2.10 <i>Period of time</i></a></li>
-        <li> [DCAT-AP]</li>
+        <li> [[VOCAB-ADMS]], <a rel="nofollow" class="external text" href="https://www.w3.org/TR/vocab-adms/#period-of-time">Section 5.2.10 <i>Period of time</i></a></li>
+        <li> [[DCAT-AP]]</li>
         <li><a rel="nofollow" class="external text" href="https://www.w3.org/TR/owl-time/">OWL-Time (2017 revision)</a> includes the following general-purpose predicates <ul><li><a rel="nofollow" class="external text" href="https://www.w3.org/TR/owl-time/#time:hasTime">time:hasTime</a> to associate a time:TemporalEntity with anything</li><li><a rel="nofollow" class="external text" href="https://www.w3.org/TR/owl-time/#time:hasBeginning">time:hasBeginning</a> to associate a time:Instant with anything, though with the entailment that the subject is itself a time:TemporalEntity (or a member of a subclass, which is general not hard)</li><li><a rel="nofollow" class="external text" href="https://www.w3.org/TR/owl-time/#time:hasEnd">time:hasEnd</a> to associate a time:Instant with anything, though with the entailment that the subject is itself a time:TemporalEntity (or a member of a subclass, which is general not hard)</li></ul></li>
         <li><a rel="nofollow" class="external text" href="https://www.w3.org/TR/vocab-ssn/">SOSA/SSN Ontology</a> defines <b>sosa:phenomenonTime</b> and <b>sosa:resultTime</b>, adapted from ISO 19156 (Observations and measurements)<ul><li><a rel="nofollow" class="external text" href="https://www.w3.org/TR/vocab-ssn/#SOSAphenomenonTime">sosa:phenomenonTime</a> refers to world time</li><li><a rel="nofollow" class="external text" href="https://www.w3.org/TR/vocab-ssn/#SOSAresultTime">sosa:resultTime</a> refers to data aquisition time <ul><li> also briefly discussed was <b>stimulusTime</b> - being the time the act of data aquisition started (complementing resultTIme which is when it finished) </li></ul></li></ul></li>
         <li><a rel="nofollow" class="external text" href="http://portal.opengeospatial.org/files/?artifact_id=41579">ISO 19156</a> also has <b>om:validTime</b> - being the time interval during which use of the result is recommended (important for forecasting applications) </li>
@@ -1675,8 +1675,8 @@ is based on evaluation of DXWG use cases and <a rel="nofollow" class="external t
           <p>Used more broadly, the notion of "reference system" can be applied to other data as well. For instance, suppose a dataset consisting of a set of measurements expressed as numbers. Are they percentages or quantities using a specific unit of measurement?</p>
         </p>
         <p class="existing_approaches">
-          <p>[SDWBP] addresses this issue in <a rel="nofollow" class="external text" href="https://www.w3.org/TR/sdw-bp/#bp-crs">Best Practice 8</a>, and illustrates a number of options that can be followed.</p>
-          <p>[GeoDCAT-AP] models this information by specifying data conformance with a given standard, as done in [VOCAB-DQV], which, in this case, is a spatial or temporal reference system. As far as spatial reference systems are concerned, they are denoted by the HTTP URIs operated by the OGC CRS register (see [SDWBP], <a rel="nofollow" class="external text" href="https://www.w3.org/TR/sdw-bp/#ex-crs-dataset-metadata">Example 22</a>):</p>
+          <p>[[SDW-BP]] addresses this issue in <a rel="nofollow" class="external text" href="https://www.w3.org/TR/sdw-bp/#bp-crs">Best Practice 8</a>, and illustrates a number of options that can be followed.</p>
+          <p>[[GeoDCAT-AP]] models this information by specifying data conformance with a given standard, as done in [[VOCAB-DQV]], which, in this case, is a spatial or temporal reference system. As far as spatial reference systems are concerned, they are denoted by the HTTP URIs operated by the OGC CRS register (see [[SDW-BP]], <a rel="nofollow" class="external text" href="https://www.w3.org/TR/sdw-bp/#ex-crs-dataset-metadata">Example 22</a>):</p>
           <pre>
 @prefix ex:      &lt;http://data.example.org/datasets/&gt; .
 @prefix dcat:    &lt;http://www.w3.org/ns/dcat#&gt; .
@@ -1694,8 +1694,8 @@ ex:ExampleDataset
         </p>
         <p class="links">
           <ul>
-        <li> [SDWBP], <a rel="nofollow" class="external text" href="https://www.w3.org/TR/sdw-bp/#bp-crs">Best Practice 8: <i>State how coordinate values are encoded</i></a></li>
-        <li> [GeoDCAT-AP] </li>
+        <li> [[SDW-BP]], <a rel="nofollow" class="external text" href="https://www.w3.org/TR/sdw-bp/#bp-crs">Best Practice 8: <i>State how coordinate values are encoded</i></a></li>
+        <li> [[GeoDCAT-AP]] </li>
       </ul>
         </p>
       </div>
@@ -1729,14 +1729,14 @@ ex:ExampleDataset
         <li> The geographic area is denoted by a geographical name, possibly by using an identifier from a <a rel="nofollow" class="external text" href="https://en.wikipedia.org/wiki/Gazetteer">gazetteer</a> (e.g., Geonames) or a registry concerning, e.g., administrative units (see, e.g., the <a rel="nofollow" class="external text" href="https://en.wikipedia.org/wiki/Nomenclature_of_Territorial_Units_for_Statistics">NUTS</a>).</li>
         <li> The geographic area is denoted by its "geometry", i.e., the geographic coordinates denoting its boundaries, its representative point (as its <a rel="nofollow" class="external text" href="https://en.wikipedia.org/wiki/Centroid">centroid</a>) or its <a rel="nofollow" class="external text" href="https://en.wikipedia.org/wiki/Minimum_bounding_box">bounding box</a>.</li>
       </ol>
-          <p>Geometries are typically used when it is necessary to denote an arbitrary geographic area, which may not correspond to a specific geographical name. Examples include (but are not limited to) satellite images and data from sensors. Geometries are also used in existing data catalogs for discovery and filtering purposes (e.g., this feature is supported in GeoNetwork and CKAN). Moreover, spatial queries are supported by the majority of the existing triple stores (including those not supporting [GeoSPARQL]).</p>
-          <p>[VOCAB-DCAT] allows the specification of the spatial coverage of a dataset by using <code>dcterms:spatial</code> [DCTerms], and includes an example making use of an HTTP URI from Geonames denoting a geographical area.</p>
+          <p>Geometries are typically used when it is necessary to denote an arbitrary geographic area, which may not correspond to a specific geographical name. Examples include (but are not limited to) satellite images and data from sensors. Geometries are also used in existing data catalogs for discovery and filtering purposes (e.g., this feature is supported in GeoNetwork and CKAN). Moreover, spatial queries are supported by the majority of the existing triple stores (including those not supporting [[GeoSPARQL]]).</p>
+          <p>[[VOCAB-DCAT]] allows the specification of the spatial coverage of a dataset by using <code>dcterms:spatial</code> [[DCTerms]], and includes an example making use of an HTTP URI from Geonames denoting a geographical area.</p>
           <p>However, no guidance is provided on how to denote arbitrary regions with a "geometry" (i.e., a point, a bounding box, a polygon), which is the typical way spatial coverage is specified in geospatial metadata.</p>
-          <p>The issue is particularly problematic since the existing vocabularies model this information in very different ways. Moreover, geometries can be expressed in a number of formats (e.g., [GML], <a rel="nofollow" class="external text" href="https://en.wikipedia.org/wiki/Well-known_text">WKT</a>, GeoJSON [RFC7946]). This situation makes it difficult to use information on spatial coverage effectively, e.g., to support spatial search and filtering.</p>
+          <p>The issue is particularly problematic since the existing vocabularies model this information in very different ways. Moreover, geometries can be expressed in a number of formats (e.g., [[GML]], <a rel="nofollow" class="external text" href="https://en.wikipedia.org/wiki/Well-known_text">WKT</a>, GeoJSON [[RFC7946]]). This situation makes it difficult to use information on spatial coverage effectively, e.g., to support spatial search and filtering.</p>
         </p>
         <p class="existing_approaches">
-          <p>[SDWBP] provides a comprehensive guidance on how to specify geometries in the Best Practices under <a rel="nofollow" class="external text" href="http://w3c.github.io/sdw/bp/#geometry-and-crs">Section 12.2.2 <i>Geometries and coordinate reference systems</i></a>.</p>
-          <p>As far as metadata are concerned, one of the documented approaches concerns the solution adopted in [GeoDCAT-AP], which models spatial coverage by using property <code>locn:geometry</code> [LOCN], and recommending encoding the geometry by using [GML] and/or [WKT] - see [SDWBP], <a rel="nofollow" class="external text" href="https://www.w3.org/TR/sdw-bp/#ex-geodcat-ap-bag-addresses">Example 15</a>:</p>
+          <p>[[SDW-BP]] provides a comprehensive guidance on how to specify geometries in the Best Practices under <a rel="nofollow" class="external text" href="http://w3c.github.io/sdw/bp/#geometry-and-crs">Section 12.2.2 <i>Geometries and coordinate reference systems</i></a>.</p>
+          <p>As far as metadata are concerned, one of the documented approaches concerns the solution adopted in [[GeoDCAT-AP]], which models spatial coverage by using property <code>locn:geometry</code> [[LOCN]], and recommending encoding the geometry by using [[GML]] and/or [WKT] - see [[SDW-BP]], <a rel="nofollow" class="external text" href="https://www.w3.org/TR/sdw-bp/#ex-geodcat-ap-bag-addresses">Example 15</a>:</p>
           <pre>
 @prefix dcat:      &lt;http://www.w3.org/ns/dcat#&gt; .
 @prefix dcterms:   &lt;http://purl.org/dc/terms/&gt; .
@@ -1769,8 +1769,8 @@ ex:ExampleDataset
         </p>
         <p class="links">
           <ul>
-        <li> [SDWBP], <a rel="nofollow" class="external text" href="http://w3c.github.io/sdw/bp/#geometry-and-crs">Section 12.2.2 <i>Geometries and coordinate reference systems</i></a></li>
-        <li> [GeoDCAT-AP]</li>
+        <li> [[SDW-BP]], <a rel="nofollow" class="external text" href="http://w3c.github.io/sdw/bp/#geometry-and-crs">Section 12.2.2 <i>Geometries and coordinate reference systems</i></a></li>
+        <li> [[GeoDCAT-AP]]</li>
       </ul>
         </p>
       </div>
@@ -1797,16 +1797,16 @@ ex:ExampleDataset
       <div class="expandOrCollapse" onclick="toggleVisibility(this)">&#x25B6; Full use case description (click to collapse):</div>
       <div class="visible">
         <p class="description">
-          <p>Cross-catalog harvesting is not a recent practice. Standard catalog services, as [OAI-PMH] and [CSW], have been designed to support this functionality. However, in the past, this was typically done across catalogs of homogeneous resources, usually pertaining to the same domain. </p>
+          <p>Cross-catalog harvesting is not a recent practice. Standard catalog services, as [[OAI-PMH]] and [[CSW]], have been designed to support this functionality. However, in the past, this was typically done across catalogs of homogeneous resources, usually pertaining to the same domain. </p>
           <p>This has changed in the last years, especially with the publication of cross-sector catalogs of government data. A notable example is the <a rel="nofollow" class="external text" href="http://data.europa.eu/europeandataportal/">European Data Portal</a>, which harvests metadata from both cross-sector and thematic catalogs across EU Member States. In this scenario, one of the issues to be addressed is the heterogeneity of the metadata standards and harvesting protocols used across catalogs. </p>
-          <p>A partial solution is provided by the development of harmonized mappings between metadata standards (see, e.g., the geospatial and statistical extensions to [DCAT-AP]), and by enabling catalog platforms, as <a rel="nofollow" class="external text" href="http://ckan.org/">CKAN</a> and <a rel="nofollow" class="external text" href="http://geonetwork-opensource.org/">GeoNetwork</a>, to support multiple harvesting protocols and to map different metadata standards into their internal representation.</p>
-          <p>An alternative approach is to enable catalogs to provide metadata in different profiles, using a standard harvesting protocol. Notably, standard protocols as [OAI-PMH] and [CSW] already support the possibility of serving records in different metadata schemas and serializations, by using specific query parameters. So, what is needed is an API-independent mechanism that can be used by clients with the existing catalog service protocols.</p>
+          <p>A partial solution is provided by the development of harmonized mappings between metadata standards (see, e.g., the geospatial and statistical extensions to [[DCAT-AP]]), and by enabling catalog platforms, as <a rel="nofollow" class="external text" href="http://ckan.org/">CKAN</a> and <a rel="nofollow" class="external text" href="http://geonetwork-opensource.org/">GeoNetwork</a>, to support multiple harvesting protocols and to map different metadata standards into their internal representation.</p>
+          <p>An alternative approach is to enable catalogs to provide metadata in different profiles, using a standard harvesting protocol. Notably, standard protocols as [[OAI-PMH]] and [[CSW]] already support the possibility of serving records in different metadata schemas and serializations, by using specific query parameters. So, what is needed is an API-independent mechanism that can be used by clients with the existing catalog service protocols.</p>
           <p>HTTP content negotiation may be the most viable solution, since HTTP is the protocol Web-based catalog services makes use of. However, although the HTTP protocol would allow metadata to be served in different formats, it does not support the ability to negotiate the metadata profile.</p>
         </p>
         <p class="existing_approaches">
-          <p>The <a rel="nofollow" class="external text" href="https://webgate.ec.europa.eu/CITnet/stash/projects/ODCKAN/repos/iso-19139-to-dcat-ap/browse/api">GeoDCAT-AP API</a> was designed to enable [CSW] endpoints to serve [ISO-19115] metadata based on the [GeoDCAT-AP] profile, by using the standard [CSW] interface - i.e., parameters <code>outputSchema</code> (for the metadata profile) and <code>outputFormat</code> (for the metadata format).</p>
-          <p>HTTP content negotiation is supported to determine the returned metadata format, without the need of using parameter <code>outputSchema</code>. The ability to negotiate also the profile would enable a client to query a [CSW] endpoint without the need of knowing the supported harvesting protocol.</p>
-          <p>Besides the resulting RDF serialisation of the source [ISO-19115] records, the API returns a set of HTTP <code>Link</code> headers, using the following <a rel="nofollow" class="external text" href="https://www.iana.org/assignments/link-relations/">relationship types</a>:</p>
+          <p>The <a rel="nofollow" class="external text" href="https://webgate.ec.europa.eu/CITnet/stash/projects/ODCKAN/repos/iso-19139-to-dcat-ap/browse/api">GeoDCAT-AP API</a> was designed to enable [[CSW]] endpoints to serve [[ISO-19115-1]] metadata based on the [[GeoDCAT-AP]] profile, by using the standard [[CSW]] interface - i.e., parameters <code>outputSchema</code> (for the metadata profile) and <code>outputFormat</code> (for the metadata format).</p>
+          <p>HTTP content negotiation is supported to determine the returned metadata format, without the need of using parameter <code>outputSchema</code>. The ability to negotiate also the profile would enable a client to query a [[CSW]] endpoint without the need of knowing the supported harvesting protocol.</p>
+          <p>Besides the resulting RDF serialisation of the source [[ISO-19115-1]] records, the API returns a set of HTTP <code>Link</code> headers, using the following <a rel="nofollow" class="external text" href="https://www.iana.org/assignments/link-relations/">relationship types</a>:</p>
           <ul>
         <li><code>derivedfrom</code>: The URL of the source document, containing the ISO 19139 records.</li>
         <li><code>profile</code>: The URI of the metadata schema used in the returned document.</li>


### PR DESCRIPTION
Just replaced single squared brackets with double ones - which makes [respec](https://github.com/w3c/respec/wiki/User's-Guide#references) recognise their content as citation keys, and fetch the corresponding bib entry from SpecRef.