### PR TITLE
Removed DCAT-AP entry - now in SpecRef

### DIFF
--- a/dcat/config.js
+++ b/dcat/config.js
@@ -68,13 +68,6 @@ var respecConfig = {
         "href":"http://schema.org/",
         "title":"Schema.org"
        },
-      "DCAT-AP": {
-        "href":"https://joinup.ec.europa.eu/asset/dcat_application_profile/description",
-        "title":"DCAT application profile for data portals in Europe",
-        "publisher":"ISA² programme of the European Commission",
-        "authors":["Makx Dekkers"],
-        "date":"2017-03-14"
-      },
       "DATS": {
         "href":"http://wg3-metadataspecifications.readthedocs.io/",
         "title":"DAta Tag Suite",


### PR DESCRIPTION
The DCAT-AP entry is now available in SpecRef (see https://github.com/tobie/specref/pull/378), so it should't be in the `localBiblio`.