### PR TITLE
dcat v1.0 ontology to serve as a starting point

### DIFF
--- a/dcat/rdf/dcat.ttl
+++ b/dcat/rdf/dcat.ttl
@@ -1,0 +1,608 @@
+# baseURI: http://www.w3.org/ns/dcat
+# imports: http://purl.org/dc/terms/
+# imports: http://www.w3.org/2004/02/skos/core
+# imports: http://www.w3.org/ns/prov-o
+# imports: http://xmlns.com/foaf/spec/index.rdf
+# prefix: dcat
+
+@prefix dc: <http://purl.org/dc/elements/1.1/> .
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix dctype: <http://purl.org/dc/dcmitype/> .
+@prefix foaf: <http://xmlns.com/foaf/0.1/> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix prov: <http://www.w3.org/ns/prov#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix schema: <http://schema.org/> .
+@prefix skos: <http://www.w3.org/2004/02/skos/core#> .
+@prefix v: <http://www.w3.org/2006/vcard/ns#> .
+@prefix vann: <http://purl.org/vocab/vann/> .
+@prefix voaf: <http://purl.org/vocommons/voaf#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+<http://www.w3.org/ns/dcat>
+  rdf:type voaf:Vocabulary ;
+  rdf:type owl:Ontology ;
+  dct:contributor <http://people.csiro.au/Simon-Cox> ;
+  dct:contributor [
+      rdf:type dct:Agent ;
+    ] ;
+  dct:contributor [
+      schema:affiliation <http://www.w3.org/data#W3C> ;
+      rdfs:seeAlso <http://philarcher.org/foaf.rdf#me> ;
+      foaf:homepage <http://www.w3.org/People/all#phila> ;
+      foaf:name "Phil Archer" ;
+    ] ;
+  dct:contributor [
+      schema:affiliation [
+          foaf:homepage <http://ec.europa.eu/dgs/informatics/> ;
+          foaf:name "European Commission, DG DIGIT" ;
+        ] ;
+      foaf:name "Vassilios Peristeras" ;
+    ] ;
+  dct:contributor [
+      schema:affiliation [
+          foaf:homepage <http://okfn.org> ;
+          foaf:name "Open Knowledge Foundation" ;
+        ] ;
+      foaf:name "Rufus Pollock" ;
+    ] ;
+  dct:contributor [
+      rdfs:seeAlso <http://makxdekkers.com/makxdekkers.rdf#me> ;
+      foaf:homepage <http://makxdekkers.com/> ;
+      foaf:name "Makx Dekkers" ;
+    ] ;
+  dct:contributor [
+      rdfs:seeAlso <http://www.eurecom.fr/~atemezin/gatemezing-foaf.rdf> ;
+      foaf:name "Ghislain Auguste Atemezing" ;
+    ] ;
+  dct:contributor [
+      foaf:homepage <http://www.asahi-net.or.jp/~ax2s-kmtn/> ;
+      foaf:name "Shuji Kamitsuna" ;
+    ] ;
+  dct:contributor [
+      foaf:name "Boris Villazón-Terrazas" ;
+    ] ;
+  dct:contributor [
+      foaf:name "Marios Meimaris" ;
+    ] ;
+  dct:contributor [
+      foaf:name "Martin Alvarez-Espinar" ;
+    ] ;
+  dct:contributor [
+      foaf:name "Richard Cyganiak" ;
+    ] ;
+  dct:creator [
+      rdfs:seeAlso <http://fadmaa.me/foaf.ttl> ;
+      foaf:name "Fadi Maali" ;
+    ] ;
+  dct:creator [
+      foaf:name "John Erickson" ;
+    ] ;
+  dct:modified "2012-04-24"^^xsd:date ;
+  dct:modified "2013-09-20"^^xsd:date ;
+  dct:modified "2013-11-28"^^xsd:date ;
+  dct:modified "2017-12-19" ;
+  rdfs:comment """DCAT es un vocabulario RDF diseñado para facilitar la interoperabilidad entre catálogo de datos publicados en la Web.
+          Gracias a utilizar DCAT para describir conjuntos de datos en los catálogo de datos, los editores aumentan el descubrimiento y permiten
+          que las aplicaciones consuman fácilmente los metadatos de varios catálogos."""@es ;
+  rdfs:comment """DCAT est un vocabulaire développé pour faciliter l'interopérabilité entre les jeux de données publiées sur le Web.
+				En utilisant DCAT pour décrire les jeux de données dans les catalogues de données, les fournisseurs de données augmentent leur découverte et permettent
+				que les applications facilement les métadonnées de plusieurs catalogues. Il permet en plus la publication décentralisée des catalogues et facilitent
+				la recherche fédérée des données entre plusieurs sites. Les métadonnées DCAT aggrégées peuvent servir comme un manifeste pour faciliter la préservation digitale des ressources.
+				DCAT est définie à l'adresse http://www.w3.org/TR/vocab-dcat/. Une quelconque version de ce document normatif et ce vocabulaire est une erreur dans ce vocabulaire"""@fr ;
+  rdfs:comment """DCAT is an RDF vocabulary designed to facilitate interoperability between data catalogs published on the Web.
+          By using DCAT to describe datasets in data catalogs, publishers increase discoverability and enable 
+          applications easily to consume metadata from multiple catalogs. It further enables decentralized 
+          publishing of catalogs and facilitates federated dataset search across sites. Aggregated DCAT metadata can 
+          serve as a manifest file to facilitate digital preservation.
+          DCAT is defined at http://www.w3.org/TR/vocab-dcat/. Any variance between that normative
+          document and this schema is an error in this schema."""@en ;
+  rdfs:comment """DCATは、ウェブ上で公開されたデータ・カタログ間の相互運用性の促進を目的とするRDFの語彙です。このドキュメントでは、その利用のために、スキーマを定義し、例を提供します。
+データ・カタログ内のデータセットを記述するためにDCATを用いると、公開者が、発見可能性を増加させ、アプリケーションが複数のカタログのメタデータを容易に利用できるようになります。さらに、カタログの分散公開を可能にし、複数のサイトにまたがるデータセットの統合検索を促進します。集約されたDCATメタデータは、ディジタル保存を促進するためのマニフェスト・ファイルとして使用できます。"""@ja ;
+  rdfs:comment """Το DCAT είναι ένα RDF λεξιλόγιο που σχεδιάσθηκε για να κάνει εφικτή τη διαλειτουργικότητα μεταξύ καταλόγων δεδομένων στον Παγκόσμιο Ιστό.
+          Χρησιμοποιώντας το DCAT για την περιγραφή συνόλων δεδομένων, οι εκδότες αυτών αυξάνουν την ανακαλυψιμότητα και επιτρέπουν στις εφαρμογές την εύκολη κατανάλωση μεταδεδομένων από πολλαπλούς καταλόγους.
+          Επιπλέον, δίνει τη δυνατότητα για αποκεντρωμένη έκδοση και διάθεση καταλόγων και επιτρέπει δυνατότητες ενοποιημένης αναζήτησης μεταξύ διαφορετικών πηγών.
+          Συγκεντρωτικά μεταδεδομένα που έχουν περιγραφεί με το DCAT μπορούν να χρησιμοποιηθούν σαν ένα δηλωτικό αρχείο (manifest file) ώστε να διευκολύνουν την ψηφιακή συντήρηση."""@el ;
+  rdfs:comment "هي أنطولوجية تسهل تبادل البيانات بين مختلف الفهارس على الوب. استخدام هذه الأنطولوجية يساعد على اكتشاف قوائم  البيانات المنشورة على الوب و يمكن التطبيقات المختلفة من الاستفادة أتوماتيكيا من البيانات المتاحة من مختلف الفهارس."@ar ;
+  rdfs:label "El vocabulario de catálogo de datos"@es ;
+  rdfs:label "Le vocabulaire des jeux de données "@fr ;
+  rdfs:label "The data catalog vocabulary"@en ;
+  rdfs:label "Το λεξιλόγιο των καταλόγων δεδομένων"@el ;
+  rdfs:label "أنطولوجية فهارس قوائم البيانات"@ar ;
+  rdfs:label "データ・カタログ語彙（DCAT）"@ja ;
+  owl:imports dct: ;
+  owl:imports <http://www.w3.org/2004/02/skos/core> ;
+  owl:imports <http://www.w3.org/ns/prov-o> ;
+  owl:imports <http://xmlns.com/foaf/spec/index.rdf> ;
+  owl:versionInfo """This is a copy of v1.0 of the DCAT vocabulary, taken from https://www.w3.org/ns/dcat.ttl
+Temporarily added imports for DCTerms, SKOS, PROV-O, FOAF to assist in development of v1.* or v2.0 by W3C Data Exchange Working Group """ ;
+  foaf:maker [
+      foaf:homepage <http://www.w3.org/2011/gld/> ;
+      foaf:name "Government Linked Data WG" ;
+    ] ;
+.
+dcat:Catalog
+  rdf:type rdfs:Class ;
+  rdf:type owl:Class ;
+  vann:usageNote "Normalmente, un catálogo de datos basado en web es representado como una sola instancia de esta clase."@es ;
+  vann:usageNote "Typically, a web-based data catalog is represented as a single instance of this class."@en ;
+  vann:usageNote "Συνήθως, ένας κατάλογος δεδομένων στον Παγκόσμιο Ιστό αναπαρίσταται ως ένα στιγμιότυπο αυτής της κλάσης."@el ;
+  vann:usageNote "通常、ウェブ・ベースのデータ・カタログは、このクラスの1つのインスタンスとして表わされます。"@ja ;
+  rdfs:comment "A curated collection of metadata about datasets"@en ;
+  rdfs:comment "Una colección conservada de metadatos de conjuntos de datos"@es ;
+  rdfs:comment "Une collection élaborée de métadonnées sur les jeux de données"@fr ;
+  rdfs:comment "Μια επιμελημένη συλλογή μεταδεδομένων περί συνόλων δεδομένων"@el ;
+  rdfs:comment "مجموعة من توصيفات قوائم البيانات"@ar ;
+  rdfs:comment "データ・カタログは、データセットに関するキュレートされたメタデータの集合です。"@ja ;
+  rdfs:isDefinedBy <http://www.w3.org/TR/vocab-dcat/> ;
+  rdfs:label "Catalog"@en ;
+  rdfs:label "Catalogue"@fr ;
+  rdfs:label "Catálogo"@es ;
+  rdfs:label "Κατάλογος"@el ;
+  rdfs:label "فهرس قوائم البيانات"@ar ;
+  rdfs:label "カタログ"@ja ;
+.
+dcat:CatalogRecord
+  rdf:type rdfs:Class ;
+  rdf:type owl:Class ;
+  vann:usageNote """C'est une classe facultative et tous les catalogues ne l'utiliseront pas. Cette classe existe pour les catalogues
+						ayant une distinction entre les métadonnées sur le jeu de données et les métadonnées sur une entrée du jeu de données dans le catalogue. """@fr ;
+  vann:usageNote """Esta clase es opcional y no todos los catálogos la utilizarán. Esta clase existe para catálogos
+						que hacen una distinción entre los metadatos acerca de un conjunto de datos y los metadatos
+						acerca de una entrada en ese conjunto de datos en el catálogo. """@es ;
+  vann:usageNote """This class is optional and not all catalogs will use it. It exists for 
+            catalogs where a distinction is made between metadata about a dataset and 
+            metadata about the dataset's entry in the catalog. For example, the publication 
+            date property of the dataset reflects the date when the information was originally 
+            made available by the publishing agency, while the publication date of the catalog 
+            record is the date when the dataset was added to the catalog. In cases where both
+            dates differ, or where only the latter is known, the publication date should only 
+            be specified for the catalog record. Notice that the W3C PROV Ontology allows 
+            describing further provenance information such as the details of the process and the 
+            agent involved in a particular change to a dataset."""@en ;
+  vann:usageNote """Αυτή η κλάση είναι προαιρετική και δεν χρησιμοποιείται από όλους τους καταλόγους. Υπάρχει για τις περιπτώσεις καταλόγων όπου 
+					  γίνεται διαχωρισμός μεταξύ των μεταδεδομένων για το σύνολο των δεδομένων και των μεταδεδομένων για την καταγραφή του συνόλου δεδομένων εντός του καταλόγου.
+					  Για παράδειγμα, η ιδιότητα της ημερομηνίας δημοσίευσης του συνόλου δεδομένων δείχνει την ημερομηνία κατά την οποία οι πληροφορίες έγιναν διαθέσιμες από τον φορέα δημοσίευσης, 
+					  ενώ η ημερομηνία δημοσίευσης της καταγραφής του καταλόγου δείχνει την ημερομηνία που το σύνολο δεδομένων προστέθηκε στον κατάλογο.
+					  Σε περιπτώσεις που οι δύο ημερομηνίες διαφέρουν, ή που μόνο η τελευταία είναι γνωστή, η ημερομηνία δημοσίευσης θα πρέπει να δίνεται για την καταγραφή του καταλόγου. 
+					  Να σημειωθεί πως η οντολογία W3C PROV επιτρέπει την περιγραφή επιπλέον πληροφοριών ιστορικού όπως λεπτομέρειες για τη διαδικασία και τον δράστη που εμπλέκονται σε μία συγκεκριμένη αλλαγή εντός του συνόλου δεδομένων."""@el ;
+  vann:usageNote "このクラスはオプションで、すべてのカタログがそれを用いるとは限りません。これは、データセットに関するメタデータとカタログ内のデータセットのエントリーに関するメタデータとで区別が行われるカタログのために存在しています。例えば、データセットの公開日プロパティーは、公開機関が情報を最初に利用可能とした日付を示しますが、カタログ・レコードの公開日は、データセットがカタログに追加された日付です。両方の日付が異っていたり、後者だけが分かっている場合は、カタログ・レコードに対してのみ公開日を指定すべきです。W3CのPROVオントロジー[prov-o]を用いれば、データセットに対する特定の変更に関連するプロセスやエージェントの詳細などの、さらに詳しい来歴情報の記述が可能となることに注意してください。"@ja ;
+  rdfs:comment "1つのデータセットを記述したデータ・カタログ内のレコード。"@ja ;
+  rdfs:comment "A record in a data catalog, describing a single dataset."@en ;
+  rdfs:comment "Un registre du catalogue ou une entrée du catalogue, décrivant un seul jeu de données"@fr ;
+  rdfs:comment "Un registro en un catálogo de datos que describe un solo conjunto de datos."@es ;
+  rdfs:comment "Μία καταγραφή ενός καταλόγου, η οποία περιγράφει ένα συγκεκριμένο σύνολο δεδομένων."@el ;
+  rdfs:isDefinedBy <http://www.w3.org/TR/vocab-dcat/> ;
+  rdfs:label "Catalog Record"@en ;
+  rdfs:label "Registre du catalogue"@fr ;
+  rdfs:label "Registro de catálogo"@es ;
+  rdfs:label "Καταγραφή καταλόγου"@el ;
+  rdfs:label "سجل"@ar ;
+  rdfs:label "カタログ・レコード"@ja ;
+.
+dcat:Dataset
+  rdf:type rdfs:Class ;
+  rdf:type owl:Class ;
+  vann:usageNote """Cette classe représente le jeu de données publié par le fournisseur de données. Dans les cas où une distinction est nécessaire entre le jeu de donénes et son 
+					  entrée dans le catalogue, la classe registre de données peut être utilisée pour ce dernier. """@fr ;
+  vann:usageNote """Esta clase representa el conjunto de datos publicado por el editor del conjunto de datos. En los casos donde es necesaria una distinción entre el
+					conjunto de datos y su entrada en el catálogo de datos"""@es ;
+  vann:usageNote """This class represents the actual dataset as published by the dataset publisher. In 
+          cases where a distinction between the actual dataset and its entry in the catalog is 
+          necessary (because metadata such as modification date and maintainer might differ), the 
+          catalog record class can be used for the latter."""@en ;
+  vann:usageNote """Η κλάση αυτή αναπαριστά το σύνολο δεδομένων αυτό καθ'εαυτό, όπως έχει δημοσιευθεί από τον εκδότη.
+          Σε περιπτώσεις όπου είναι απαραίτητος ο διαχωρισμός μεταξύ του συνόλου δεδομένων και της καταγραφής αυτού στον κατάλογο (γιατί μεταδεδομένα όπως η ημερομηνία αλλαγής και ο συντηρητής μπορεί να διαφέρουν) 
+          η κλάση της καταγραφής καταλόγου μπορεί να χρησιμοποιηθεί για το τελευταίο."""@el ;
+  vann:usageNote "このクラスは、データセットの公開者が公開する実際のデータセットを表わします。カタログ内の実際のデータセットとそのエントリーとの区別が必要な場合（修正日と維持者などのメタデータが異なるかもしれないので）は、後者にcatalog recordというクラスを使用できます。"@ja ;
+  rdfs:comment "1つのエージェントによって公開またはキュレートされ、1つ以上の形式でアクセスまたはダウンロードできるデータの集合。"@ja ;
+  rdfs:comment "A collection of data, published or curated by a single source, and available for access or download in one or more formats"@en ;
+  rdfs:comment "Una colección de datos, publicados o conservados por una única fuente, y disponibles para acceder o descagar en uno o más formatos"@es ;
+  rdfs:comment "Une collection de données, publiée ou élaborée par une seule source, et disponible pour accès ou téléchargement dans un ou plusieurs formats"@fr ;
+  rdfs:comment "Μία συλλογή από δεδομένα, δημοσιευμένη ή επιμελημένη από μία και μόνο πηγή, διαθέσιμη δε προς πρόσβαση ή μεταφόρτωση σε μία ή περισσότερες μορφές"@el ;
+  rdfs:comment "قائمة بيانات منشورة أو مجموعة من قبل مصدر ما و متاح الوصول إليها أو تحميلها"@ar ;
+  rdfs:isDefinedBy <http://www.w3.org/TR/vocab-dcat/> ;
+  rdfs:label "Conjunto de datos"@es ;
+  rdfs:label "Dataset"@en ;
+  rdfs:label "Jeu de données"@fr ;
+  rdfs:label "Σύνολο Δεδομένων"@el ;
+  rdfs:label "قائمة بيانات"@ar ;
+  rdfs:label "データセット"@ja ;
+  rdfs:subClassOf dctype:Dataset ;
+.
+dcat:Distribution
+  rdf:type rdfs:Class ;
+  rdf:type owl:Class ;
+  vann:usageNote """Ceci représente une disponibilité générale du jeu de données, et implique qu'il n'existe pas d'information
+					sur la méthode d'accès réelle des données, par exple, si c'est un lien de téléchargement direct ou à travers une page Web. """@fr ;
+  vann:usageNote """Esto representa una disponibilidad general de un conjunto de datos, e implica que no existe información acerca 
+          del método de acceso real a los datos, i.e., si es un enlace de descarga directa o a través de una página Web."""@es ;
+  vann:usageNote """This represents a general availability of a dataset it implies no information about the 
+          actual access method of the data, i.e. whether it is a direct download, API, or some 
+          through Web page. The use of dcat:downloadURL property indicates directly downloadable distributions."""@en ;
+  vann:usageNote """Αυτό αναπαριστά μία γενική διαθεσιμότητα ενός συνόλου δεδομένων και δεν υπονοεί τίποτα περί του πραγματικού τρόπου πρόσβασης στα δεδομένα, αν είναι άμεσα μεταφορτώσιμα,
+					  μέσω API ή μέσω μίας ιστοσελίδας. Η χρήση της ιδιότητας dcat:downloadURL δείχνει μόνο άμεσα μεταφορτώσιμες διανομές."""@el ;
+  vann:usageNote "これは、データセットの一般的な利用可能性を表わし、データの実際のアクセス方式に関する情報（つまり、直接ダウンロードなのか、APIなのか、ウェブページを介したものなのか）を意味しません。dcat:downloadURLプロパティーの使用は、直接ダウンロード可能な配信を意味します。"@ja ;
+  rdfs:comment """Representa una forma disponible y específica a un conjunto de datos. Cada conjunto de datos puede estar disponible en
+          formas diferentes, estas formas pueden representar formatos diferentes del conjunto de datos o puntos de acceso diferentes."""@es ;
+  rdfs:comment """Represents a specific available form of a dataset. Each dataset might be available in 
+          different forms, these forms might represent different formats of the dataset or different 
+          endpoints. Examples of distributions include a downloadable CSV file, an API or an RSS feed"""@en ;
+  rdfs:comment """Représente une forme spécifique d'un jeu de données. Caque jeu de données peut être disponible
+					sous différentes formes, celles-ci pouvant représenter différents formats du jeu de données ou différents endpoint. Des exemples de distribution
+					sont des fichirs CSV, des API ou des flux RSS."""@fr ;
+  rdfs:comment """Αναπαριστά μία συγκεκριμένη διαθέσιμη μορφή ενός συνόλου δεδομένων. Κάθε σύνολο δεδομενων μπορεί να είναι διαθέσιμο σε 
+					διαφορετικές μορφές, οι μορφές αυτές μπορεί να αναπαριστούν διαφορετικές μορφές αρχείων ή διαφορετικά σημεία διάθεσης.
+					Παραδείγματα διανομών συμπεριλαμβάνουν ένα μεταφορτώσιμο αρχείο μορφής CSV, ένα API ή ένα RSS feed."""@el ;
+  rdfs:comment "شكل محدد لقائمة البيانات يمكن الوصول إليه. قائمة بيانات ما يمكن أن تكون متاحه باشكال و أنواع متعددة.  ملف يمكن تحميله أو واجهة برمجية يمكن من خلالها الوصول إلى البيانات هي أمثلة على ذلك."@ar ;
+  rdfs:comment "データセットの特定の利用可能な形式を表わします。各データセットは、異なる形式で利用できることがあり、これらの形式は、データセットの異なる形式や、異なるエンドポイントを表わす可能性があります。配信の例には、ダウンロード可能なCSVファイル、API、RSSフィードが含まれます。"@ja ;
+  rdfs:isDefinedBy <http://www.w3.org/TR/vocab-dcat/> ;
+  rdfs:label "Distribución"@es ;
+  rdfs:label "Distribution"@en ;
+  rdfs:label "Distribution"@fr ;
+  rdfs:label "Διανομή"@el ;
+  rdfs:label "التوزيع"@ar ;
+  rdfs:label "配信"@ja ;
+.
+dcat:Download
+  rdf:type rdfs:Class ;
+  rdf:type owl:Class ;
+  rdfs:comment "represents a downloadable distribution of a dataset. This term has been deprecated" ;
+  rdfs:isDefinedBy dcat: ;
+  rdfs:label "Download (Deprecated)" ;
+  rdfs:subClassOf dcat:Distribution ;
+  owl:deprecated "true"^^xsd:boolean ;
+.
+dcat:Feed
+  rdf:type rdfs:Class ;
+  rdf:type owl:Class ;
+  rdfs:comment "represents availability of a dataset as a feed. This term has been deprecated" ;
+  rdfs:isDefinedBy dcat: ;
+  rdfs:label "Feed (Deprecated)" ;
+  rdfs:subClassOf dcat:Distribution ;
+  owl:deprecated "true"^^xsd:boolean ;
+.
+dcat:WebService
+  rdf:type rdfs:Class ;
+  rdf:type owl:Class ;
+  rdfs:comment "represents a web service that enables access to the data of a dataset. This term has been deprecated" ;
+  rdfs:isDefinedBy dcat: ;
+  rdfs:label "Web Service (Deprecated)" ;
+  rdfs:subClassOf dcat:Distribution ;
+  owl:deprecated "true"^^xsd:boolean ;
+.
+dcat:accessURL
+  rdf:type rdf:Property ;
+  rdf:type owl:ObjectProperty ;
+  vann:usageNote """El valor es una URL.
+          Si la distribución es accesible solamente través de una página de aterrizaje (i.e., no se conoce una URL de descarga directa),
+          entonces el enlance a la página de aterrizaje debe ser duplicado como accessURL sobre la distribución."""@es ;
+  vann:usageNote """La valeur est une URL.
+						Si la distribution est accessible seulement au travers d'une page d'atterrissage (c-à-dire on n'ignore une URL de téléchargement direct) ,
+						alors le lien à la page d'atterrissage doit être dupliqué comee accessURL sur la distribution."""@fr ;
+  vann:usageNote """The value is a URL.
+          If the distribution(s) are accessible only through a landing page (i.e. direct download URLs are 
+          not known), then the landing page link should be duplicated as accessURL on a distribution."""@en ;
+  vann:usageNote """Η τιμή είναι ένα URL.
+					Αν η/οι διανομή/ές είναι προσβάσιμη/ες μόνο μέσω μίας ιστοσελίδας αρχικής πρόσβασης (δηλαδή αν δεν υπάρχουν γνωστές διευθύνσεις άμεσης μεταφόρτωσης), τότε ο σύνδεσμος της ιστοσελίδας αρχικής πρόσβασης πρέπει να αναπαραχθεί ως accessURL σε μία διανομή."""@el ;
+  vann:usageNote """確実にダウンロードでない場合や、ダウンロードかどうかが不明である場合は、downloadURLではなく、accessURLを用いてください。
+ランディング・ページを通じてしか配信にアクセスできない場合（つまり、直接的なダウンロードURLが不明）は、配信におけるaccessURLとしてランディング・ページのリンクをコピーすべきです（SHOULD）。"""@ja ;
+  rdfs:comment """Ceci peut être tout type d'URL qui donne accès à une distribution du jeu de données. Par exemple, un lien à une page HTML contenant un lien au jeu de données, 
+					un Flux RSS, un point d'accès SPARQL. Utilisez le lorsque votre catalogue ne contient pas d'information sur quoi il est ou quand ce n'est pas téléchargeable."""@fr ;
+  rdfs:comment """Could be any kind of URL that gives access to a distribution of the dataset. E.g. landing page, 
+          download, feed URL, SPARQL endpoint. Use when your catalog does not have information on which it 
+          is or when it is definitely not a download."""@en ;
+  rdfs:comment """Puede ser cualquier tipo de URL que de acceso a una distribución del conjunto de datos, e.g., página de aterrizaje, descarga,
+					URL feed, punto de acceso SPARQL. Utilizado cuando su catálogo de datos no tiene información sobre donde está o cuando no se puede descargar"""@es ;
+  rdfs:comment """Μπορεί να είναι οποιουδήποτε είδους URL που δίνει πρόσβαση στη διανομή ενός συνόλου δεδομένων. Π.χ. ιστοσελίδα αρχικής πρόσβασης, 
+          μεταφόρτωση, feed URL, σημείο διάθεσης SPARQL. Να χρησιμοποιείται όταν ο κατάλογος δεν περιέχει πληροφορίες εαν πρόκειται ή όχι για μεταφορτώσιμο αρχείο."""@el ;
+  rdfs:comment "أي رابط يتيح الوصول إلى البيانات. إذا كان الرابط هو ربط مباشر لملف يمكن تحميله استخدم الخاصية downloadURL"@ar ;
+  rdfs:comment "データセットの配信にアクセス権を与えるランディング・ページ、フィード、SPARQLエンドポイント、その他の種類の資源。"@ja ;
+  rdfs:domain dcat:Distribution ;
+  rdfs:isDefinedBy <http://www.w3.org/TR/vocab-dcat/> ;
+  rdfs:label "URL d'accès"@fr ;
+  rdfs:label "URL de acceso"@es ;
+  rdfs:label "URL πρόσβασης"@el ;
+  rdfs:label "access URL"@en ;
+  rdfs:label "رابط وصول"@ar ;
+  rdfs:label "アクセスURL"@ja ;
+  rdfs:range rdfs:Resource ;
+.
+dcat:byteSize
+  rdf:type rdf:Property ;
+  rdf:type owl:DatatypeProperty ;
+  vann:usageNote """El tamaño en bytes puede ser aproximado cuando no es conocido el tamaño exacto.
+          El valor literal de dcat:byteSize debe ser tipado como xsd:decimal"""@es ;
+  vann:usageNote """La taille en octects peut être approximative lorsque l'on ignore la taille réelle.
+					La valeur littérale de dcat:byteSize doit être de type xsd:decimal"""@fr ;
+  vann:usageNote """The size in bytes can be approximated when the precise size is not known. 
+          The literal value of dcat:byteSize should by typed as xsd:decimal"""@en ;
+  vann:usageNote """Το μέγεθος σε bytes μπορεί να προσεγγιστεί όταν η ακριβής τιμή δεν είναι γνωστή.
+          Η τιμή της dcat:byteSize θα πρέπει να δίνεται με τύπο δεδομένων xsd:decimal"""@el ;
+  vann:usageNote "الحجم يمكن أن يكون تقريبي إذا كان الحجم الدقيق غير معروف"@ar ;
+  vann:usageNote "正確なサイズが不明である場合、サイズは、バイトによる近似値を示すことができます。"@ja ;
+  rdfs:comment "El tamaño de una distribución en bytes"@es ;
+  rdfs:comment "La taille de la distribution en octects"@fr ;
+  rdfs:comment "The size of a distribution in bytes."@en ;
+  rdfs:comment "Το μέγεθος μιας διανομής σε bytes."@el ;
+  rdfs:comment "الحجم بالبايتات "@ar ;
+  rdfs:comment "バイトによる配信のサイズ。"@ja ;
+  rdfs:domain dcat:Distribution ;
+  rdfs:isDefinedBy <http://www.w3.org/TR/vocab-dcat/> ;
+  rdfs:label "byte size"@en ;
+  rdfs:label "taille en octects"@fr ;
+  rdfs:label "tamaño en bytes"@es ;
+  rdfs:label "μέγεθος σε bytes"@el ;
+  rdfs:label "الحجم بالبايت"@ar ;
+  rdfs:label "バイト・サイズ"@ja ;
+  rdfs:range rdfs:Literal ;
+.
+dcat:bytes
+  rdf:type rdf:Property ;
+  rdf:type owl:DatatypeProperty ;
+  rdfs:comment "describe size of resource in bytes. This term has been deprecated" ;
+  rdfs:domain dcat:Distribution ;
+  rdfs:isDefinedBy dcat: ;
+  rdfs:label "size in bytes (Deprecated)" ;
+  rdfs:range xsd:integer ;
+  owl:deprecated "true"^^xsd:boolean ;
+.
+dcat:contactPoint
+  rdf:type rdf:Property ;
+  rdf:type owl:ObjectProperty ;
+  rdfs:comment "Enlaza un conjunto de datos a información de contacto relevante utilizando VCard"@es ;
+  rdfs:comment "Links a dataset to relevant contact information which is provided using VCard."@en ;
+  rdfs:comment "Relie un jeu de données à une information de contact utile en utilisant VCard."@fr ;
+  rdfs:comment "Συνδέει ένα σύνολο δεδομένων με ένα σχετικό σημείο επικοινωνίας, μέσω VCard."@el ;
+  rdfs:comment "تربط قائمة البيانات بعنوان اتصال موصف  باستخدام VCard"@ar ;
+  rdfs:comment "データセットを、VCardを用いて提供されている適切な連絡先情報にリンクします。"@ja ;
+  rdfs:domain dcat:Dataset ;
+  rdfs:isDefinedBy <http://www.w3.org/TR/vocab-dcat/> ;
+  rdfs:label "contact point"@en ;
+  rdfs:label "point de contact"@fr ;
+  rdfs:label "punto de contacto"@es ;
+  rdfs:label "σημείο επικοινωνίας"@el ;
+  rdfs:label "عنوان اتصال"@ar ;
+  rdfs:label "窓口"@ja ;
+  rdfs:range v:Kind ;
+.
+dcat:dataDictionary
+  rdf:type rdf:Property ;
+  rdfs:comment "links a dataset to a dictionary that helps interpreting the data. This term has been deprecated" ;
+  rdfs:domain dcat:Dataset ;
+  rdfs:isDefinedBy dcat: ;
+  rdfs:label "data dictionary (Deprecated)" ;
+  owl:deprecated "true"^^xsd:boolean ;
+.
+dcat:dataQuality
+  rdf:type rdf:Property ;
+  rdfs:comment "describes the quality of data e.g. precision. This should not be used to describe the data collection characteristics, other more specialized statistical properties can be used instead. This term has been deprecated" ;
+  rdfs:domain dcat:Dataset ;
+  rdfs:isDefinedBy dcat: ;
+  rdfs:label "data quality (Deprecated)" ;
+  owl:deprecated "true"^^xsd:boolean ;
+.
+dcat:dataset
+  rdf:type rdf:Property ;
+  rdf:type owl:ObjectProperty ;
+  rdfs:comment "Enlaza un catálogo a un conjunto de datos que es parte de ese catálogo"@es ;
+  rdfs:comment "Links a catalog to a dataset that is part of the catalog."@en ;
+  rdfs:comment "Relie un catalogue à un jeu de données faisant partie de ce catalogue"@fr ;
+  rdfs:comment "Συνδέει έναν κατάλογο με ένα σύνολο δεδομένων το οποίο ανήκει στον εν λόγω κατάλογο."@el ;
+  rdfs:comment "تربط الفهرس بقائمة بيانات ضمنه"@ar ;
+  rdfs:comment "カタログの一部であるデータセット。"@ja ;
+  rdfs:domain dcat:Catalog ;
+  rdfs:isDefinedBy <http://www.w3.org/TR/vocab-dcat/> ;
+  rdfs:label "conjunto de datos"@es ;
+  rdfs:label "dataset"@en ;
+  rdfs:label "jeu de données"@fr ;
+  rdfs:label "σύνολο δεδομένων"@el ;
+  rdfs:label "قائمة بيانات"@ar ;
+  rdfs:label "データセット"@ja ;
+  rdfs:range dcat:Dataset ;
+  rdfs:subPropertyOf dct:hasPart ;
+.
+dcat:distribution
+  rdf:type rdf:Property ;
+  rdf:type owl:ObjectProperty ;
+  rdfs:comment "Conecta un conjunto de datos a una de sus distribuciones disponibles"@es ;
+  rdfs:comment "Connecte un jeu de données à des distributions disponibles."@fr ;
+  rdfs:comment "Connects a dataset to one of its available distributions."@en ;
+  rdfs:comment "Συνδέει ένα σύνολο δεδομένων με μία από τις διαθέσιμες διανομές του."@el ;
+  rdfs:comment "تربط قائمة البيانات بطريقة أو بشكل يسمح  الوصول الى البيانات"@ar ;
+  rdfs:comment "データセットを、その利用可能な配信に接続します。"@ja ;
+  rdfs:domain dcat:Dataset ;
+  rdfs:isDefinedBy <http://www.w3.org/TR/vocab-dcat/> ;
+  rdfs:label "distribución"@es ;
+  rdfs:label "distribution"@en ;
+  rdfs:label "distribution"@fr ;
+  rdfs:label "διανομή"@el ;
+  rdfs:label "توزيع"@ar ;
+  rdfs:label "データセット配信"@ja ;
+  rdfs:range dcat:Distribution ;
+.
+dcat:downloadURL
+  rdf:type rdf:Property ;
+  rdf:type owl:ObjectProperty ;
+  vann:usageNote "La valeur est une URL."@fr ;
+  vann:usageNote "TEl valor es una URL."@es ;
+  vann:usageNote "The value is a URL."@en ;
+  vann:usageNote "Η τιμή είναι ένα URL."@el ;
+  rdfs:comment """Ceci est un lien direct à un fichier téléchargeable en un format donnée. Exple fichier CSV ou RDF. Le format
+					est décrit par les propriétés de distribution dc:format et/ou dcat:mediaType"""@fr ;
+  rdfs:comment """Este es un enlace directo a un fichero descargable en un formato dado, e.g., fichero CSV o RDF. El 
+          formato es descrito por las propiedades de la distribución dc:format y/o dcat:mediaType"""@es ;
+  rdfs:comment """This is a direct link to a downloadable file in a given format. E.g. CSV file or RDF file. The 
+          format is described by the distribution's dc:format and/or dcat:mediaType"""@en ;
+  rdfs:comment "dcat:downloadURLはdcat:accessURLの特定の形式です。しかし、DCATプロファイルが非ダウンロード・ロケーションに対してのみaccessURLを用いる場合には、より強い分離を課すことを望む可能性があるため、この含意を強化しないように、DCATは、dcat:downloadURLをdcat:accessURLのサブプロパティーであると定義しません。"@ja ;
+  rdfs:comment """Είναι ένας σύνδεσμος άμεσης μεταφόρτωσης ενός αρχείου σε μια δεδομένη μορφή. Π.χ. ένα αρχείο CSV ή RDF. 
+					Η μορφη αρχείου περιγράφεται από τις ιδιότητες dc:format ή/και dcat:mediaType της διανομής"""@el ;
+  rdfs:comment "رابط مباشر لملف يمكن تحميله. نوع الملف يتم توصيفه باستخدام الخاصية dc:format dcat:mediaType "@ar ;
+  rdfs:domain dcat:Distribution ;
+  rdfs:isDefinedBy <http://www.w3.org/TR/vocab-dcat/> ;
+  rdfs:label "URL de descarga"@es ;
+  rdfs:label "URL de téléchargement"@fr ;
+  rdfs:label "URL μεταφόρτωσης"@el ;
+  rdfs:label "download URL"@en ;
+  rdfs:label "رابط تحميل"@ar ;
+  rdfs:label "ダウンロードURL"@ja ;
+  rdfs:range rdfs:Resource ;
+.
+dcat:granularity
+  rdf:type rdf:Property ;
+  rdfs:comment "describes the level of granularity of data in a dataset. The granularity can be in time, place etc. This term has been deprecated" ;
+  rdfs:domain dcat:Dataset ;
+  rdfs:isDefinedBy dcat: ;
+  rdfs:label "granularity (Deprecated)" ;
+  owl:deprecated "true"^^xsd:boolean ;
+.
+dcat:keyword
+  rdf:type rdf:Property ;
+  rdf:type owl:DatatypeProperty ;
+  rdfs:comment "A keyword or tag describing the dataset."@en ;
+  rdfs:comment "Un mot-clé ou étiquette décrivant un jeu de donnnées."@fr ;
+  rdfs:comment "Una palabra clave o etiqueta que describa al conjunto de datos."@es ;
+  rdfs:comment "Μία λέξη-κλειδί ή μία ετικέτα που περιγράφει το σύνολο δεδομένων."@el ;
+  rdfs:comment "كلمة  مفتاحيه توصف قائمة البيانات"@ar ;
+  rdfs:comment "データセットを記述しているキーワードまたはタグ。"@ja ;
+  rdfs:domain dcat:Dataset ;
+  rdfs:isDefinedBy <http://www.w3.org/TR/vocab-dcat/> ;
+  rdfs:label "keyword"@en ;
+  rdfs:label "mot-clés "@fr ;
+  rdfs:label "palabra clave"@es ;
+  rdfs:label "λέξη-κλειδί"@el ;
+  rdfs:label "كلمة  مفتاحية "@ar ;
+  rdfs:label "キーワード/タグ"@ja ;
+  rdfs:range rdfs:Literal ;
+  rdfs:subPropertyOf dct:subject ;
+.
+dcat:landingPage
+  rdf:type rdf:Property ;
+  rdf:type owl:ObjectProperty ;
+  vann:usageNote """If the distribution(s) are accessible only through a landing page (i.e. direct download 
+          URLs are not known), then the landing page link should be duplicated as accessURL on a distribution."""@en ;
+  vann:usageNote """Si la distribución es accesible solamente través de una página de aterrizaje (i.e., no se conoce una URL de descarga directa),
+          entonces el enlance a la página de aterrizaje debe ser duplicado como accessURL sobre la distribución."""@es ;
+  vann:usageNote """Si la distribution est seulement accessible à travers une page d'atterrissage (exple. pas de connaissance d'URLS de téléchargement direct ), alors
+						le lien de la page d'atterrissage doit être dupliqué comme accessURL sur la distribution."""@fr ;
+  vann:usageNote "Αν η/οι διανομή/ές είναι προσβάσιμη/ες μόνο μέσω μίας ιστοσελίδας αρχικής πρόσβασης (δηλαδή αν δεν υπάρχουν γνωστές διευθύνσεις άμεσης μεταφόρτωσης), τότε ο σύνδεσμος της ιστοσελίδας αρχικής πρόσβασης πρέπει να αναπαραχθεί ως accessURL σε μία διανομή."@el ;
+  vann:usageNote "ランディング・ページを通じてしか配信にアクセスできない場合（つまり、直接的なダウンロードURLが不明）には、配信におけるaccessURLとしてランディング・ページのリンクをコピーすべきです（SHOULD）。"@ja ;
+  rdfs:comment "A Web page that can be navigated to in a Web browser to gain access to the dataset, its distributions and/or additional information."@en ;
+  rdfs:comment "Una página Web que puede ser visitada en un explorador Web para tener acceso al conjunto de datos, sus distribuciones y/o información adicional"@es ;
+  rdfs:comment "Une page Web accessible par un navigateur Web donnant accès au jeu de données, ses distributions et/ou des informations additionnelles."@fr ;
+  rdfs:comment "Μία ιστοσελίδα πλοηγίσιμη μέσω ενός φυλλομετρητή (Web browser) που δίνει πρόσβαση στο σύνολο δεδομένων, τις διανομές αυτού ή/και επιπρόσθετες πληροφορίες."@el ;
+  rdfs:comment "صفحة وب يمكن من خلالها الوصول الى قائمة البيانات أو إلى معلومات إضافية متعلقة بها "@ar ;
+  rdfs:comment "データセット、その配信および（または）追加情報にアクセスするためにウエブ・ブラウザでナビゲートできるウェブページ。"@ja ;
+  rdfs:domain dcat:Dataset ;
+  rdfs:isDefinedBy <http://www.w3.org/TR/vocab-dcat/> ;
+  rdfs:label "landing page"@en ;
+  rdfs:label "page d'atterrissage"@fr ;
+  rdfs:label "página de aterrizaje"@es ;
+  rdfs:label "ιστοσελίδα αρχικής πρόσβασης"@el ;
+  rdfs:label "صفحة وصول"@ar ;
+  rdfs:label "ランディング・ページ"@ja ;
+  rdfs:range foaf:Document ;
+  rdfs:subPropertyOf foaf:Page ;
+.
+dcat:mediaType
+  rdf:type rdf:Property ;
+  rdf:type owl:ObjectProperty ;
+  rdfs:comment """Cette propriété doit être utilisée quand c'est définit le type de média de la distribution
+					en IANA, sinon dct:format DOIT être utilisé avec différentes valeurs."""@fr ;
+  rdfs:comment """Esta propiedad debe ser usada cuando está definido el tipo de media de la distribución 
+					en IANA, de otra manera dct:format puede ser utilizado con diferentes valores"""@es ;
+  rdfs:comment """This property SHOULD be used when the media type of the distribution is defined 
+          in IANA, otherwise dct:format MAY be used with different values."""@en ;
+  rdfs:comment """Η ιδιότητα αυτή ΘΑ ΠΡΕΠΕΙ να χρησιμοποιείται όταν ο τύπος μέσου μίας διανομής είναι ορισμένος στο IANA, αλλιώς 
+          η ιδιότητα dct:format ΔΥΝΑΤΑΙ να χρησιμοποιηθεί με διαφορετικές τιμές."""@el ;
+  rdfs:comment "يجب استخدام هذه الخاصية إذا كان نوع الملف معرف ضمن IANA"@ar ;
+  rdfs:comment "このプロパティーは、配信のメディア・タイプがIANAで定義されているときに使用すべきで（SHOULD）、そうでない場合には、dct:formatを様々な値と共に使用できます（MAY）。"@ja ;
+  rdfs:domain dcat:Distribution ;
+  rdfs:isDefinedBy <http://www.w3.org/TR/vocab-dcat/> ;
+  rdfs:label "media type"@en ;
+  rdfs:label "tipo de media"@es ;
+  rdfs:label "type de média"@fr ;
+  rdfs:label "τύπος μέσου"@el ;
+  rdfs:label "نوع الميديا"@ar ;
+  rdfs:label "メディア・タイプ"@ja ;
+  rdfs:range dct:MediaTypeOrExtent ;
+  rdfs:subPropertyOf dct:format ;
+.
+dcat:record
+  rdf:type rdf:Property ;
+  rdf:type owl:ObjectProperty ;
+  rdfs:comment "Enlaza un catálogo a sus registros."@es ;
+  rdfs:comment "Links a catalog to its records."@en ;
+  rdfs:comment "Relie un catalogue à ses registres"@fr ;
+  rdfs:comment "Συνδέει έναν κατάλογο με τις καταγραφές του."@el ;
+  rdfs:comment "تربط الفهرس بسجل ضمنه"@ar ;
+  rdfs:comment "カタログの一部であるカタログ・レコード。"@ja ;
+  rdfs:domain dcat:Catalog ;
+  rdfs:isDefinedBy <http://www.w3.org/TR/vocab-dcat/> ;
+  rdfs:label "record"@en ;
+  rdfs:label "registre"@fr ;
+  rdfs:label "registro"@es ;
+  rdfs:label "καταγραφή"@el ;
+  rdfs:label "سجل"@ar ;
+  rdfs:label "カタログ・レコード"@ja ;
+  rdfs:range dcat:CatalogRecord ;
+.
+dcat:size
+  rdf:type rdf:Property ;
+  rdfs:comment "the size of a distribution. This term has been deprecated" ;
+  rdfs:domain dcat:Distribution ;
+  rdfs:isDefinedBy dcat: ;
+  rdfs:label "size (Deprecated)" ;
+  rdfs:subPropertyOf dct:extent ;
+  owl:deprecated "true"^^xsd:boolean ;
+.
+dcat:theme
+  rdf:type rdf:Property ;
+  rdf:type owl:ObjectProperty ;
+  vann:usageNote """El conjunto de skos:Concepts utilizados para categorizar el conjunto de datos están organizados en
+          un skos:ConceptScheme que describe todas las categorías y sus relaciones en el catálogo"""@es ;
+  vann:usageNote """The set of skos:Concepts used to categorize the datasets are organized in 
+          a skos:ConceptScheme describing all the categories and their relations in the catalog."""@en ;
+  vann:usageNote """Un ensemble de skos:Concepts utilisés pour catégoriser un jeu de données sont organisés en 
+						un skos:ConceptScheme décrivqnt toutes les catégories et ses relations dans le catalogue. """@fr ;
+  vann:usageNote """Το σετ των skos:Concepts που χρησιμοποιείται για να κατηγοριοποιήσει τα σύνολα δεδομένων είναι οργανωμένο εντός 
+          ενός skos:ConceptScheme που περιγράφει όλες τις κατηγορίες και τις σχέσεις αυτών στον κατάλογο."""@el ;
+  vann:usageNote "データセットを分類するために用いられるskos:Conceptの集合は、カタログのすべてのカテゴリーとそれらの関係を記述しているskos:ConceptSchemeで組織化されます。"@ja ;
+  rdfs:comment "La categoría principal del conjunto de datos. Un conjunto de datos puede tener varios temas."@es ;
+  rdfs:comment "La catégorie principale du jeu de données. Un jeu de données peut avoir plusieurs thèmes."@fr ;
+  rdfs:comment "The main category of the dataset. A dataset can have multiple themes."@en ;
+  rdfs:comment "Η κύρια κατηγορία του συνόλου δεδομένων. Ένα σύνολο δεδομένων δύναται να έχει πολλαπλά θέματα."@el ;
+  rdfs:comment "التصنيف الرئيسي لقائمة البيانات. قائمة البيانات يمكن أن تملك أكثر من تصنيف رئيسي واحد."@ar ;
+  rdfs:comment "データセットの主要カテゴリー。データセットは複数のテーマを持つことができます。"@ja ;
+  rdfs:domain dcat:Dataset ;
+  rdfs:isDefinedBy <http://www.w3.org/TR/vocab-dcat/> ;
+  rdfs:label "tema"@es ;
+  rdfs:label "theme"@en ;
+  rdfs:label "thème"@fr ;
+  rdfs:label "Θέμα"@el ;
+  rdfs:label "التصنيف"@ar ;
+  rdfs:label "テーマ/カテゴリー"@ja ;
+  rdfs:range skos:Concept ;
+  rdfs:subPropertyOf dct:subject ;
+.
+dcat:themeTaxonomy
+  rdf:type rdf:Property ;
+  rdf:type owl:ObjectProperty ;
+  rdfs:comment "El sistema de organización del conocimiento utilizado para clasificar conjuntos de datos de catálogos."@es ;
+  rdfs:comment "Le systhème d'ogranisation de connaissances utilisé pour classifier les jeux de données du catalogue."@fr ;
+  rdfs:comment "The knowledge organization system (KOS) used to classify catalog's datasets."@en ;
+  rdfs:comment "Το σύστημα οργάνωσης γνώσης που χρησιμοποιείται για την κατηγοριοποίηση των συνόλων δεδομένων του καταλόγου."@el ;
+  rdfs:comment "لائحة التصنيفات المستخدمه لتصنيف قوائم البيانات ضمن الفهرس"@ar ;
+  rdfs:comment "カタログのデータセットを分類するために用いられる知識組織化体系（KOS；knowledge organization system）。"@ja ;
+  rdfs:domain dcat:Catalog ;
+  rdfs:isDefinedBy <http://www.w3.org/TR/vocab-dcat/> ;
+  rdfs:label "taxonomie de thèmes"@fr ;
+  rdfs:label "taxonomía de temas"@es ;
+  rdfs:label "theme taxonomy"@en ;
+  rdfs:label "Ταξινομία θεματικών κατηγοριών."@el ;
+  rdfs:label "قائمة التصنيفات"@ar ;
+  rdfs:label "テーマ"@ja ;
+  rdfs:range skos:ConceptScheme ;
+.


### PR DESCRIPTION
copied directly from https://www.w3.org/ns/dcat.ttl
plus imports added for FOAF, SKOS, dcterms, prov-o