### PR TITLE
Associate dct:type with dcat:Dataset using owl:Restriction

### DIFF
--- a/dcat/rdf/dcat.ttl
+++ b/dcat/rdf/dcat.ttl
@@ -211,6 +211,12 @@ dcat:Dataset
   rdfs:label "قائمة بيانات"@ar ;
   rdfs:label "データセット"@ja ;
   rdfs:subClassOf dctype:Dataset ;
+  rdfs:subClassOf [
+      rdf:type owl:Restriction ;
+      rdfs:comment "Existential quantification constraint - the genre of a dataset is expected to be provided, using a value from some controlled vocabulary such as DCMI Types" ;
+      owl:onProperty dct:type ;
+      owl:someValuesFrom rdfs:Class ;
+    ] ;
 .
 dcat:Distribution
   rdf:type rdfs:Class ;


### PR DESCRIPTION
Add existential quantification constraint to associate dct:type predicate with dcat:Dataset class

Related to #64 