### PR TITLE
Update value of shortName field

### DIFF
--- a/ucr/config.js
+++ b/ucr/config.js
@@ -1,7 +1,7 @@
 var respecConfig = {
 //	preProcess: [dfn_index],
     specStatus: "ED",
-    shortName: "dxwg-ucr",
+    shortName: "dcat-ucr",
 //    previousMaturity:     "NOTE",
 //    previousPublishDate:  "2016-07-23",
 //    previousURI:          "https://www.w3.org/TR/2016/NOTE-poe-ucr-20160721/",


### PR DESCRIPTION
To fix the problem that the [UCR document in GH space](https://w3c.github.io/dxwg/ucr/) points to 

https://www.w3.org/TR/dxwg-ucr/

instead of

https://www.w3.org/TR/dcat-ucr/

How this revision addresses the problem:

As explained in the relevant [ReSpec documentation page](https://github.com/w3c/respec/wiki/shortName), field `shortName` is used to determine the last part of specification URL in TR space. As the UCR URL in TR space is https://www.w3.org/TR/dcat-ucr/ , the value of field `shortName` should be `dcat-ucr`.