### PR TITLE
Added qualified terms issue to publisher property

### DIFF
--- a/dcat/index.html
+++ b/dcat/index.html
@@ -794,6 +794,11 @@ If a ISO 639-1 (two-letter) code is defined for language, then its corresponding
 
 <section id="Property:dataset_publisher">
 <h4>Property: publisher</h4>
+
+<p class="issue" data-number="80">
+	The desire to have qualified forms of properties (as done in [PROV-O](https://www.w3.org/TR/prov-o/)) has been raised. If dcat:Dataset is a prov:Entity (not decided yet) then `publisher` could be a qualified prov:Entity -> prov:Agent relationship.
+</p>
+
 <table class="definition">
   <thead><tr><th>RDF Property:</th><th><a href="http://purl.org/dc/terms/publisher">dct:publisher</a></th></tr></thead>
   <tbody>


### PR DESCRIPTION
representing Issue 80 in the document. Qualification may eventually apply in many places in DACT 1.1/2.0 but this is a current tangible place.