### PR TITLE
Minor nits in DCAT document

### DIFF
--- a/dcat/index.html
+++ b/dcat/index.html
@@ -16,7 +16,7 @@
 	<p style="text-align: center;">The (revised) DCAT vocabulary is available <a href="https://raw.githubusercontent.com/w3c/dxwg/gh-pages/dcat/rdf/dcat.ttl">here</a>.</p>
 </section>
 <section id="sotd">
-	<p>The <a href="http://vocab.deri.ie/dcat">original DCAT vocabulary</a> was developed at DERI, refined by the <a href="http://www.w3.org/egov/">eGov Interest Group</a>, and then finally standardized by the <a href="http://www.w3.org/2011/gld/">Government Linked Data (GLD)</a> Working Group.</p>
+	<p>The <a href="http://vocab.deri.ie/dcat">original DCAT vocabulary</a> was developed at DERI, refined by the <a href="http://www.w3.org/egov/">eGov Interest Group</a>, and then finally <a href="https://www.w3.org/TR/2014/REC-vocab-dcat-20140116/">standardized</a> by the <a href="http://www.w3.org/2011/gld/">Government Linked Data (GLD)</a> Working Group.</p>
 	<p>
 		This revised version of DCAT was developed by the <a href="https://www.w3.org/2017/dxwg/wiki/Main_Page">Dataset Exchange Working Group</a> in response to a new set of <a href="https://www.w3.org/TR/dcat-ucr/">Use Cases and Requirements</a> submitted on the basis of experience since the original version, and new applications not originally considered.
 	</p>
@@ -885,7 +885,7 @@ If a ISO 639-1 (two-letter) code is defined for language, then its corresponding
 <h4>Property: publisher</h4>
 
 <p class="issue" data-number="80">
-	The desire to have qualified forms of properties (as done in <a href="https://www.w3.org/TR/prov-o/">PROV-O</a>) has been raised. If dcat:Dataset is a prov:Entity (not decided yet) then `publisher` could be a qualified prov:Entity -> prov:Agent relationship.
+	The desire to have qualified forms of properties (as done in [[PROV-O]]) has been raised. If dcat:Dataset is a prov:Entity (not decided yet) then `publisher` could be a qualified prov:Entity -> prov:Agent relationship.
 </p>
 
 <table class="definition">


### PR DESCRIPTION
Insert link to DCAT v1 in introduction; 
use respec syntax for PROV-O references