### PR TITLE
Some small revisions

### DIFF
--- a/dcat/rdf/schema.ttl
+++ b/dcat/rdf/schema.ttl
@@ -4,6 +4,7 @@
 # imports: https://raw.githubusercontent.com/schemaorg/schemaorg/master/data/releases/3.3/ext-meta.ttl
 # prefix: dcat-schema
 
+@prefix dc: <http://purl.org/dc/elements/1.1/>
 @prefix dcat: <http://www.w3.org/ns/dcat#> .
 @prefix dcat-schema: <http://www.w3.org/ns/dcat/schema#> .
 @prefix dct: <http://purl.org/dc/terms/> .
@@ -15,8 +16,14 @@
 @prefix skos: <http://www.w3.org/2004/02/skos/core#> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
-<http://purl.org/dc/elements/1.1/title>
+dc:title
   owl:equivalentProperty schema:name ;
+.
+dct:title
+  owl:equivalentProperty schema:name ;
+.
+dc:description
+  owl:equivalentProperty schema:description ;
 .
 dct:description
   owl:equivalentProperty schema:description ;


### PR DESCRIPTION
- Added namespace prefix for DC11
- Added `owl:equivalentProperty` axioms for both `dct:title` and `dc:description`, to complement those about `dc:title` and `dct:description`