### PR TITLE
original DCAT had foaf:Page where it looks like foaf:page was intended.

### DIFF
--- a/dcat/rdf/dcat.ttl
+++ b/dcat/rdf/dcat.ttl
@@ -503,7 +503,7 @@ dcat:landingPage
   rdfs:label "صفحة وصول"@ar ;
   rdfs:label "ランディング・ページ"@ja ;
   rdfs:range foaf:Document ;
-  rdfs:subPropertyOf foaf:Page ;
+  rdfs:subPropertyOf foaf:page ;
 .
 dcat:mediaType
   rdf:type rdf:Property ;


### PR DESCRIPTION
This looks like an erratum in the original DCAT. 
