### PR TITLE
Editorial changes

### DIFF
--- a/dcat/rdf/dcat.ttl
+++ b/dcat/rdf/dcat.ttl
@@ -300,7 +300,7 @@ dcat:accessURL
   vann:usageNote """The value is a URL.
           If the distribution(s) are accessible only through a landing page (i.e. direct download URLs are 
           not known), then the landing page link should be duplicated as accessURL on a distribution."""@en ;
-   vann:usageNote """Il valore è un URL.  Se le distribuzioni sono accessibili solo attraverso una pagina web (ad esempio, gli URL per il download diretto non sono noti), il link della pagina web deve essere duplicato come accessURL su la distribuzione."""@it ;
+   vann:usageNote """Il valore è un URL.  Se le distribuzioni sono accessibili solo attraverso una pagina web (ad esempio, gli URL per il download diretto non sono noti), il link della pagina web deve essere duplicato come accessURL sulla distribuzione."""@it ;
   vann:usageNote """Η τιμή είναι ένα URL.
 					Αν η/οι διανομή/ές είναι προσβάσιμη/ες μόνο μέσω μίας ιστοσελίδας αρχικής πρόσβασης (δηλαδή αν δεν υπάρχουν γνωστές διευθύνσεις άμεσης μεταφόρτωσης), τότε ο σύνδεσμος της ιστοσελίδας αρχικής πρόσβασης πρέπει να αναπαραχθεί ως accessURL σε μία διανομή."""@el ;
   vann:usageNote """確実にダウンロードでない場合や、ダウンロードかどうかが不明である場合は、downloadURLではなく、accessURLを用いてください。
@@ -375,7 +375,7 @@ dcat:contactPoint
   rdf:type owl:ObjectProperty ;
   rdfs:comment "Enlaza un conjunto de datos a información de contacto relevante utilizando VCard"@es ;
   rdfs:comment "Links a dataset to relevant contact information which is provided using VCard."@en ;
-  rdfs:comment "Collega un dataset alle  informazioni del contatto pertinente   utilizzando VCard."@it ;
+  rdfs:comment "Collega un dataset alle informazioni del contatto pertinente utilizzando VCard."@it ;
   rdfs:comment "Relie un jeu de données à une information de contact utile en utilisant VCard."@fr ;
   rdfs:comment "Συνδέει ένα σύνολο δεδομένων με ένα σχετικό σημείο επικοινωνίας, μέσω VCard."@el ;
   rdfs:comment "تربط قائمة البيانات بعنوان اتصال موصف  باستخدام VCard"@ar ;
@@ -458,16 +458,16 @@ dcat:downloadURL
   vann:usageNote "Il valore é una URL."@it ;
   vann:usageNote "Η τιμή είναι ένα URL."@el ;
   rdfs:comment """Ceci est un lien direct à un fichier téléchargeable en un format donnée. Exple fichier CSV ou RDF. Le format
-					est décrit par les propriétés de distribution dc:format et/ou dcat:mediaType"""@fr ;
+					est décrit par les propriétés de distribution dct:format et/ou dcat:mediaType"""@fr ;
   rdfs:comment """Este es un enlace directo a un fichero descargable en un formato dado, e.g., fichero CSV o RDF. El 
-          formato es descrito por las propiedades de la distribución dc:format y/o dcat:mediaType"""@es ;
+          formato es descrito por las propiedades de la distribución dct:format y/o dcat:mediaType"""@es ;
   rdfs:comment """This is a direct link to a downloadable file in a given format. E.g. CSV file or RDF file. The 
-          format is described by the distribution's dc:format and/or dcat:mediaType"""@en ;
-  rdfs:comment """Questo è un link diretto al file scaricabile in un dato formato. E.g. CSV file o RDF file. Il formato è descritto dal dc:format e/o dal dcat:mediaType della distribuzione."""@it ;
+          format is described by the distribution's dct:format and/or dcat:mediaType"""@en ;
+  rdfs:comment """Questo è un link diretto al file scaricabile in un dato formato. E.g. un file CSV o un file RDF. Il formato è descritto dal dct:format e/o dal dcat:mediaType della distribuzione."""@it ;
   rdfs:comment "dcat:downloadURLはdcat:accessURLの特定の形式です。しかし、DCATプロファイルが非ダウンロード・ロケーションに対してのみaccessURLを用いる場合には、より強い分離を課すことを望む可能性があるため、この含意を強化しないように、DCATは、dcat:downloadURLをdcat:accessURLのサブプロパティーであると定義しません。"@ja ;
   rdfs:comment """Είναι ένας σύνδεσμος άμεσης μεταφόρτωσης ενός αρχείου σε μια δεδομένη μορφή. Π.χ. ένα αρχείο CSV ή RDF. 
-					Η μορφη αρχείου περιγράφεται από τις ιδιότητες dc:format ή/και dcat:mediaType της διανομής"""@el ;
-  rdfs:comment "رابط مباشر لملف يمكن تحميله. نوع الملف يتم توصيفه باستخدام الخاصية dc:format dcat:mediaType "@ar ;
+					Η μορφη αρχείου περιγράφεται από τις ιδιότητες dct:format ή/και dcat:mediaType της διανομής"""@el ;
+  rdfs:comment "رابط مباشر لملف يمكن تحميله. نوع الملف يتم توصيفه باستخدام الخاصية dct:format dcat:mediaType "@ar ;
   rdfs:domain dcat:Distribution ;
   rdfs:isDefinedBy <http://www.w3.org/TR/vocab-dcat/> ;
   rdfs:label "URL de descarga"@es ;
@@ -491,7 +491,7 @@ dcat:keyword
   rdf:type rdf:Property ;
   rdf:type owl:DatatypeProperty ;
   rdfs:comment "A keyword or tag describing a resource."@en ;
-rdfs:comment "Una parola chiave o una etichetta per descrivere la risorsa."@it ;
+rdfs:comment "Una parola chiave o un'etichetta per descrivere la risorsa."@it ;
   rdfs:comment "Un mot-clé ou étiquette décrivant une ressource."@fr ;
   rdfs:comment "Una palabra clave o etiqueta que describe un recurso."@es ;
   rdfs:comment "Μία λέξη-κλειδί ή μία ετικέτα που περιγράφει το σύνολο δεδομένων."@el ;


### PR DESCRIPTION
- Some editorial changes to the Italian translation (@riccardoAlbertoni , please review)
- Replaced `dc:format` with `dct:format`

Other editorial issues not addressed:
- The Italian translation sometimes uses "metadata" sometimes "metadato"/"metadati"
- The `vann:usageNote` for `dcat:accessURL` and `dcat:downloadURL` starts with "The value is a URL." I wonder whether this is a leftover from previous versions of DCAT, where both properties were `owl:DatatypeProperty`'s, with `xsd:anyURI` as range.