### PR TITLE
Populated changelog + ed changes

### DIFF
--- a/dcat/index.html
+++ b/dcat/index.html
@@ -32,7 +32,7 @@
 
 <h2>Introduction</h2>
 
-<p class="note">From DCAT 1.0</p>
+<p class="note">From DCAT 1.0 [[!VOCAB-DCAT]]</p>
 
 <p>Data can come in many formats, ranging from spreadsheets, through XML and RDF, to various speciality formats. DCAT does not make any assumptions about the serialisation format of the datasets described in a catalog. Other, complementary vocabularies may be used together with DCAT to provide more detailed format-specific information. For example, properties from the VoID vocabulary [[VOID]] can be used to express various statistics about a DCAT-described dataset if that dataset is in RDF format.</p>
 <p>This document does not prescribe any particular method of deploying data expressed in DCAT. DCAT is applicable in many contexts including RDF accessible via SPARQL endpoints, embedded in HTML pages as RDFa, or serialized as e.g. RDF/XML or Turtle. The examples in this document use Turtle simply because of Turtle's readability.</p>
@@ -72,7 +72,7 @@
 
 <section id="conformance">
 
-<p class="note">From DCAT 1.0</p>
+<p class="note">From DCAT 1.0 [[!VOCAB-DCAT]]</p>
 
 <p>A data catalog conforms to DCAT if:</p>
 <ul>
@@ -104,7 +104,7 @@ RDF syntaxes, access protocols, and access policies is not mandated by this spec
 
 <h2>Vocabulary Overview</h2>
 
-<p class="note">From DCAT 1.0 except as noted</p>
+<p class="note">From DCAT 1.0 [[!VOCAB-DCAT]] except as noted</p>
 
 <p>DCAT is an RDF vocabulary well-suited to representing government data catalogs such as <a href="https://www.data.gov/">data.gov</a> and <a href="http://data.gov.uk">data.gov.uk</a>. DCAT defines three main classes:</p>
 <ul><li> <code><a href="#Class:_Catalog">dcat:Catalog</a></code> represents the catalog
@@ -131,11 +131,11 @@ These are considered out of the scope of this version of the vocabulary. Neverth
 </p>
 </section>
 
-<p>Another important class in DCAT is <code><a href="#Class:_Catalog_record">dcat:CatalogRecord</a></code> which describes a dataset entry in the catalog. Notice that while dcat:Dataset represents the dataset itself, dcat:CatalogRecord represents the record that describes a dataset in the catalog. The use of the CatalogRecord is considered optional. It is used to capture provenance information about dataset entries in a catalog. If this distinction is not necessary then CatalogRecord can be safely ignored.</p>
+<p>Another important class in DCAT is <code><a href="#Class:_Catalog_record">dcat:CatalogRecord</a></code> which describes a dataset entry in the catalog. Notice that while dcat:Dataset represents the dataset itself, dcat:CatalogRecord represents the record that describes a dataset in the catalog. The use of dcat:CatalogRecord is considered optional. It is used to capture provenance information about dataset entries in a catalog. If this distinction is not necessary then dcat:CatalogRecord can be safely ignored.</p>
 
 
 <p class="note">
-    In <a href="https://www.w3.org/TR/vocab-dcat/">DCAT version 1.0</a> <a href="#class-dataset">dcat:Dataset</a> was a sub-class of <a href="http://purl.org/dc/dcmitype/Dataset">dctype:Dataset</a>, which is a term of the <a href="http://dublincore.org/documents/dcmi-terms/#section-7">DCMI Types vocabulary</a>.
+    In DCAT version 1.0 [[!VOCAB-DCAT]] <a href="#class-dataset">dcat:Dataset</a> was a sub-class of <a href="http://purl.org/dc/dcmitype/Dataset">dctype:Dataset</a>, which is a term of the <a href="http://dublincore.org/documents/dcmi-terms/#section-7">DCMI Types vocabulary</a> [[DCTERMS]].
 	This relationship has been removed in the revised DCAT vocabulary - see <a href="https://github.com/w3c/dxwg/issues/98">Issue #98</a>.
 </p>
 
@@ -361,7 +361,7 @@ Alongside it are a set of other RDF files that provide additional information, i
 The definitions (including domain and range) of terms outside the dcat namespace are provided here only for convenience and must not be considered normative. The authoritative definitions of these terms are in the corresponding specifications: [[!DC11]], [[!DCTERMS]], [[!FOAF]], [[!RDF-SCHEMA]], [[!SKOS-REFERENCE]], [[!XMLSCHEMA11-2]] and [[!VCARD-RDF]].
 </p>
 
-<p class="note">Description of DCAT vocabulary elements from DCAT 1.0 except where indicated.</p>
+<p class="note">Description of DCAT vocabulary elements from DCAT 1.0 [[!VOCAB-DCAT]] except where indicated.</p>
 </section>
 
 <section id="class-catalog">
@@ -837,7 +837,7 @@ into a separate named graph. The name of that graph should be the IRI of the cat
 </table>
 
 <p class="note">
-    In DCAT version 1.0 <a href="#class-dataset">dcat:Dataset</a> was a sub-class of <a href="http://purl.org/dc/dcmitype/Dataset">dctype:Dataset</a>, which is a member of the <a href="http://dublincore.org/documents/dcmi-terms/#section-7">DCMI Types vocabulary</a>.
+    In DCAT version 1.0 [[!VOCAB-DCAT]] <a href="#class-dataset">dcat:Dataset</a> was a sub-class of <a href="http://purl.org/dc/dcmitype/Dataset">dctype:Dataset</a>, which is a member of the <a href="http://dublincore.org/documents/dcmi-terms/#section-7">DCMI Types vocabulary</a>.
 	This relationship has been removed in the revised DCAT vocabulary - see <a href="https://github.com/w3c/dxwg/issues/98">Issue #98</a>.
 </p>
 
@@ -1009,7 +1009,7 @@ If a ISO 639-1 (two-letter) code is defined for language, then its corresponding
 <h4>Property: theme/category</h4>
 
 <p class="note">
-	In <a href="https://www.w3.org/TR/vocab-dcat/">DCAT version 1.0</a> the domain of dcat:theme was dcat:Dataset,
+	In DCAT version 1.0 [[!VOCAB-DCAT]] the domain of dcat:theme was dcat:Dataset,
   which limited use of this property in other contexts. The domain has been relaxed in this revision -
   see <a href="https://github.com/w3c/dxwg/issues/123">Issue #123</a>.
 </p>
@@ -1065,7 +1065,7 @@ If a ISO 639-1 (two-letter) code is defined for language, then its corresponding
 <h4>Property: keyword/tag</h4>
 
 <p class="note">
-	In <a href="https://www.w3.org/TR/vocab-dcat/">DCAT version 1.0</a> the domain of dcat:keyword was dcat:Dataset,
+	In DCAT version 1.0 [[!VOCAB-DCAT]] the domain of dcat:keyword was dcat:Dataset,
   which limited use of this property in other contexts. The domain has been relaxed in this revision -
   see <a href="https://github.com/w3c/dxwg/issues/121">Issue #121</a>.
 </p>
@@ -1083,7 +1083,7 @@ If a ISO 639-1 (two-letter) code is defined for language, then its corresponding
 <h4>Property: contact point</h4>
 
 <p class="note">
-	In <a href="https://www.w3.org/TR/vocab-dcat/">DCAT version 1.0</a> the domain of dcat:contactPoint was dcat:Dataset,
+	In DCAT version 1.0 [[!VOCAB-DCAT]] the domain of dcat:contactPoint was dcat:Dataset,
   which limited use of this property in other contexts. The domain has been relaxed in this revision -
   see <a href="https://github.com/w3c/dxwg/issues/95">Issue #95</a>.
 </p>
@@ -1122,7 +1122,7 @@ If a ISO 639-1 (two-letter) code is defined for language, then its corresponding
 <h4>Property: landing page</h4>
 
 <p class="note">
-	In <a href="https://www.w3.org/TR/vocab-dcat/">DCAT version 1.0</a> the domain of dcat:landingPage was dcat:Dataset,
+	In DCAT version 1.0 [[!VOCAB-DCAT]] the domain of dcat:landingPage was dcat:Dataset,
   which limited use of this property in other contexts. The domain has been relaxed in this revision -
   see <a href="https://github.com/w3c/dxwg/issues/122">Issue #122</a>.
 </p>
@@ -1135,7 +1135,7 @@ If a ISO 639-1 (two-letter) code is defined for language, then its corresponding
     <tr><td class="prop">Range:</td><td><a href="http://xmlns.com/foaf/0.1/Document">foaf:Document</a></td></tr>
     <tr><td class="prop">Usage note:</td><td>
         If the distribution(s) are accessible only through a landing page
-    (i.e. direct download URLs are not known), then the landing page link <em title="SHOULD" class="rfc2119">SHOULD</em> be duplicated as accessURL on a distribution. (see <a href="#example-landing-page">example 4.4</a>)
+    (i.e. direct download URLs are not known), then the landing page link <em title="SHOULD" class="rfc2119">SHOULD</em> be duplicated as dcat:accessURL on a distribution. (see <a href="#example-landing-page">example 4.4</a>)
     </td></tr>
   </tbody>
 </table>
@@ -1303,11 +1303,11 @@ Examples of distributions include a downloadable CSV file, an API or an RSS feed
     <tr><td class="prop">Usage note:</td><td>
     <ul>
     <li>
-    Use accessURL, and not downloadURL, when it is definitely not a download or when you are not sure whether it is.
+    Use dcat:accessURL, and not dcat:downloadURL, when it is definitely not a download or when you are not sure whether it is.
     </li>
     <li>
     If the distribution(s) are accessible only through a landing page
-    (i.e. direct download URLs are not known), then the landing page link <em title="SHOULD" class="rfc2119">SHOULD</em> be duplicated as accessURL on a distribution. (see <a href="#example-landing-page">example 4.4</a>)
+    (i.e. direct download URLs are not known), then the landing page link <em title="SHOULD" class="rfc2119">SHOULD</em> be duplicated as dcat:accessURL on a distribution. (see <a href="#example-landing-page">example 4.4</a>)
     </li>
     </ul>
 
@@ -1331,7 +1331,7 @@ Examples of distributions include a downloadable CSV file, an API or an RSS feed
     <tr><td class="prop">Domain:</td><td><a href="http://www.w3.org/ns/dcat#Distribution">dcat:Distribution</a></td></tr>
     <tr><td class="prop">Range:</td><td><a href="http://www.w3.org/2000/01/rdf-schema#Resource">rdfs:Resource</a></td></tr>
      <tr><td class="prop">Usage note:</td><td>
-     dcat:downloadURL is a specific form of dcat:accessURL. Nevertheless, DCAT does not  define dcat:downloadURL as a subproperty of dcat:accessURL not to enforce this entailment  as DCAT profiles may wish to impose a stronger separation where they only use accessURL for non-download locations.
+     dcat:downloadURL is a specific form of dcat:accessURL. Nevertheless, DCAT does not  define dcat:downloadURL as a subproperty of dcat:accessURL not to enforce this entailment  as DCAT profiles may wish to impose a stronger separation where they only use dcat:accessURL for non-download locations.
      </td></tr>
     <tr><td class="prop">See also</td><td><a href="#Property:distribution_accessurl">distribution access URL</a></td></tr>
   </tbody>
@@ -1458,7 +1458,7 @@ Examples of distributions include a downloadable CSV file, an API or an RSS feed
 
 	<p class="note">
 		DCAT version 1.0 handling of license and rights do not appear to satisfy all requirements.
-		The recently completed W3C ODRL vocabulary [[odrl-vocab]] provides a rich language for describing many kinds of rights and obligations.
+		The recently completed W3C ODRL vocabulary [[ODRL-VOCAB]] provides a rich language for describing many kinds of rights and obligations.
 		In this chapter it is planned to describe some patterns for linking DCAT Datasets and/or Distributions to suitable rights expressions.
 		See <a href="https://github.com/w3c/dxwg/milestone/1">Milestone 1</a> for more discussion.
 	</p>
@@ -1549,13 +1549,47 @@ Examples of distributions include a downloadable CSV file, an API or an RSS feed
       <h2>Change history</h2>
       <p>A full change-log is available on <a href="https://github.com/w3c/dxwg/commits/gh-pages/dcat">GitHub</a></p>
       <section id="changes-since-20140116">
-        <h2>Changes since the W3C Recommendation of 16 January 2014</h2>
+        <h3>Changes since the W3C Recommendation of 16 January 2014</h3>
         <p>The document has undergone the following changes since the <a href="http://www.w3.org/TR/2014/REC-vocab-dcat-20140116/">W3C Recommendation of 16 January 2014</a>:</p>
 
         <ul>
-          <li>...</li>
-        </ul>
-      </section>
 
-	</body>
+<li><a href="#class-dataset">Class: Dataset</a>: 
+In DCAT version 1.0 [[!VOCAB-DCAT]] <a href="#class-dataset">dcat:Dataset</a> was a sub-class of <a href="http://purl.org/dc/dcmitype/Dataset">dctype:Dataset</a>, which is a term of the <a href="http://dublincore.org/documents/dcmi-terms/#section-7">DCMI Types vocabulary</a> [[DCTERMS]]. This relationship has been removed in the revised DCAT vocabulary - see <a href="https://github.com/w3c/dxwg/issues/98">Issue #98</a>.
+</li>
+
+<li><a href="#Property:dataset_theme">Property: theme/category</a>:
+	In DCAT version 1.0 [[!VOCAB-DCAT]] the domain of dcat:theme was dcat:Dataset,
+  which limited use of this property in other contexts. The domain has been relaxed in this revision -
+  see <a href="https://github.com/w3c/dxwg/issues/123">Issue #123</a>.
+</li>
+
+<li><a href="#Property:dataset_type">Property: type/genre</a>:
+	Added in DCAT revision - see <a href="https://github.com/w3c/dxwg/issues/64">Issue #64</a>.
+</li>
+
+<li><a href="#Property:dataset_keyword">Property: keyword/tag</a>:
+	In DCAT version 1.0 [[!VOCAB-DCAT]] the domain of dcat:keyword was dcat:Dataset,
+  which limited use of this property in other contexts. The domain has been relaxed in this revision -
+  see <a href="https://github.com/w3c/dxwg/issues/121">Issue #121</a>.
+</li>
+
+<li><a href="#Property:dataset_contactPoint">Property: contact point</a>:
+	In DCAT version 1.0 [[!VOCAB-DCAT]] the domain of dcat:contactPoint was dcat:Dataset,
+  which limited use of this property in other contexts. The domain has been relaxed in this revision -
+  see <a href="https://github.com/w3c/dxwg/issues/95">Issue #95</a>.
+</li>
+
+<li><a href="#Property:dataset_landingpage">Property: landing page</a>:
+	In DCAT version 1.0 [[!VOCAB-DCAT]] the domain of dcat:landingPage was dcat:Dataset,
+  which limited use of this property in other contexts. The domain has been relaxed in this revision -
+  see <a href="https://github.com/w3c/dxwg/issues/122">Issue #122</a>.
+</li>
+
+        </ul>
+        
+      </section>
+    </section>
+
+  </body>
 </html>


### PR DESCRIPTION
As per [ACTION-98](https://www.w3.org/2017/dxwg/track/actions/98):

- Copied into the changelog the NOTEs in the spec concerning changes wrt DCAT 1.0
- Added ref to DCAT 1.0
- Minor editorial changes