### PR TITLE
dcat:keyword - Remove sub-property axiom for consistency with document

### DIFF
--- a/dcat/rdf/dcat.ttl
+++ b/dcat/rdf/dcat.ttl
@@ -522,7 +522,7 @@ dcat:keyword
   rdfs:label "كلمة  مفتاحية "@ar ;
   rdfs:label "キーワード/タグ"@ja ;
   rdfs:range rdfs:Literal ;
-  rdfs:subPropertyOf dct:subject ;
+#  rdfs:subPropertyOf dct:subject ; # datatype property is inconsistent with dct:subject usage note "intended to be used with non-literal values" and also inconsistent with the DCAT-2014 document
 .
 dcat:landingPage
   rdf:type rdf:Property ;


### PR DESCRIPTION
- see https://github.com/w3c/dxwg/issues/175