### PR TITLE
Add description of relation to LDP and LDN

### DIFF
--- a/dcat/index.html
+++ b/dcat/index.html
@@ -1773,6 +1773,207 @@ If a ISO 639-1 (two-letter) code is defined for language, then its corresponding
 
 </section>
 
+<section id="other-w3c-recommendations">
+
+	<h2>Relation to other W3C Recommendations</h2>
+
+	<p class="issue" data-number="254">
+		DCAT should be aligned with other recent Linked Data based Recommendations.
+	</p>
+	
+	<section id="ldp">
+		<h3>Linked Data Platform (LDP)</h3>
+		
+		<p>
+			DCAT provides a data model for representation of metadata about datasets in the form of Linked Data, but it does not specify how this metadata should be accessed or modified.
+			The DCAT compatible metadata can be viewed as collections of Catalog Records, Datasets and Data Services contained in a Catalog, and a collection of Distributions contained in a Dataset.
+			The Linked Data Platform [[ldp]] specification deals with access to and modification of Linked Data Platform Containers (LDPCs).
+			This section provides guidance on how to represent DCAT metadata as LDP Containers, which supports namely the implementation of <a href="https://solid.mit.edu/" title="Solid">Solid</a> based DCAT catalogs.
+		</p>
+
+		<p>
+			First, we will present an example of a LDPC for datasets in a catalog.
+			There is one catalog with one dataset.
+			The dataset is contained in the <code>&lt;/datasets/&gt;</code> LDP Direct Container.
+			To ensure the LDPC discovery, we connect it to the Catalog using the <code>dcat:datasets</code> predicate.
+		</p>
+		<div class="example">
+			<div class="example-title marker">
+				<span>Example 1</span>
+			</div>
+			<pre class="nohighlight turtle" aria-busy="false" aria-live="polite">
+@prefix dcat: &lt;http://www.w3.org/ns/dcat#&gt; .
+@prefix ldp:  &lt;http://www.w3.org/ns/ldp#&gt; .
+
+@base &lt;https://example.org/resource/catalog&gt; .
+
+&lt;&gt; a dcat:Catalog ;
+	dcat:datasets &lt;/datasets/&gt; ;
+	dcat:dataset &lt;/datasets/001&gt; .
+	
+&lt;/datasets/&gt; a ldp:Container, ldp:DirectContainer ;
+	ldp:membershipResource &lt;&gt; ;
+	ldp:hasMemberRelation dcat:dataset ;
+	ldp:contains &lt;/datasets/001&gt; .
+	
+&lt;/datasets/001&gt; a dcat:Dataset .</pre>
+		</div>
+		
+		<p>
+			In the second example, we add LDPCs <code>&lt;/records/&gt;</code> for Catalog Records and <code>&lt;/services/&gt;</code> for Data Services, discoverable using <code>dcat:records</code> and <code>dcat:services</code> predicates from the Catalog:
+		</p>
+		<div class="example">
+			<div class="example-title marker">
+				<span>Example 2</span>
+			</div>
+			<pre class="nohighlight turtle" aria-busy="false" aria-live="polite">
+@prefix dcat: &lt;http://www.w3.org/ns/dcat#&gt; .
+@prefix ldp:  &lt;http://www.w3.org/ns/ldp#&gt; .
+
+@base &lt;https://example.org/resource/catalog&gt; .
+
+&lt;&gt; a dcat:Catalog ;
+	dcat:records &lt;/records/&gt; ;
+	dcat:datasets &lt;/datasets/&gt; ;
+	dcat:services &lt;/services/&gt; ;
+	dcat:dataset &lt;/datasets/001&gt; .
+	
+&lt;/records/&gt; a ldp:Container, ldp:DirectContainer ;
+	ldp:membershipResource &lt;&gt; ;
+	ldp:hasMemberRelation dcat:record ;
+	ldp:contains &lt;/records/001&gt; .
+
+&lt;/datasets/&gt; a ldp:Container, ldp:DirectContainer ;
+	ldp:membershipResource &lt;&gt; ;
+	ldp:hasMemberRelation dcat:dataset ;
+	ldp:contains &lt;/datasets/001&gt; .
+	
+&lt;/services/&gt; a ldp:Container, ldp:DirectContainer ;
+	ldp:membershipResource &lt;&gt; ;
+	ldp:hasMemberRelation dcat:service ;
+	ldp:contains &lt;/services/001&gt; .
+
+&lt;/records/001&gt; a dcat:CatalogRecord ;
+	foaf:primaryTopic &lt;/datasets/001&gt; .
+	
+&lt;/datasets/001&gt; a dcat:Dataset ;
+
+&lt;/services/001&gt; a dcat:DataService .</pre>
+		</div>
+		<p>
+			Each dataset has its own LDPC for its distributions.
+			In the third example, we show the LDPC <code>&lt;/datasets/001/distributions/&gt;</code> for distributions of a single dataset, <code>&lt;/datasets/001&gt;</code>, discoverable through the <code>dcat:distributions</code> predicate.
+		</p>
+		<div class="example">
+			<div class="example-title marker">
+				<span>Example 3</span>
+			</div>
+			<pre class="nohighlight turtle" aria-busy="false" aria-live="polite">
+@prefix dcat: &lt;http://www.w3.org/ns/dcat#&gt; .
+@prefix ldp:  &lt;http://www.w3.org/ns/ldp#&gt; .
+
+@base &lt;https://example.org/resource/catalog&gt; .
+
+&lt;/datasets/001&gt; a dcat:Dataset ;
+	dcat:distributions &lt;/datasets/001/distributions/&gt; ;
+	dcat:distribution &lt;/datasets/001/distributions/001&gt; .
+
+&lt;/datasets/001/distributions/&gt; a ldp:Container, ldp:DirectContainer ;
+	ldp:membershipResource &lt;/datasets/001&gt; ;
+	ldp:hasMemberRelation dcat:distribution ;
+	ldp:contains &lt;/datasets/001/distributions/001&gt; .
+
+&lt;/datasets/001/distributions/001&gt; a dcat:Distribution .</pre>
+		</div>
+		
+		<p class="note">For catalogs with many datasets, catalog records, data services or distributions, 
+		the Linked Data Platform Paging mechanism [[ldp-paging]] SHOULD be used to provide access to them.</p>
+		
+		<p>
+			In the next sections we formally define the additional properties used for discovery of LDP containers.
+		</p>
+		
+		<section id="Property:catalog_datasets">
+		<h4>Property: datasets</h4>
+
+		<table class="definition">
+		  <thead><tr><th>RDF Property:</th><th><a href="http://www.w3.org/ns/dcat#datasets">dcat:datasets</a></th></tr></thead>
+		  <tbody>
+			<tr><td class="prop">Definition:</td><td>Connects a catalog to the LDP container of its datasets.</td></tr>
+			<tr><td class="prop">Domain:</td><td><a href="http://www.w3.org/ns/dcat#Catalog">dcat:Catalog</a></td></tr>
+			<tr><td class="prop">Range:</td><td><a href="http://www.w3.org/ns/ldp#DirectContainer">ldp:DirectContainer</a></td></tr>
+		  </tbody>
+		</table>
+		</section>
+
+		<section id="Property:catalog_records">
+		<h4>Property: catalog records</h4>
+
+		<table class="definition">
+		  <thead><tr><th>RDF Property:</th><th><a href="http://www.w3.org/ns/dcat#records">dcat:records</a></th></tr></thead>
+		  <tbody>
+			<tr><td class="prop">Definition:</td><td>Connects a catalog to the LDP container of its catalog records.</td></tr>
+			<tr><td class="prop">Domain:</td><td><a href="http://www.w3.org/ns/dcat#Catalog">dcat:Catalog</a></td></tr>
+			<tr><td class="prop">Range:</td><td><a href="http://www.w3.org/ns/ldp#DirectContainer">ldp:DirectContainer</a></td></tr>
+		  </tbody>
+		</table>
+		</section>
+
+		<section id="Property:catalog_services">
+		<h4>Property: data services</h4>
+
+		<table class="definition">
+		  <thead><tr><th>RDF Property:</th><th><a href="http://www.w3.org/ns/dcat#services">dcat:services</a></th></tr></thead>
+		  <tbody>
+			<tr><td class="prop">Definition:</td><td>Connects a catalog to the LDP container of its data services.</td></tr>
+			<tr><td class="prop">Domain:</td><td><a href="http://www.w3.org/ns/dcat#Catalog">dcat:Catalog</a></td></tr>
+			<tr><td class="prop">Range:</td><td><a href="http://www.w3.org/ns/ldp#DirectContainer">ldp:DirectContainer</a></td></tr>
+		  </tbody>
+		</table>
+		</section>
+
+		<section id="Property:dataset_distributions">
+		<h4>Property: distributions</h4>
+
+		<table class="definition">
+		  <thead><tr><th>RDF Property:</th><th><a href="http://www.w3.org/ns/dcat#distributions">dcat:distributions</a></th></tr></thead>
+		  <tbody>
+			<tr><td class="prop">Definition:</td><td>Connects a dataset to the LDP container of its distributions.</td></tr>
+			<tr><td class="prop">Domain:</td><td><a href="http://www.w3.org/ns/dcat#Dataset">dcat:Dataset</a></td></tr>
+			<tr><td class="prop">Range:</td><td><a href="http://www.w3.org/ns/ldp#DirectContainer">ldp:DirectContainer</a></td></tr>
+		  </tbody>
+		</table>
+		</section>
+
+	</section>
+
+	<section id="ldn">
+		<h3>Linked Data Notifications (LDN)</h3>
+		
+		<p>
+			Linked Data Notifications (LDN) [[ldn]] can be used with DCAT e.g. for feedback collection.
+			Any resource can have an LDN Inbox. 
+			In the following example we show a dataset <code>&lt;/datasets/001&gt;</code> as an LDN Target with an LDN Inbox.
+		</p>
+		<div class="example">
+			<div class="example-title marker">
+				<span>Example 4</span>
+			</div>
+			<pre class="nohighlight turtle" aria-busy="false" aria-live="polite">
+@prefix dcat: &lt;http://www.w3.org/ns/dcat#&gt; .
+@prefix ldp:  &lt;http://www.w3.org/ns/ldp#&gt; .
+
+@base &lt;https://example.org/resource/catalog&gt; .
+
+&lt;/datasets/001&gt; a dcat:Dataset ;
+	ldp:inbox &lt;/datasets/001/inbox/&gt; .
+
+&lt;/datasets/001/inbox/&gt; ldp:contains &lt;/datasets/001/inbox/001&gt; .</pre>
+		</div>
+	</section>
+
+</section>
+
 <section class="appendix" id="issue-summary">
   <!-- A list of issues will magically appear here -->
 </section>


### PR DESCRIPTION
Added a section with examples and property definitions describing relation of DCAT to LDP and LDN W3C Recommendations. This is in relation to #254.