### PR TITLE
Remove old milestone links, link to wiki instead

### DIFF
--- a/dcat/index.html
+++ b/dcat/index.html
@@ -130,7 +130,7 @@ It has been decided to add an explicit class for Data Distribution Services in t
 Provision for other data services to also be part of a Catalog will also be made, as well as for Catalogs to be composed of other Catalogs.
 See <a href="https://github.com/w3c/dxwg/issues/172">Issue #172</a>. </p>
 <p>
-	 <a href="https://github.com/w3c/dxwg/milestone/5">Milestone 5</a> collects a number of issues related to this requirement.
+	 <a href="https://github.com/w3c/dxwg/wiki/Cataloguing-data-services">The wiki page on Cataloguing data services</a> describes some proposals related to this requirement.
 </p>
 </div>
 
@@ -1943,7 +1943,7 @@ Besides, the examples and more in general the DQV  is neutral to the data portal
 
 	<p class="note">
 		In this chapter it is planned to describe patterns for the use of the [[PROV-O]] vocabulary to support the various provenance-related requirements.
-		See <a href="https://github.com/w3c/dxwg/milestone/2">Milestone 2</a> for more discussion.
+		See <a href="https://github.com/w3c/dxwg/wiki/Provenance-patterns">the wiki page on Provenance Patterns</a> for more discussion.
 	</p>
 
 </section>
@@ -2006,7 +2006,7 @@ Besides, the examples and more in general the DQV  is neutral to the data portal
 </p>
 
 <p class="note">
-	See <a href="https://github.com/w3c/dxwg/milestone/4">Milestone 4</a> for more discussion.
+	See <a href="https://github.com/w3c/dxwg/wiki/Alignments-and-crosswalks">the wikipage on Alignments and Crosswalks</a> for more discussion.
 </p>
 
 
@@ -2023,7 +2023,7 @@ Besides, the examples and more in general the DQV  is neutral to the data portal
 </p>
 
 <p class="note">
-	See <a href="https://github.com/w3c/dxwg/milestone/3">Milestone 3</a> for more discussion.
+	See <a href="https://github.com/w3c/dxwg/wiki/Application-profiles">the wikipage on Application Profiles</a> for more discussion.
 </p>
 
 </section>
@@ -2277,7 +2277,7 @@ Besides, the examples and more in general the DQV  is neutral to the data portal
 </li>
 
 <li>
-	<a href="#class-resource">Class: Catalogued resource</a>: In DCAT 2014 [[VOCAB-DCAT-20140116]] the scope of a <a href="#class-catalog">dcat:Catalog</a> was limited to Datasets. This has been generalized, and properties common to all catalogued resources are now associated with a super-class dcat:Resource - see <a href="https://github.com/w3c/dxwg/issues/172">Issue #172</a> and <a href="https://github.com/w3c/dxwg/issues/116">Issue #116</a>. <a href="https://github.com/w3c/dxwg/milestone/5">Milestone 5</a> collects a number of issues related to this.
+	<a href="#class-resource">Class: Catalogued resource</a>: In DCAT 2014 [[VOCAB-DCAT-20140116]] the scope of a <a href="#class-catalog">dcat:Catalog</a> was limited to Datasets. This has been generalized, and properties common to all catalogued resources are now associated with a super-class dcat:Resource - see <a href="https://github.com/w3c/dxwg/issues/172">Issue #172</a> and <a href="https://github.com/w3c/dxwg/issues/116">Issue #116</a>. <a href="https://github.com/w3c/dxwg/wiki/Cataloguing-data-services">The wiki page on Cataloguing data services</a> describes some proposals related to this requirement.
 	</p>
 </li>
 

--- a/dcat/index.html
+++ b/dcat/index.html
@@ -1943,7 +1943,7 @@ Besides, the examples and more in general the DQV  is neutral to the data portal
 
 	<p class="note">
 		In this chapter it is planned to describe patterns for the use of the [[PROV-O]] vocabulary to support the various provenance-related requirements.
-		See <a href="https://github.com/w3c/dxwg/wiki/Provenance-patterns">the wiki page on Provenance Patterns</a> for more discussion.
+		See the wiki page on <a href="https://github.com/w3c/dxwg/wiki/Provenance-patterns">Provenance Patterns</a> for more discussion.
 	</p>
 
 </section>
@@ -1956,7 +1956,7 @@ Besides, the examples and more in general the DQV  is neutral to the data portal
 		DCAT 2014 handling of license and rights do not appear to satisfy all requirements [[VOCAB-DCAT-20140116]].
 		The recently completed W3C ODRL vocabulary [[ODRL-VOCAB]] provides a rich language for describing many kinds of rights and obligations.
 		In this chapter it is planned to describe some patterns for linking DCAT Datasets and/or Distributions to suitable rights expressions.
-		See <a href="https://github.com/w3c/dxwg/milestone/1">Milestone 1</a> for more discussion.
+		See the wiki page on <a href="https://github.com/w3c/dxwg/wiki/License-and-rights">License and rights</a> for more discussion.
 	</p>
 
 </section>
@@ -2006,7 +2006,7 @@ Besides, the examples and more in general the DQV  is neutral to the data portal
 </p>
 
 <p class="note">
-	See <a href="https://github.com/w3c/dxwg/wiki/Alignments-and-crosswalks">the wikipage on Alignments and Crosswalks</a> for more discussion.
+	See the wiki page on <a href="https://github.com/w3c/dxwg/wiki/Alignments-and-crosswalks">Alignments and Crosswalks</a> for more discussion.
 </p>
 
 
@@ -2023,7 +2023,7 @@ Besides, the examples and more in general the DQV  is neutral to the data portal
 </p>
 
 <p class="note">
-	See <a href="https://github.com/w3c/dxwg/wiki/Application-profiles">the wikipage on Application Profiles</a> for more discussion.
+	See the wiki page on <a href="https://github.com/w3c/dxwg/wiki/Application-profiles">Application Profiles</a> for more discussion.
 </p>
 
 </section>

--- a/dcat/index.html
+++ b/dcat/index.html
@@ -130,7 +130,7 @@ It has been decided to add an explicit class for Data Distribution Services in t
 Provision for other data services to also be part of a Catalog will also be made, as well as for Catalogs to be composed of other Catalogs.
 See <a href="https://github.com/w3c/dxwg/issues/172">Issue #172</a>. </p>
 <p>
-	 <a href="https://github.com/w3c/dxwg/wiki/Cataloguing-data-services">The wiki page on Cataloguing data services</a> describes some proposals related to this requirement.
+	 The wiki page on <a href="https://github.com/w3c/dxwg/wiki/Cataloguing-data-services">Cataloguing data services</a> describes some proposals related to this requirement.
 </p>
 </div>
 
@@ -1975,7 +1975,7 @@ Besides, the examples and more in general the DQV  is neutral to the data portal
 
 	<p class="note">
 		In this chapter it is planned to describe some patterns for describing Dataset and/or Distribution versions.
-		See <a href="https://github.com/w3c/dxwg/milestone/6">Milestone 6</a> for more discussion.
+		See the wiki page on <a href="https://github.com/w3c/dxwg/wiki/Dataset-versioning">Dataset versioning</a> for more discussion.
 	</p>
 
 </section>
@@ -2277,7 +2277,7 @@ Besides, the examples and more in general the DQV  is neutral to the data portal
 </li>
 
 <li>
-	<a href="#class-resource">Class: Catalogued resource</a>: In DCAT 2014 [[VOCAB-DCAT-20140116]] the scope of a <a href="#class-catalog">dcat:Catalog</a> was limited to Datasets. This has been generalized, and properties common to all catalogued resources are now associated with a super-class dcat:Resource - see <a href="https://github.com/w3c/dxwg/issues/172">Issue #172</a> and <a href="https://github.com/w3c/dxwg/issues/116">Issue #116</a>. <a href="https://github.com/w3c/dxwg/wiki/Cataloguing-data-services">The wiki page on Cataloguing data services</a> describes some proposals related to this requirement.
+	<a href="#class-resource">Class: Catalogued resource</a>: In DCAT 2014 [[VOCAB-DCAT-20140116]] the scope of a <a href="#class-catalog">dcat:Catalog</a> was limited to Datasets. This has been generalized, and properties common to all catalogued resources are now associated with a super-class dcat:Resource - see <a href="https://github.com/w3c/dxwg/issues/172">Issue #172</a> and <a href="https://github.com/w3c/dxwg/issues/116">Issue #116</a>. The wiki page on <a href="https://github.com/w3c/dxwg/wiki/Cataloguing-data-services">Cataloguing data services</a> describes some proposals related to this requirement.
 	</p>
 </li>
 


### PR DESCRIPTION
As discussed, links now go direct to wiki pages, avoiding the redundant milestones.  Where the milestone didn't exist or where it was simple to do, I've updated the wiki pages to link to the issues discussed on the page.