### PR TITLE
Update URLs to DataCite / DCAT-AP mapping

### DIFF
--- a/ucr/index.html
+++ b/ucr/index.html
@@ -800,7 +800,7 @@ Users need a way to view the aggregated collection level metadata and the associ
       </ul>
         </p>
         <p class="existing_approaches">
-          <p><a rel="nofollow" class="external text" href="https://github.com/ec-jrc/datacite-to-dcat-ap/">A study</a> has been carried out at the <a rel="nofollow" class="external text" href="https://ec.europa.eu/jrc/">European Commission's Joint Research Centre (JRC)</a>, in order to create mappings between [[DataCite]] (the current <i>de facto</i> standard for data citation) and [[DCAT-AP]]. </p>
+          <p><a rel="nofollow" class="external text" href="https://ec-jrc.github.io/datacite-to-dcat-ap/">A study</a> has been carried out at the <a rel="nofollow" class="external text" href="https://ec.europa.eu/jrc/">European Commission's Joint Research Centre (JRC)</a>, in order to create mappings between [[DataCite]] (the current <i>de facto</i> standard for data citation) and [[DCAT-AP]]. </p>
           <p>The results show that [[DCAT-AP]] covers most of the required [[DataCite]] metadata elements, but some of them are missing. In particular:</p>
           <ul>
         <li> Mandatory elements:<ul><li> Dataset creator (but [[GeoDCAT-AP]] supports it)</li></ul></li>
@@ -813,7 +813,7 @@ Users need a way to view the aggregated collection level metadata and the associ
           <ul>
         <li><a rel="nofollow" class="external text" href="https://www.w3.org/2016/11/sdsvoc/SDSVoc16_paper_27#data-citation"><i>Using DCAT-AP for research data</i>.</a> Smart Descriptions &amp; Smarter Vocabularies (SDSVoc). Amsterdam, 30 Nov - 1 Dec 2016.</li>
         <li>
-          <a rel="nofollow" class="external text" href="https://github.com/ec-jrc/datacite-to-dcat-ap/">
+          <a rel="nofollow" class="external text" href="https://ec-jrc.github.io/datacite-to-dcat-ap/">
             <i>DataCite to DCAT-AP Mapping</i>
           </a>
         </li>
@@ -1407,14 +1407,14 @@ input:Dataset a dcat:Dataset .
         <li> Services are modeled as <code>dcat:Catalog</code>, in case of a catalog service, and with <code>dctype:Service</code> [[DCTerms]] in all the other cases.</li>
         <li> The type of service (discovery, download, view, etc.) is modeled by using <code>dcterms:type</code>.</li>
       </ul>
-          <p>A similar approach has been adopted in <a rel="nofollow" class="external text" href="https://github.com/ec-jrc/datacite-to-dcat-ap/">the study</a> carried out by the <a rel="nofollow" class="external text" href="https://ec.europa.eu/jrc/">European Commission's Joint Research Centre (JRC)</a> to map [[DataCite]] to [[DCAT-AP]]. </p>
+          <p>A similar approach has been adopted in <a rel="nofollow" class="external text" href="https://ec-jrc.github.io/datacite-to-dcat-ap/">the study</a> carried out by the <a rel="nofollow" class="external text" href="https://ec.europa.eu/jrc/">European Commission's Joint Research Centre (JRC)</a> to map [[DataCite]] to [[DCAT-AP]]. </p>
           <p>The resource types supported in [[DataCite]] are 14. Most of them fall into the generic [[VOCAB-DCAT]] definition of "dataset", so they are modeled with <code>dcat:Dataset</code>. Moreover, the DCMI Type Vocabulary [[DCTerms]] is used to model both the dataset "type", and those resource types that cannot be modeled as datasets (events, physical objects, services).</p>
         </p>
         <p class="links">
           <ul>
         <li> [[GeoDCAT-AP]]</li>
         <li>
-          <a rel="nofollow" class="external text" href="https://github.com/ec-jrc/datacite-to-dcat-ap/">
+          <a rel="nofollow" class="external text" href="https://ec-jrc.github.io/datacite-to-dcat-ap/">
             <i>DataCite to DCAT-AP Mapping</i>
           </a>
         </li>


### PR DESCRIPTION
Just and editorial change, to point to the relevant specification, instead of its repository:
- Old URL: https://github.com/ec-jrc/datacite-to-dcat-ap/
- New URL: https://ec-jrc.github.io/datacite-to-dcat-ap/