### PR TITLE
Minor types and references/links

### DIFF
--- a/dcat/index.html
+++ b/dcat/index.html
@@ -1336,7 +1336,7 @@ into a separate named graph. The name of that graph <em title="SHOULD" class="rf
   <tbody>
     <tr><td class="prop">Definition:</td><td>The IRI of the service end-point.</td></tr>
 		<tr><td class="prop">Domain:</td><td><a href="http://www.w3.org/ns/dcat#DataService">dcat:DataService</a> </td></tr>
-		<tr><td class="prop">Range:</td><td><a href="http://www.w3.org/2001/XMLSchema#anyURI">xsd:anyURI</a> </td></tr>
+		<tr><td class="prop">Range:</td><td><a href="http://www.w3.org/TR/XMLSchema11-2/#anyURI">xsd:anyURI</a> </td></tr>
   </tbody>
 </table>
 </section>
@@ -2016,9 +2016,9 @@ Other examples of quality documentation are available in the W3C Group Note DQV 
 <p> This subsection  shows different modelling patterns combining DQV [[vocab-dqv]] with  PROV [[PROV-O]] and EARL [[EARL10-Schema]] to represent the conformance degree to a stated quality standard and the details about the conformance tests. 
 </p>
     
-<section id="quality-confomance-statement"> 
+<section id="quality-conformance-statement"> 
 <h3>Conformance to a standard</h3>
- <p>The use of <a href="http://dublincore.org/documents/dcmi-terms/#terms-conformsTo">dct:conformsTo</a> and <a href="http://dublincore.org/documents/dcmi-terms/#terms-conformsTo">dct:Standard</a> is a well-known pattern to represent the conformance to a standard. The following example declares a fictional a:Dataset conformant to the "Commission Regulation (EU) No 1089/2010 of 23 November 2010 implementing Directive 2007/2/EC".</p>
+ <p>The use of <a href="http://dublincore.org/documents/dcmi-terms/#terms-conformsTo">dct:conformsTo</a> and <a href="http://dublincore.org/documents/dcmi-terms/#terms-Standard">dct:Standard</a> is a well-known pattern to represent the conformance to a standard. The following example declares a fictional a:Dataset conformant to the "Commission Regulation (EU) No 1089/2010 of 23 November 2010 implementing Directive 2007/2/EC".</p>
 <pre>       
 a:Dataset a dcat:Dataset;
     dct:conformsTo &lt;http://data.europa.eu/eli/reg/2014/1312/oj&gt; .  
@@ -2029,7 +2029,7 @@ a:Dataset a dcat:Dataset;
     dct:issued "2010-11-23"^^xsd:date .
 </pre>
 </section> 
-<section id="quality-confomance-degree"> 
+<section id="quality-conformance-degree"> 
 <h3> Degree of conformance</h3>
      <p>Some legal context requires to specify the degree of conformance. For example,  INSPIRE metadata adopts a specific <a href="http://inspire.ec.europa.eu/metadata-codelist/DegreeOfConformity">controlled vocabulary</a> to express  non-conformance and non-evaluation beside the full compliance. As suggested in [[geodcat-ap]], the following example specifies the degree of conformance (i.e.,  not conformant) by declaring the  <a href="http://dublincore.org/documents/dcmi-terms/#terms-type">dct:type</a> for the result of conformance test.  [[geodcat-ap]] suggests to use a PROV entity to model the  conformance test (e.g., a:TestResult),  a PROV activity to model the testing activity (e,g., a:TestingActivity), a PROV plan derived by the INSPIRE Directive to represent  conformance test (e.g., a:ConformanceTest). A qualified PROV association binds the testing activity to the conformance test.  
     </p> 
@@ -2073,7 +2073,7 @@ iso:inherentandSystemDependentDataQuality
     a  dqv:Category ;
    skos:prefLabel "Inherent and System-Dependent Data Quality"@en.  
         </pre>
-<p>The quality measurement :measurement_complianceToINSPIRE represents the level of compliance for a dataset a:Dataset, namely, measurement of the metric :levelOfComplianceToINSPIRE. If only a part of the compliance tests succeeds (e.g. half of the compliance tests), the measurement would look like in the following:
+<p>The quality measurement :measurement_complianceToINSPIRE represents the level of compliance for a dataset a:Dataset, namely, measurement of the metric :levelOfComplianceToINSPIRE. If only a part of the compliance tests succeeds (e.g. half of the compliance tests), the measurement would look like in the following:</p>
      <pre>
 :measurement_complianceToINSPIRE 
    a         dqv:QualityMeasurement;
@@ -2083,9 +2083,9 @@ iso:inherentandSystemDependentDataQuality
    dcterms:date      "2018-01-10"^^xsd:date ;
    dqv:isMeasurementOf    :levelOfComplianceToINSPIRE .
     </pre>
-</p>    
+    
 </section> 
-<section id="quality-confomance-test-results"> 
+<section id="quality-conformance-test-results"> 
 <h3>Conformance test results</h3>
     <p> Further information about the tests can be provided using EARL [[EARL10-Schema]]. EARL provides specific classes to describe the testing activity, which can be adopted in conjunction with PROV. 
 The following example describes the Testing activity a:TestingActivity as an EARL Assertion instead of a qualified association on the PROV activity. The EARL Assertion states the dataset a:Dataset has been tested with the conformance test a:ConformanceTest, and it has passed the test as described in a:testResult.  


### PR DESCRIPTION
This tidies up a few glitches in the doc (and a ref to xml-schema).  Its the last set of sub-editing I want to do for a bit - the draft basically passes the linkchecker and html checker.  