### PR TITLE
Explain removal of subclass relationship between dcat:Dataset and dctype:Dataset.

### DIFF
--- a/dcat/index.html
+++ b/dcat/index.html
@@ -1451,10 +1451,15 @@ into a separate named graph. The name of that graph <em title="SHOULD" class="rf
   </tbody>
 </table>
 
-<p class="note">
-    In DCAT 2014 [[!VOCAB-DCAT-20140116]] <a href="#Class:Dataset">dcat:Dataset</a> was a sub-class of <a href="http://purl.org/dc/dcmitype/Dataset">dctype:Dataset</a>, which is a member of the <a href="http://dublincore.org/documents/dcmi-terms/#section-7">DCMI Types vocabulary</a> [[DCTERMS]].
-	This relationship has been removed in the revised DCAT vocabulary - see <a href="https://github.com/w3c/dxwg/issues/98">Issue #98</a>.
-</p>
+<div class="note">
+	<p>
+		In DCAT 2014 [[!VOCAB-DCAT-20140116]] <a href="#Class:Dataset">dcat:Dataset</a> was a sub-class of <a href="http://purl.org/dc/dcmitype/Dataset">dctype:Dataset</a>, which is a member of the <a href="http://dublincore.org/documents/dcmi-terms/#section-7">DCMI Types vocabulary</a> [[DCTERMS]].
+		The scope of <a href="#Class:Dataset">dcat:Dataset</a> also includes other members of the <a href="http://dublincore.org/documents/dcmi-terms/#section-7">DCMI Types vocabulary</a>, so the implicitly limited sub-class relationship from DCAT 2014 [[!VOCAB-DCAT-20140116]] has been removed in this revised DCAT vocabulary - see <a href="https://github.com/w3c/dxwg/issues/98">Issue #98</a>.
+	</p>
+	<p>
+		Note that members of the <a href="http://dublincore.org/documents/dcmi-terms/#section-7">DCMI Types vocabulary</a> may appear as the value of the <a href="#Property:resource_type">dct:type</a> property, as shown in <a href="#classifying-dataset-types">Classifying dataset types</a>.
+	</p>
+</div>
 
 
 <section id="Property:dataset_creator">


### PR DESCRIPTION
Addressing #350 