### PR TITLE
improved CNEG link

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,4 +10,4 @@
 - [DCAT Revision](https://w3c.github.io/dxwg/dcat/)  
   - [DCAT Revision First Public Working Draft (FPWD)](https://www.w3.org/TR/vocab-dcat-2/)
 - [Dataset Exchange Guidance for Application Profiles](https://w3c.github.io/dxwg/profiles/)
-- [Content Negotiation by Profile](https://github.com/w3c/dxwg/tree/gh-pages/conneg-by-ap)
+- [Content Negotiation by Profile](https://w3c.github.io/dxwg/conneg-by-ap/)


### PR DESCRIPTION
Changed link for CNEG to link to the HTML rendered doc, not the GitHub files.

Lars just added a link to the files but the HTML page is better for a README link.