### PR TITLE
moved CNEG link to github.io HTML

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,4 +10,4 @@
 - [DCAT Revision](https://w3c.github.io/dxwg/dcat/)  
   - [DCAT Revision First Public Working Draft (FPWD)](https://www.w3.org/TR/vocab-dcat-2/)
 - [Dataset Exchange Guidance for Application Profiles](https://w3c.github.io/dxwg/profiles/)
-- [Content Negotiation by Profile](https://github.com/w3c/dxwg/tree/gh-pages/conneg-by-ap)
+- [Content Negotiation by Profile](https://w3c.github.io/conneg-by-ap/)


### PR DESCRIPTION
Lars added a link to the CNEG HTML file in the repo but it's easier for users to go the GitHub.io rendered HTML link of the CNEG doc