### PR TITLE
Editorial changes (ACTION-228)

### DIFF
--- a/dcat/config.js
+++ b/dcat/config.js
@@ -38,7 +38,7 @@ var respecConfig = {
 //            href: "https://pro.europeana.eu/person/antoine-isaac"
 //        },{
 //            value: "Andrea Perego, European Commission",
-//            href: "https://ec.europa.eu/jrc/en/research-topic/digital-earth"
+//            href: "https://ec.europa.eu/jrc/"
 //        }]
 //      },{
         key: "Editors of previous version",
@@ -69,7 +69,7 @@ var respecConfig = {
          date : "2016"
        },
       "ZaveriEtAl" : {
-          title : "Quality assessment for Linked Data: A Survey",
+          title : "Quality assessment for Linked Data: A Survey",
           authors : [ "Amrapali Zaveri", "Anisa Rula", "Andrea Maurino",
                       "Ricardo Pietrobon", "Jens  Lehmann", "Sören Auer" ],
           status : "Semantic Web, vol. 7, no. 1, pp. 63-93, 2015",
@@ -84,10 +84,6 @@ var respecConfig = {
          title : "Data Documentation Initiative",
          publisher : "DDI Alliance"
       },
-      "schema-org" : {
-         href:"http://schema.org/",
-         title:"Schema.org"
-      },
       "DATS": {
           "href": "https://github.com/datatagsuite/",
           "title": "Data Tag Suite",
@@ -95,32 +91,32 @@ var respecConfig = {
           "publisher": "NIH Big Data 2 Knowledge bioCADDIE and NIH Data Commons projects",
           "date": "2016"
       },
-      "dbpedia-ont" : {
+      "DBPEDIA-ONT" : {
          href:"http://dbpedia.org/ontology/",
          title:"DBPedia ontology"
       },
-      "doap" : {
+      "DOAP" : {
          href:"https://github.com/ewilderj/doap/wiki",
          title:"Description of a Project",
          authors: ["Edd Wilder-James"]
       },
-      "frapo" : {
+      "FRAPO" : {
          href:"http://www.sparontologies.net/ontologies/frapo",
          title:"FRAPO, the Funding, Research Administration and Projects Ontology",
          authors: ["David Shotton"],
          date: "04 September 2017"
       },
-      "obo" : {
+      "OBO" : {
          href:"http://www.obofoundry.org/",
          title:"The OBO Foundry"
       },
-      "pdo" : {
+      "PDO" : {
          href:"http://vocab.deri.ie/pdo",
          title:"Project Documents Ontology",
          authors: ["Pradeep Varma"],
          date: "09 July 2010"
       },
-      "vivo-isf" : {
+      "VIVO-ISF" : {
          href:"http://github.com/vivo-isf/vivo-isf",
          title:"VIVO-ISF Data Standard"
       },
@@ -131,15 +127,15 @@ var respecConfig = {
           href : "http://patterns.dataincubator.org/book/"
       },
       "PROF-CONNEG": {
-            href: "https://www.w3.org/TR/conneg-by-ap/",
+            href: "https://w3c.github.io/dxwg/conneg-by-ap/",
             title: "Content Negotiation by Profile",
-            date: " 2018-12-31",
+            date: " 2018-10-03",
             status: "W3C Editor's Draft"
       },
       "PROF-GUIDE": {
-            href: "https://www.w3.org/TR/profile-guidance/",
+            href: "https://w3c.github.io/dxwg/profiles/",
             title: "Profile Guidance",
-            date: " 2018-12-31",
+            date: " 2018-10-03",
             status: "W3C Editor's Draft"
       },
       "PROF-IETF": {
@@ -147,7 +143,7 @@ var respecConfig = {
                 "L. Svensson",
                 "R. Verborgh"
             ],
-            href: "https://profilenegotiation.github.io/I-D-Accept--Schema/I-D-accept-schema/",
+            href: "https://profilenegotiation.github.io/I-D-Accept--Schema/I-D-accept-schema",
             title: "Negotiating Profiles in HTTP",
             date: " 2017-10-24",
             status: "IETF Internet Draft"

--- a/dcat/index.html
+++ b/dcat/index.html
@@ -189,7 +189,7 @@ See <a href="https://github.com/w3c/dxwg/issues/172">Issue #172</a>. </p>
 <p>A <b>CatalogRecord</b> describes an entry in the catalog. Notice that while <code>dcat:Resource</code> represents the dataset or service itself, <code>dcat:CatalogRecord</code> is the record that describes the registration of an item in the catalog. The use of <code>dcat:CatalogRecord</code> is considered optional. It is used to capture provenance information about entries in a catalog. If this distinction is not necessary then <code>dcat:CatalogRecord</code> can be safely ignored.</p>
 
 
-<p id="blankNodes">RDF allows resources to have global identifiers (IRIs) or to be blank nodes.  Blank nodes can be used to denote resources without explicitly naming them with an IRI. They can appear in the subject and object position of a triple [[rdf11-primer]].
+<p id="blankNodes">RDF allows resources to have global identifiers (IRIs) or to be blank nodes.  Blank nodes can be used to denote resources without explicitly naming them with an IRI. They can appear in the subject and object position of a triple [[RDF11-PRIMER]].
 While blank nodes may offer flexibility for some use cases, in a Linked Data context, blank nodes limit our ability to collaboratively annotate data. A  blank node resource cannot be the target of a link and it can't be annotated with new information from new sources. As one of the biggest benefits of the Linked Data approach is that "anyone can say anything anywhere", use of blank nodes undermines some of the advantages we can gain from wide adoption of the RDF model. Even within the closed world of a single application dataset, use of blank nodes can quickly become limiting when integrating new data [[LinkedDataPatterns]].
 For these reasons, instances of the DCAT main classes <em title="SHOULD" class="rfc2119">SHOULD</em> have a global identifier, and use of blank nodes is generally discouraged when encoding DCAT in RDF.</p>
 
@@ -295,7 +295,7 @@ It is recommended to define the concept as part of the concepts scheme identifie
 
 <p>
 	The type or genre of a dataset <em title="MAY" class="rfc2119">MAY</em> be indicated using the <a href="http://purl.org/dc/terms/type">dct:type</a> property.
-	The value of the property <em title="SHOULD" class="rfc2119">SHOULD</em> be taken from a well governed and broadly recognised set of resource types, such as the <a href="http://dublincore.org/documents/dcmi-terms/#section-7">DCMI Type Vocabulary</a>, the <a href="https://id.loc.gov/vocabulary/marcgt.html">MARC Genre/Terms Scheme</a>, the <a href="https://schema.datacite.org/meta/kernel-4.1/include/datacite-resourceType-v4.1.xsd">DataCite resource types</a> or the PARSE.Insight content-types from Re3data [[re3data-schema]].
+	The value of the property <em title="SHOULD" class="rfc2119">SHOULD</em> be taken from a well governed and broadly recognised set of resource types, such as the <a href="http://dublincore.org/documents/dcmi-terms/#section-7">DCMI Type Vocabulary</a>, the <a href="https://id.loc.gov/vocabulary/marcgt.html">MARC Genre/Terms Scheme</a>, the <a href="https://schema.datacite.org/meta/kernel-4.1/include/datacite-resourceType-v4.1.xsd">DataCite resource types</a> or the PARSE.Insight content-types from Re3data [[RE3DATA-SCHEMA]].
 </p>
 <p>
 	In the following examples a (notional) dataset is classified separately using a values from different vocabularies.
@@ -1113,7 +1113,7 @@ If a ISO 639-1 (two-letter) code is defined for language, then its corresponding
 <h4>Property: publisher</h4>
 
 <p class="issue" data-number="80">
-	The desire to have qualified forms of properties (as done in [[PROV-O]]) has been raised. If dcat:Dataset is a prov:Entity (not decided yet) then `publisher` could be a qualified prov:Entity -> prov:Agent relationship.
+	The desire to have qualified forms of properties (as done in [[PROV-O]]) has been raised. If dcat:Dataset is a prov:Entity (not decided yet) then `publisher` could be a qualified prov:Entity &rarr; prov:Agent relationship.
 </p>
 
 <table class="definition">
@@ -1718,9 +1718,9 @@ New property for Dataset in this revision of DCAT, added when considering the da
 	<a href="http://www.w3.org/ns/prov#Activity">prov:Activity</a> provides for some basic properties such as begin and end time, associated agents etc.
 	Further details may be provided through classes defined in applications.
 	A number of ontologies for describing projects are available, for example
-	VIVO for academic research projects [[vivo-isf]],
-	DOAP (Description of a Project) for software projects [[doap]], and
-	DBPedia for general projects [[dbpedia-ont]] which are expected to be suitable for different applications.
+	VIVO for academic research projects [[VIVO-ISF]],
+	DOAP (Description of a Project) for software projects [[DOAP]], and
+	DBPedia for general projects [[DBPEDIA-ONT]] which are expected to be suitable for different applications.
 </p>
 </section>
 
@@ -2075,7 +2075,7 @@ New property for Dataset in this revision of DCAT, added when considering the da
 
 <section id="quality-information" class="informative">
     <h2>Quality information</h2>
-<div class="note"><p>This section is not-normative as it provides guidance on how to document the quality of DCAT first class entities (e.g., datasets, distributions) and it does not define new DCAT terms. The guidance relies on the Data Quality Vocabulary(DQV)[[vocab-dqv]], which is a W3C Group Note.</p></div>
+<div class="note"><p>This section is not-normative as it provides guidance on how to document the quality of DCAT first class entities (e.g., datasets, distributions) and it does not define new DCAT terms. The guidance relies on the Data Quality Vocabulary(DQV)[[VOCAB-DQV]], which is a W3C Group Note.</p></div>
 
 The Data Quality Vocabulary (DQV) offers common modelling patterns for different aspects of Data Quality.
 
@@ -2089,7 +2089,7 @@ It can relate  DCAT datasets and distributions with different types of quality i
 Each type of quality information can pertain to one or more quality dimensions, namely, quality characteristics relevant to the consumer. The practice to see the quality as a multi-dimensional space is consolidated in the field of quality management to split the quality management into addressable chunks. DQV does not define a normative list of quality dimensions. It offers the quality dimensions proposed in ISO/IEC 25012 [[ISOIEC25012]] and Zaveri et al. [[ZaveriEtAl]] as two possible starting points. It also provides an <a href="https://www.w3.org/2016/05/ldqd">RDF representation</a> for the quality dimensions and categories defined in the latter. Ultimately, implementers will need to choose themselves the collection of quality dimensions that best fits their needs.
 
 The following section shows how DCAT and DQV can be coupled to describe the quality of datasets and distributions.
-For a comprehensive introduction  and further examples of use, please refer to the Data Quality Vocabulary (DQV) group note [[vocab-dqv]].
+For a comprehensive introduction  and further examples of use, please refer to the Data Quality Vocabulary (DQV) group note [[VOCAB-DQV]].
 <div class="note">
 <p>The following examples make no comments on where the quality information would reside and how it is managed. That is out of scope for the DCAT vocabulary.  The assumption made is that the quality individuals are available using the URIs indicated.
 Besides, the examples and more in general the DQV  is neutral to the data portal design choices on how to collect quality information. For example, data portals can collect DQV instances by implementing specific UI to annotate data or by taking inputs from 3rd-party services.
@@ -2169,7 +2169,7 @@ Besides, the examples and more in general the DQV  is neutral to the data portal
     prov:endedAtTime      "2018-05-27T02:52:02Z"^^xsd:dateTime;
     prov:startedAtTime     "2018-05-27T00:52:02Z"^^xsd:dateTime .
     </pre></div>
-Other examples of quality documentation are available in the W3C Group Note DQV [[vocab-dqv]], including examples about <a href="https://www.w3.org/TR/vocab-dqv/#ExpressDatasetAccuracyPrecision">how express dataset accuracy and precision</a>.
+Other examples of quality documentation are available in the W3C Group Note DQV [[VOCAB-DQV]], including examples about <a href="https://www.w3.org/TR/vocab-dqv/#ExpressDatasetAccuracyPrecision">how express dataset accuracy and precision</a>.
     </section>
 <section id="quality-conformance">
 <h2>Documenting conformance to standards</h2>
@@ -2177,7 +2177,7 @@ Other examples of quality documentation are available in the W3C Group Note DQV 
 	The issue suggests to represent "the degree a dataset conforms to a stated quality standard" and "the details of data quality conformance test results". This section is a starter to deal with the above requests by relying on the existing  W3C vocabularies.
     Comments and suggestions about the following examples as well as the proposal of alternative patterns are more than welcome.
     </p>
-<p> This subsection  shows different modelling patterns combining DQV [[vocab-dqv]] with  PROV [[PROV-O]] and EARL [[EARL10-Schema]] to represent the conformance degree to a stated quality standard and the details about the conformance tests.
+<p> This subsection  shows different modelling patterns combining DQV [[VOCAB-DQV]] with  PROV [[PROV-O]] and EARL [[EARL10-Schema]] to represent the conformance degree to a stated quality standard and the details about the conformance tests.
 </p>
 
 <section id="quality-conformance-statement">
@@ -2197,7 +2197,7 @@ a:Dataset a dcat:Dataset;
 </section>
 <section id="quality-conformance-degree">
 <h3> Degree of conformance</h3>
-     <p>Some legal context requires to specify the degree of conformance. For example,  INSPIRE metadata adopts a specific <a href="http://inspire.ec.europa.eu/metadata-codelist/DegreeOfConformity">controlled vocabulary</a> to express  non-conformance and non-evaluation beside the full compliance. As suggested in [[geodcat-ap]], the following example specifies the degree of conformance (i.e.,  not conformant) by declaring the  <a href="http://dublincore.org/documents/dcmi-terms/#terms-type">dct:type</a> for the result of conformance test.  [[geodcat-ap]] suggests to use a PROV entity to model the  conformance test (e.g., a:TestResult),  a PROV activity to model the testing activity (e,g., a:TestingActivity), a PROV plan derived by the INSPIRE Directive to represent  conformance test (e.g., a:ConformanceTest). A qualified PROV association binds the testing activity to the conformance test.
+     <p>Some legal context requires to specify the degree of conformance. For example,  INSPIRE metadata adopts a specific <a href="http://inspire.ec.europa.eu/metadata-codelist/DegreeOfConformity">controlled vocabulary</a> to express  non-conformance and non-evaluation beside the full compliance. As suggested in [[GeoDCAT-AP]], the following example specifies the degree of conformance (i.e.,  not conformant) by declaring the  <a href="http://dublincore.org/documents/dcmi-terms/#terms-type">dct:type</a> for the result of conformance test.  [[GeoDCAT-AP]] suggests to use a PROV entity to model the  conformance test (e.g., a:TestResult),  a PROV activity to model the testing activity (e,g., a:TestingActivity), a PROV plan derived by the INSPIRE Directive to represent  conformance test (e.g., a:ConformanceTest). A qualified PROV association binds the testing activity to the conformance test.
     </p>
 <div class="example">
   <pre class="nohighlight turtle" aria-busy="false" aria-live="polite">
@@ -2223,7 +2223,7 @@ a:ConformanceTest a prov:Plan ;
     # Here you can specify additional information on the test
     prov:wasDerivedFrom &lt;http://data.europa.eu/eli/reg/2014/1312/oj&gt; .
     </pre></div>
-<p>Also,  DQV [[vocab-dqv]] can be deployed to  measure the compliance to a specific standard. In the following, the :levelOfComplianceToINSPIRE is a quality metrics which measures the compliance of a dataset to INSPIRE in terms of the percentage of passed compliance tests. The example assumes iso as a namespace representing the quality dimensions and categories defined in the ISO/IEC 25012.</p>
+<p>Also,  DQV [[VOCAB-DQV]] can be deployed to  measure the compliance to a specific standard. In the following, the :levelOfComplianceToINSPIRE is a quality metrics which measures the compliance of a dataset to INSPIRE in terms of the percentage of passed compliance tests. The example assumes iso as a namespace representing the quality dimensions and categories defined in the ISO/IEC 25012.</p>
 <div class="example">
   <pre class="nohighlight turtle" aria-busy="false" aria-live="polite">
 
@@ -2453,7 +2453,7 @@ a:TestingActivity a prov:Activity;
 <section id="dcat-sdo" class="informative">
 	<h3>Schema.org</h3>
 	<p>
-		<a href="https://schema.org/">Schema.org</a> includes a number of types and properties based on the original DCAT work (see <a href="https://schema.org/Dataset">schema:Dataset</a> as a starting point),
+		Schema.org [[SCHEMA-ORG]] includes a number of types and properties based on the original DCAT work (see <a href="https://schema.org/Dataset">schema:Dataset</a> as a starting point),
 		and the index for Google's <a href="https://g.co/datasetsearch">Dataset Search service</a> relies on structured description in web pages about datasets based on both
 		<a href="https://developers.google.com/search/docs/data-types/dataset">schema.org and DCAT</a>.
 	</p>
@@ -2463,7 +2463,7 @@ a:TestingActivity a prov:Activity;
 	</p>
 	<p>
 		A <a href="https://www.w3.org/wiki/WebSchemas/Datasets">mapping between DCAT 2014 and schema.org</a> was discussed on the original proposal to extend schema.org for describing datasets and data catalogs.
-		Partial mappings between DCAT 2014 [[VOCAB-DCAT-20140116]] and <a href="https://schema.org/docs/schemas.html">schema.org</a> were provided earlier by the
+		Partial mappings between DCAT 2014 [[VOCAB-DCAT-20140116]] and schema.org were provided earlier by the
 		<a href="https://ec-jrc.github.io/dcat-ap-to-schema-org/">European Commission</a> and the <a href="https://www.w3.org/2015/spatial/wiki/ISO_19115_-_DCAT_-_Schema.org_mapping">Spatial Data on the Web Working Group</a>.
 	</p>
 	<p>
@@ -2893,7 +2893,7 @@ a:TestingActivity a prov:Activity;
 		<p>
 			DCAT provides a data model for representation of metadata about datasets in the form of Linked Data, but it does not specify how this metadata can be accessed or modified.
 			The DCAT compatible metadata can be viewed as collections of Catalog Records, Datasets and Data Services contained in a Catalog, and a collection of Distributions contained in a Dataset.
-			The Linked Data Platform [[ldp]] specification deals with access to and modification of Linked Data Platform Containers (LDPCs).
+			The Linked Data Platform [[LDP]] specification deals with access to and modification of Linked Data Platform Containers (LDPCs).
 			This section provides guidance on how to represent DCAT metadata as LDP Containers, which supports namely the implementation of <a href="https://solid.mit.edu/" title="Solid">Solid</a> based DCAT catalogs.
 		</p>
 
@@ -2993,7 +2993,7 @@ a:TestingActivity a prov:Activity;
 		</div>
 
 		<p class="note">For catalogs with many datasets, catalog records, data services or distributions,
-		the Linked Data Platform Paging mechanism [[ldp-paging]] <em title="SHOULD" class="rfc2119">SHOULD</em> be used to provide access to them.</p>
+		the Linked Data Platform Paging mechanism [[LDP-Paging]] <em title="SHOULD" class="rfc2119">SHOULD</em> be used to provide access to them.</p>
 
 		<p>
 			In the next sections we formally define the additional properties used for discovery of LDP containers.
@@ -3057,7 +3057,7 @@ a:TestingActivity a prov:Activity;
 		<h3>Linked Data Notifications (LDN)</h3>
 
 		<p>
-			Linked Data Notifications (LDN) [[ldn]] can be used with DCAT e.g. for feedback collection.
+			Linked Data Notifications (LDN) [[LDN]] can be used with DCAT e.g. for feedback collection.
 			Any resource can have an LDN Inbox.
 			In the following example we show a dataset <code>&lt;/datasets/001&gt;</code> as an LDN Target with an LDN Inbox.
 		</p>
@@ -3133,7 +3133,7 @@ a:TestingActivity a prov:Activity;
 </li>
 
 <li>
-	<a href="#quality-information">Quality information</a>: Recommendations for how to associate quality information to datasets using elements from the W3C DQV vocabulary [[vocab-dqv]] are provided. Since [[vocab-dqv]] is not a rec-track document, these are non-normative - see <a href="https://github.com/w3c/dxwg/issues/57">Issue #57</a> and <a href="https://github.com/w3c/dxwg/issues/58">Issue #58</a>.
+	<a href="#quality-information">Quality information</a>: Recommendations for how to associate quality information to datasets using elements from the W3C DQV vocabulary [[VOCAB-DQV]] are provided. Since [[VOCAB-DQV]] is not a rec-track document, these are non-normative - see <a href="https://github.com/w3c/dxwg/issues/57">Issue #57</a> and <a href="https://github.com/w3c/dxwg/issues/58">Issue #58</a>.
 </li>
 
 <li>


### PR DESCRIPTION
As per [ACTION-228](https://www.w3.org/2017/dxwg/track/actions/228):
- Fixed broken URLs for PROF-* bib refs, and replaced the ones with URLs pointing to W3C TR space with their URL on GH pages
- Harmonised case of bib keys
- Removed duplicate entry for schema-org
- Added missing ref to schema-org
