### PR TITLE
Refactor DCAT examples

### DIFF
--- a/dcat/examples/dataset-004.ttl
+++ b/dcat/examples/dataset-004.ttl
@@ -1,0 +1,48 @@
+# baseURI: http://example.org/dataset-004
+# imports: http://www.w3.org/ns/dcat
+
+@prefix : <http://example.org/dataset-004#> .
+@prefix dcat: <http://www.w3.org/ns/dcat#> .
+@prefix dct: <http://purl.org/dc/terms/> .
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+<http://example.org/dataset-004>
+  rdf:type owl:Ontology ;
+  owl:imports <http://www.w3.org/ns/dcat> ;
+.
+:dataset-004
+  rdf:type dcat:Dataset ;
+  dcat:distribution :dataset-004-csv ;
+  dcat:distribution :dataset-004-png ;
+.
+:dataset-004-csv
+  rdf:type dcat:Distribution ;
+  dcat:accessService :table-service-005 ;
+  dcat:accessURL <http://example.org/api/table-005> ;
+  dcat:mediaType <https://www.iana.org/assignments/media-types/text/csv> ;
+.
+:dataset-004-png
+  rdf:type dcat:Distribution ;
+  dcat:accessService :figure-service-006 ;
+  dcat:accessURL <http://example.org/api/figure-006> ;
+  dcat:mediaType <https://www.iana.org/assignments/media-types/image/png> ;
+.
+:figure-service-006
+  rdf:type dcat:DataDistributionService ;
+  dct:conformsTo <http://example.org/apidef/figure/v1.0> ;
+  dct:type <https://inspire.ec.europa.eu/metadata-codelist/SpatialDataServiceType/view> ;
+  dcat:endpointDescription <http://example.org/api/figure-006/params> ;
+  dcat:endpointURL <http://example.org/api/figure-006> ;
+  dcat:servesDataset :dataset-004 ;
+.
+:table-service-005
+  rdf:type dcat:DataDistributionService ;
+  dct:conformsTo <http://example.org/apidef/table/v2.2> ;
+  dct:type <https://inspire.ec.europa.eu/metadata-codelist/SpatialDataServiceType/download> ;
+  dcat:endpointDescription <http://example.org/api/table-005/capability> ;
+  dcat:endpointURL <http://example.org/api/table-005> ;
+  dcat:servesDataset :dataset-004 ;
+.

--- a/dcat/index.html
+++ b/dcat/index.html
@@ -430,7 +430,50 @@
 
     <section id="a-dataset-available-from a service">
         <h3>A dataset available through a service</h3>
-        <p>TBC        </p>
+        <p>:dataset-004 is distributed in different representations from different services.
+          The <code>accessURL</code> for each <code>Distribution</code> corresponds with the <code>endpointURL</code> of the service.
+          Each service is characterized by its general type using <code>dct:type</code> (here using values from the INSPIRE spatial data service type vocabulary),
+          its specific API definition using <code>dct:conformsTo</code>,
+          with the detailed description of the individual endpoint parameters and options linked using <code>dcat:endpointDescription</code>.
+        </p>
+<div class="example">
+  <pre class="nohighlight turtle" aria-busy="false" aria-live="polite">
+:dataset-004
+  rdf:type dcat:Dataset ;
+  dcat:distribution :dataset-004-csv ;
+  dcat:distribution :dataset-004-png ;
+.
+:dataset-004-csv
+  rdf:type dcat:Distribution ;
+  dcat:accessService :table-service-005 ;
+  dcat:accessURL &lt;http://example.org/api/table-005&gt; ;
+  dcat:mediaType &lt;https://www.iana.org/assignments/media-types/text/csv&gt; ;
+.
+:dataset-004-png
+  rdf:type dcat:Distribution ;
+  dcat:accessService :figure-service-006 ;
+  dcat:accessURL &lt;http://example.org/api/figure-006&gt; ;
+  dcat:mediaType &lt;https://www.iana.org/assignments/media-types/image/png&gt; ;
+.
+:figure-service-006
+  rdf:type dcat:DataDistributionService ;
+  dct:conformsTo &lt;http://example.org/apidef/figure/v1.0&gt; ;
+  dct:type &lt;https://inspire.ec.europa.eu/metadata-codelist/SpatialDataServiceType/view&gt; ;
+  dcat:endpointDescription &lt;http://example.org/api/figure-006/params&gt; ;
+  dcat:endpointURL &lt;http://example.org/api/figure-006&gt; ;
+  dcat:servesDataset :dataset-004 ;
+.
+:table-service-005
+  rdf:type dcat:DataDistributionService ;
+  dct:conformsTo &lt;http://example.org/apidef/table/v2.2&gt; ;
+  dct:type &lt;https://inspire.ec.europa.eu/metadata-codelist/SpatialDataServiceType/download&gt; ;
+  dcat:endpointDescription &lt;http://example.org/api/table-005/capability&gt; ;
+  dcat:endpointURL &lt;http://example.org/api/table-005&gt; ;
+  dcat:servesDataset :dataset-003, :dataset-004 ;
+.  </pre>
+</div>
+
+
 
     </section>
 

--- a/dcat/index.html
+++ b/dcat/index.html
@@ -428,240 +428,9 @@
         does not have to be defined as a separate dcat:Distribution instance.
     </section>
 
-    <section id="bag-of-files">
-        <h3>Loosely structured catalog</h3>
-
-        <p class="note">
-            The background to this example is discussed in 	<a href="https://github.com/w3c/dxwg/issues/253">Best practice for a loosely-structured catalog</a>
-        </p>
-
-        <p>
-            In many legacy catalogues and repositories (e.g. CKAN), ‘datasets’ are ‘just a bag of files’. There is no distinction made between part/whole, distribution (representation), and other kinds of relationship (e.g. documentation, schema, supporting documents) from the dataset to each of the files.
-        </p>
-        <p>
-            If the nature of the relationships between a dataset and component resources in a catalogue, repository, or elsewhere are not known, <b>dct:relation</b> can be used:
-        </p>
-        <div class="example">
-  <pre class="nohighlight turtle" aria-busy="false" aria-live="polite">
-:d33937
-  dct:description "A set of RDF graphs representing the International [Chrono]stratigraphic Chart, ..." ;
-  dct:identifier "https://doi.org/10.25919/5b4d2b83cbf2d"^^xsd:anyURI ;
-  dct:creator &lt;https://orcid.org/0000-0002-3884-3420&gt;;
-  dct:relation &lt;https://vocabs.ands.org.au/viewById/196&gt; ;
-  dct:relation :ChronostratChart2017-02.pdf  ;
-  dct:relation :ChronostratChart2017-02.jpg ;
-  dct:relation :timescale.zip ;
-  dct:relation :isc2017.jsonld ;
-  dct:relation :isc2017.nt ;
-  dct:relation :isc2017.rdf ;
-  dct:relation :isc2017.ttl ;
-  .
-  </pre></div>
-        <p>
-            If it is clear that any of these related resources is a proper <i>representation</i> of the dataset, dcat:distribution should be used.
-        </p>
-        <div class="example">
-  <pre class="nohighlight turtle" aria-busy="false" aria-live="polite">
-:d33937
-  rdf:type dcat:Dataset ;
-  dct:description "A set of RDF graphs representing the International [Chrono]stratigraphic Chart, ..." ;
-  dct:identifier "https://doi.org/10.25919/5b4d2b83cbf2d"^^xsd:anyURI ;
-  dct:relation &lt;https://vocabs.ands.org.au/viewById/196&gt; ;
-  dct:relation :ChronostratChart2017-02.pdf  ;
-  dct:relation :ChronostratChart2017-02.jpg ;
-  dct:relation :timescale.zip ;
-  dcat:distribution :d33937-jsonld ;
-  dcat:distribution :d33937-nt ;
-  dcat:distribution :d33937-rdf ;
-  dcat:distribution :d33937-ttl ;
-  .
-:d33937-jsonld  rdf:type dcat:Distribution ;
-  dcat:downloadURL :isc2017.jsonld ;
-  dcat:byteSize "698039"^^xsd:decimal ;
-  dcat:mediaType &lt;https://www.iana.org/assignments/media-types/application/ld+json&gt; ;
-  .
-:d33937-nt  rdf:type dcat:Distribution ;
-  dcat:downloadURL :isc2017.nt ;
-  dcat:byteSize "2047874"^^xsd:decimal ;
-  dcat:mediaType &lt;https://www.iana.org/assignments/media-types/application/n-triples&gt; ;
-  .
-:d33937-rdf  rdf:type dcat:Distribution ;
-  dcat:downloadURL :isc2017.rdf ;
-  dcat:byteSize "1600569"^^xsd:decimal ;
-  dcat:mediaType &lt;https://www.iana.org/assignments/media-types/application/rdf+xml&gt; ;
-  .
-:d33937-ttl  rdf:type dcat:Distribution ;
-  dcat:downloadURL :isc2017.ttl ;
-  dcat:byteSize "531703"^^xsd:decimal ;
-  dcat:mediaType &lt;https://www.iana.org/assignments/media-types/text/turtle&gt; ;
-  .
-	</pre></div>
-        <p>
-            This example is available from the <a href="https://github.com/w3c/dxwg/tree/gh-pages/dcat/examples">DXWG code repository</a> at <a href="https://raw.githubusercontent.com/w3c/dxwg/gh-pages/dcat/examples/csiro-dap-examples.ttl">csiro-dap-examples.ttl</a>
-        </p>
-    </section>
-
-    <section id="examples-dataset-provenance">
-        <h3>Dataset provenance</h3>
-        <p>
-            The provenance or business context of a dataset can be described using elements from the W3C Provenance Ontology [[PROV-O]].
-        </p>
-        <p>
-            For example, a simple link from a dataset description to the project that generated the dataset can be formalized as follows (other details elided for clarity):
-        </p>
-        <div class="example">
-  <pre class="nohighlight turtle" aria-busy="false" aria-live="polite">
-dap:atnf-P366-2003SEPT
-  rdf:type dcat:Dataset ;
-  dct:bibliographicCitation "Burgay, M; McLaughlin, M; Kramer, M; Lyne, A; Joshi, B; Pearce, G; D'Amico, N; Possenti, A; Manchester, R; Camilo, F (2017): Parkes observations for project P366 semester 2003SEPT. v1. CSIRO. Data Collection. https://doi.org/10.4225/08/598dc08d07bb7" ;
-  dct:title "Parkes observations for project P366 semester 2003SEPT" ;
-  dcat:landingPage &lt;https://data.csiro.au/dap/landingpage?pid=csiro:P366-2003SEPT&gt; ;
-  prov:wasGeneratedBy dap:P366 ;
-.
-
-dap:P366
-  rdf:type prov:Activity ;
-  dct:type "Observation" ;
-  prov:startedAtTime "2000-11-01"^^xsd:date ;
-  prov:used dap:Parkes-radio-telescope ;
-  prov:wasInformedBy dap:ATNF ;
-  rdfs:label "P366 - Parkes multibeam high-latitude pulsar survey" ;
-  rdfs:seeAlso &lt;https://doi.org/10.1111/j.1365-2966.2006.10100.x&gt; ;
-.
-	</pre></div>
-        <p>
-            This example is available from the <a href="https://github.com/w3c/dxwg/tree/gh-pages/dcat/examples">DXWG code repository</a> at <a href="https://raw.githubusercontent.com/w3c/dxwg/gh-pages/dcat/examples/csiro-dap-examples.ttl">csiro-dap-examples.ttl</a>
-        </p>
-        <p>
-            Several properties capture provenance information, including within the citation and title, but the primary link to a formal description of the project is through <a href="#Property:dataset_wasgeneratedby">prov:wasGeneratedBy</a>.
-            A terse description of the project is shown as a <a href="http://www.w3.org/ns/prov#Activity">prov:Activity</a>, though this would not necessarily be part of the same catalog.
-            Note that as the project is ongoing, the activity has no end date.
-        </p>
-        <p>
-            Further provenance information might be provided using the other <i>starting point properties</i> from PROV, in particular <a href="http://www.w3.org/TR/prov-o/#wasAttributedTo">prov:wasAttributedTo</a> (to link to an agent associated with the dataset production) and <a href="http://www.w3.org/TR/prov-o/#wasDerivedFrom">prov:wasDerivedFrom</a> (to link to a predecessor dataset). Both of these complement Dublin Core properties already used in DCAT, as follows:
-        </p>
-        <ul>
-            <li>
-                <b>prov:wasAttributedTo</b> provides a general link to all kinds of associated agents, such as project sponsors, managers, dataset owners, etc which are not correctly characterized using <b>dct:creator</b>, <b>dct:contributor</b> or <b>dct:publisher</b>.
-            </li>
-            <li>
-                <b>prov:wasDerivedFrom</b> supports a more specific relationship to an input or predecessor dataset compared with <b>dct:source</b>, which is not necessarily a previous dataset.
-            </li>
-        </ul>
-        <p>
-            For a more detailed discussion of the use of PROV for dataset provenance, including recommendations on the use of <i>qualified properties</i>, see the chapter on <a href="#prov-patterns">Provenance Patterns</a> below.
-        </p>
-
-    </section>
-
-    <section id="data-service-examples">
-        <h3>Data services</h3>
-        <p>
-            Data services may be described using DCAT.
-            The values of the classifiers <b>dct:type</b>, <b>dct:conformsTo</b>, and <b>dcat:endpointDescription</b> provide progressively more detail about a service, whose actual endpoint is given by the <b>dcat:endpointURL</b>.
-        </p>
-        <p>
-            The first example describes a data catalog hosted by the European Environment Agency.
-            This is classified as a <a href="#Class:Discovery_Service">dcat:DiscoveryService</a> and also has the <code>dct:type</code> set to <a href="http://inspire.ec.europa.eu/metadata-codelist/SpatialDataServiceType/discovery">discovery</a> from the <a href="http://inspire.ec.europa.eu/metadata-codelist/SpatialDataServiceType/">INSPIRE classification of spatial data service types</a>.
-        </p>
-        <p>
-            This example is available from the <a href="https://github.com/w3c/dxwg/tree/gh-pages/dcat/examples">DXWG code repository</a> at <a href="https://raw.githubusercontent.com/w3c/dxwg/gh-pages/dcat/examples/eea-csw.ttl">eea-csw.ttl</a>
-        </p>
-        <div class="example">
-  <pre class="nohighlight turtle" aria-busy="false" aria-live="polite">
-a:EEA-CSW-Endpoint
-  rdf:type dcat:DiscoveryService ;
-  dc:subject "infoCatalogueService"@en ;
-  dct:accessRights &lt;http://publications.europa.eu/resource/authority/access-right/PUBLIC&gt; ;
-  dct:conformsTo &lt;http://www.opengis.net/def/serviceType/ogc/csw&gt; ;
-  dct:description "The EEA public catalogue of spatial datasets references the spatial datasets used by the European Environment Agency as well as the spatial datasets produced by or for the EEA. In the latter case, when datasets are publicly available, a link to the location from where they can be downloaded is included in the dataset's metadata. The catalogue has been initially populated with the most important spatial datasets already available on the data&maps section of the EEA website and is currently updated with any newly published spatial dataset."@en ;
-  dct:identifier "eea-sdi-public-catalogue" ;
-  dct:issued "2012-01-01"^^xsd:date ;
-  dct:license &lt;https://creativecommons.org/licenses/by/2.5/dk/&gt; ;
-  dct:spatial [
-      rdf:type dct:Location ;
-      locn:geometry "&lt;gml:Envelope srsName=\"http://www.opengis.net/def/crs/OGC/1.3/CRS84\"&gt;&lt;gml:lowerCorner&gt;-180 -90&lt;/gml:lowerCorner&gt;&lt;gml:upperCorner&gt;180 90&lt;/gml:upperCorner&gt;&lt;/gml:Envelope&gt;"^^gsp:gmlLiteral ;
-      locn:geometry "POLYGON((-180 90,180 90,180 -90,-180 -90,-180 90))"^^gsp:wktLiteral ;
-    ] ;
-  dct:title "European Environment Agency's public catalogue of spatial datasets."@en ;
-  dct:type &lt;http://inspire.ec.europa.eu/metadata-codelist/ResourceType/service&gt; ;
-  dct:type &lt;http://inspire.ec.europa.eu/metadata-codelist/SpatialDataServiceType/discovery&gt; ;
-  dcat:contactPoint a:EEA ;
-  dcat:endpointDescription &lt;https://sdi.eea.europa.eu/catalogue/srv/eng/csw?service=CSW&request=GetCapabilities&gt; ;
-  dcat:endpointURL &lt;http://sdi.eea.europa.eu/catalogue/srv/eng/csw&gt; ;
-.
-	</pre></div>
-        <p>
-            The next example shows a dataset hosted by Geoscience Australia, which is available from three distinct services, as indicated by the value of the <a href="#Property:datadistributionservice_servesdataset">dcat:servesDataset</a> property of each of the service descriptions.
-            These are classified as a <a href="#Class:Data_Distribution_Service">dcat:DataDistributionService</a> and also have the <code>dct:type</code> set to <a href="http://inspire.ec.europa.eu/metadata-codelist/SpatialDataServiceType/download">download</a> and <a href="http://inspire.ec.europa.eu/metadata-codelist/SpatialDataServiceType/view">view</a> from the <a href="http://inspire.ec.europa.eu/metadata-codelist/SpatialDataServiceType/">INSPIRE classification of spatial data service types</a>.
-        </p>
-        <p>
-            This example is available from the <a href="https://github.com/w3c/dxwg/tree/gh-pages/dcat/examples">DXWG code repository</a> at <a href="https://raw.githubusercontent.com/w3c/dxwg/gh-pages/dcat/examples/ga-courts.ttl">ga-courts.ttl</a>
-        </p>
-        <div class="example">
-  <pre class="nohighlight turtle" aria-busy="false" aria-live="polite">
-ga-courts:jc
-  rdf:type dcat:Dataset ;
-  dct:description "The dataset contains spatial locations, in point format, of the Australian High Court, Australian Federal Courts and the Australian Magistrates Courts." ;
-  dct:spatial [
-      rdf:type dct:Location ;
-      locn:geometry "&lt;gml:Envelope srsName=\"http://www.opengis.net/def/crs/EPSG/0/4283\"&gt;&lt;gml:lowerCorner&gt;115.864566 -42.885989&lt;/gml:lowerCorner&gt;&lt;gml:upperCorner&gt;153.276835 -12.460578&lt;/gml:upperCorner&gt;&lt;/gml:Envelope&gt;"^^gsp:gmlLiteral ;
-    ] ;
-  dct:title "Judicial Courts" ;
-  dct:type &lt;http://purl.org/dc/dcmitype/Dataset&gt; ;
-  dcat:landingPage &lt;https://ecat.ga.gov.au/geonetwork/srv/eng/catalog.search#/metadata/cc365600-294a-597d-e044-00144fdd4fa6&gt; ;
-.
-ga-courts:jc-esri
-  rdf:type dcat:DataDistributionService ;
-  dct:conformsTo &lt;https://developers.arcgis.com/rest/&gt; ;
-  dct:description "This web service provides access to the National Judicial Courts dataset and presents the spatial locations of all the known Australian High Courts, Australian Federal Courts and the Australian Federal Circuit Courts located within Australia, all complemented with feature attribution." ;
-  dct:identifier "2b8540c8-4a43-144d-e053-12a3070a3ff7" ;
-  dct:title "National Judicial Courts MapServer" ;
-  dct:type &lt;http://purl.org/dc/dcmitype/Service&gt; ;
-  dct:type &lt;https://inspire.ec.europa.eu/metadata-codelist/SpatialDataServiceType/download&gt; ;
-  dct:type &lt;https://inspire.ec.europa.eu/metadata-codelist/SpatialDataServiceType/view&gt; ;
-  dcat:endpointURL &lt;http://services.ga.gov.au/gis/rest/services/Judicial_Courts/MapServer&gt; ;
-  dcat:landingPage &lt;https://ecat.ga.gov.au/geonetwork/srv/eng/catalog.search#/metadata/2b8540c8-4a43-144d-e053-12a3070a3ff7&gt; ;
-  dcat:servesDataset ga-courts:jc ;
-.
-ga-courts:jc-wfs
-  rdf:type dcat:DataDistributionService ;
-  dct:conformsTo &lt;http://www.opengis.net/def/serviceType/ogc/wfs/2.0.0&gt; ;
-  dct:conformsTo &lt;http://www.opengis.net/def/serviceType/ogc/wfs/1.1.0&gt; ;
-  dct:conformsTo &lt;http://www.opengis.net/def/serviceType/ogc/wfs/1.0.0&gt; ;
-  dct:description "This web service provides access to the National Judicial Courts dataset and presents the spatial locations of all the known Australian High Courts, Australian Federal Courts and the Australian Federal Circuit Courts located within Australia, all complemented with feature attribution." ;
-  dct:identifier "2b8540c8-4a42-144d-e053-12a3070a3ff7" ;
-  dct:title "National Judicial Courts WFS" ;
-  dct:type &lt;http://purl.org/dc/dcmitype/Service&gt; ;
-  dct:type &lt;https://inspire.ec.europa.eu/metadata-codelist/SpatialDataServiceType/download&gt; ;
-  dcat:endpointDescription &lt;http://services.ga.gov.au/gis/services/Judicial_Courts/MapServer/WFSServer?request=GetCapabilities&service=WFS&gt; ;
-  dcat:endpointURL &lt;http://services.ga.gov.au/gis/services/Judicial_Courts/MapServer/WFSServer&gt; ;
-  dcat:landingPage &lt;https://ecat.ga.gov.au/geonetwork/srv/eng/catalog.search#/metadata/2b8540c8-4a42-144d-e053-12a3070a3ff7&gt; ;
-  dcat:servesDataset ga-courts:jc ;
-.
-ga-courts:jc-wms
-  rdf:type dcat:DataDistributionService ;
-  dct:conformsTo &lt;http://www.opengis.net/def/serviceType/ogc/wms/1.3&gt; ;
-  dct:description "This web service provides access to the National Judicial Courts dataset and presents the spatial locations of all the known Australian High Courts, Australian Federal Courts and the Australian Federal Circuit Courts located within Australia, all complemented with feature attribution." ;
-  dct:identifier "2b8540c8-4a41-144d-e053-12a3070a3ff7" ;
-  dct:title "National Judicial Courts WMS" ;
-  dct:type &lt;http://purl.org/dc/dcmitype/Service&gt; ;
-  dct:type &lt;https://inspire.ec.europa.eu/metadata-codelist/SpatialDataServiceType/view&gt; ;
-  dcat:endpointDescription &lt;http://services.ga.gov.au/gis/services/Judicial_Courts/MapServer/WMSServer?request=GetCapabilities&service=WMS&gt; ;
-  dcat:endpointURL &lt;http://services.ga.gov.au/gis/services/Judicial_Courts/MapServer/WMSServer&gt; ;
-  dcat:landingPage &lt;https://ecat.ga.gov.au/geonetwork/srv/eng/catalog.search#/metadata/2b8540c8-4a41-144d-e053-12a3070a3ff7&gt; ;
-  dcat:servesDataset ga-courts:jc ;
-.
-	</pre></div>
-
-    </section>
-
-    <section id="more-examples-needed">
-        <h3>More examples needed</h3>
-
-        <p class="note">
-            This section will contain more examples on the use of DCAT.
-        </p>
+    <section id="a-dataset-available-from a service">
+        <h3>A dataset available through a service</h3>
+        <p>TBC        </p>
 
     </section>
 
@@ -3133,6 +2902,249 @@ a:TestingActivity a prov:Activity;
     -->
     <p>The editors also gratefully acknowledge the chairs of this Working Group: Karen Coyle, Caroline Burle and Peter Winstanley &mdash; and staff contacts Phil Archer and Dave Raggett.</p>
 </section>
+
+<section class="appendix" id="collection-of-examples">
+  <h2>Examples</h2>
+  <section id="bag-of-files">
+      <h3>Loosely structured catalog</h3>
+
+      <p class="note">
+          The background to this example is discussed in 	<a href="https://github.com/w3c/dxwg/issues/253">Best practice for a loosely-structured catalog</a>
+      </p>
+
+      <p>
+          In many legacy catalogues and repositories (e.g. CKAN), ‘datasets’ are ‘just a bag of files’. There is no distinction made between part/whole, distribution (representation), and other kinds of relationship (e.g. documentation, schema, supporting documents) from the dataset to each of the files.
+      </p>
+      <p>
+          If the nature of the relationships between a dataset and component resources in a catalogue, repository, or elsewhere are not known, <b>dct:relation</b> can be used:
+      </p>
+      <div class="example">
+<pre class="nohighlight turtle" aria-busy="false" aria-live="polite">
+:d33937
+dct:description "A set of RDF graphs representing the International [Chrono]stratigraphic Chart, ..." ;
+dct:identifier "https://doi.org/10.25919/5b4d2b83cbf2d"^^xsd:anyURI ;
+dct:creator &lt;https://orcid.org/0000-0002-3884-3420&gt;;
+dct:relation &lt;https://vocabs.ands.org.au/viewById/196&gt; ;
+dct:relation :ChronostratChart2017-02.pdf  ;
+dct:relation :ChronostratChart2017-02.jpg ;
+dct:relation :timescale.zip ;
+dct:relation :isc2017.jsonld ;
+dct:relation :isc2017.nt ;
+dct:relation :isc2017.rdf ;
+dct:relation :isc2017.ttl ;
+.
+</pre></div>
+      <p>
+          If it is clear that any of these related resources is a proper <i>representation</i> of the dataset, dcat:distribution should be used.
+      </p>
+      <div class="example">
+<pre class="nohighlight turtle" aria-busy="false" aria-live="polite">
+:d33937
+rdf:type dcat:Dataset ;
+dct:description "A set of RDF graphs representing the International [Chrono]stratigraphic Chart, ..." ;
+dct:identifier "https://doi.org/10.25919/5b4d2b83cbf2d"^^xsd:anyURI ;
+dct:relation &lt;https://vocabs.ands.org.au/viewById/196&gt; ;
+dct:relation :ChronostratChart2017-02.pdf  ;
+dct:relation :ChronostratChart2017-02.jpg ;
+dct:relation :timescale.zip ;
+dcat:distribution :d33937-jsonld ;
+dcat:distribution :d33937-nt ;
+dcat:distribution :d33937-rdf ;
+dcat:distribution :d33937-ttl ;
+.
+:d33937-jsonld  rdf:type dcat:Distribution ;
+dcat:downloadURL :isc2017.jsonld ;
+dcat:byteSize "698039"^^xsd:decimal ;
+dcat:mediaType &lt;https://www.iana.org/assignments/media-types/application/ld+json&gt; ;
+.
+:d33937-nt  rdf:type dcat:Distribution ;
+dcat:downloadURL :isc2017.nt ;
+dcat:byteSize "2047874"^^xsd:decimal ;
+dcat:mediaType &lt;https://www.iana.org/assignments/media-types/application/n-triples&gt; ;
+.
+:d33937-rdf  rdf:type dcat:Distribution ;
+dcat:downloadURL :isc2017.rdf ;
+dcat:byteSize "1600569"^^xsd:decimal ;
+dcat:mediaType &lt;https://www.iana.org/assignments/media-types/application/rdf+xml&gt; ;
+.
+:d33937-ttl  rdf:type dcat:Distribution ;
+dcat:downloadURL :isc2017.ttl ;
+dcat:byteSize "531703"^^xsd:decimal ;
+dcat:mediaType &lt;https://www.iana.org/assignments/media-types/text/turtle&gt; ;
+.
+</pre></div>
+      <p>
+          This example is available from the <a href="https://github.com/w3c/dxwg/tree/gh-pages/dcat/examples">DXWG code repository</a> at <a href="https://raw.githubusercontent.com/w3c/dxwg/gh-pages/dcat/examples/csiro-dap-examples.ttl">csiro-dap-examples.ttl</a>
+      </p>
+  </section>
+
+  <section id="examples-dataset-provenance">
+      <h3>Dataset provenance</h3>
+      <p>
+          The provenance or business context of a dataset can be described using elements from the W3C Provenance Ontology [[PROV-O]].
+      </p>
+      <p>
+          For example, a simple link from a dataset description to the project that generated the dataset can be formalized as follows (other details elided for clarity):
+      </p>
+      <div class="example">
+<pre class="nohighlight turtle" aria-busy="false" aria-live="polite">
+dap:atnf-P366-2003SEPT
+rdf:type dcat:Dataset ;
+dct:bibliographicCitation "Burgay, M; McLaughlin, M; Kramer, M; Lyne, A; Joshi, B; Pearce, G; D'Amico, N; Possenti, A; Manchester, R; Camilo, F (2017): Parkes observations for project P366 semester 2003SEPT. v1. CSIRO. Data Collection. https://doi.org/10.4225/08/598dc08d07bb7" ;
+dct:title "Parkes observations for project P366 semester 2003SEPT" ;
+dcat:landingPage &lt;https://data.csiro.au/dap/landingpage?pid=csiro:P366-2003SEPT&gt; ;
+prov:wasGeneratedBy dap:P366 ;
+.
+
+dap:P366
+rdf:type prov:Activity ;
+dct:type "Observation" ;
+prov:startedAtTime "2000-11-01"^^xsd:date ;
+prov:used dap:Parkes-radio-telescope ;
+prov:wasInformedBy dap:ATNF ;
+rdfs:label "P366 - Parkes multibeam high-latitude pulsar survey" ;
+rdfs:seeAlso &lt;https://doi.org/10.1111/j.1365-2966.2006.10100.x&gt; ;
+.
+</pre></div>
+      <p>
+          This example is available from the <a href="https://github.com/w3c/dxwg/tree/gh-pages/dcat/examples">DXWG code repository</a> at <a href="https://raw.githubusercontent.com/w3c/dxwg/gh-pages/dcat/examples/csiro-dap-examples.ttl">csiro-dap-examples.ttl</a>
+      </p>
+      <p>
+          Several properties capture provenance information, including within the citation and title, but the primary link to a formal description of the project is through <a href="#Property:dataset_wasgeneratedby">prov:wasGeneratedBy</a>.
+          A terse description of the project is shown as a <a href="http://www.w3.org/ns/prov#Activity">prov:Activity</a>, though this would not necessarily be part of the same catalog.
+          Note that as the project is ongoing, the activity has no end date.
+      </p>
+      <p>
+          Further provenance information might be provided using the other <i>starting point properties</i> from PROV, in particular <a href="http://www.w3.org/TR/prov-o/#wasAttributedTo">prov:wasAttributedTo</a> (to link to an agent associated with the dataset production) and <a href="http://www.w3.org/TR/prov-o/#wasDerivedFrom">prov:wasDerivedFrom</a> (to link to a predecessor dataset). Both of these complement Dublin Core properties already used in DCAT, as follows:
+      </p>
+      <ul>
+          <li>
+              <b>prov:wasAttributedTo</b> provides a general link to all kinds of associated agents, such as project sponsors, managers, dataset owners, etc which are not correctly characterized using <b>dct:creator</b>, <b>dct:contributor</b> or <b>dct:publisher</b>.
+          </li>
+          <li>
+              <b>prov:wasDerivedFrom</b> supports a more specific relationship to an input or predecessor dataset compared with <b>dct:source</b>, which is not necessarily a previous dataset.
+          </li>
+      </ul>
+      <p>
+          For a more detailed discussion of the use of PROV for dataset provenance, including recommendations on the use of <i>qualified properties</i>, see the chapter on <a href="#prov-patterns">Provenance Patterns</a> below.
+      </p>
+
+  </section>
+
+  <section id="data-service-examples">
+      <h3>Data services</h3>
+      <p>
+          Data services may be described using DCAT.
+          The values of the classifiers <b>dct:type</b>, <b>dct:conformsTo</b>, and <b>dcat:endpointDescription</b> provide progressively more detail about a service, whose actual endpoint is given by the <b>dcat:endpointURL</b>.
+      </p>
+      <p>
+          The first example describes a data catalog hosted by the European Environment Agency.
+          This is classified as a <a href="#Class:Discovery_Service">dcat:DiscoveryService</a> and also has the <code>dct:type</code> set to <a href="http://inspire.ec.europa.eu/metadata-codelist/SpatialDataServiceType/discovery">discovery</a> from the <a href="http://inspire.ec.europa.eu/metadata-codelist/SpatialDataServiceType/">INSPIRE classification of spatial data service types</a>.
+      </p>
+      <p>
+          This example is available from the <a href="https://github.com/w3c/dxwg/tree/gh-pages/dcat/examples">DXWG code repository</a> at <a href="https://raw.githubusercontent.com/w3c/dxwg/gh-pages/dcat/examples/eea-csw.ttl">eea-csw.ttl</a>
+      </p>
+      <div class="example">
+<pre class="nohighlight turtle" aria-busy="false" aria-live="polite">
+a:EEA-CSW-Endpoint
+rdf:type dcat:DiscoveryService ;
+dc:subject "infoCatalogueService"@en ;
+dct:accessRights &lt;http://publications.europa.eu/resource/authority/access-right/PUBLIC&gt; ;
+dct:conformsTo &lt;http://www.opengis.net/def/serviceType/ogc/csw&gt; ;
+dct:description "The EEA public catalogue of spatial datasets references the spatial datasets used by the European Environment Agency as well as the spatial datasets produced by or for the EEA. In the latter case, when datasets are publicly available, a link to the location from where they can be downloaded is included in the dataset's metadata. The catalogue has been initially populated with the most important spatial datasets already available on the data&maps section of the EEA website and is currently updated with any newly published spatial dataset."@en ;
+dct:identifier "eea-sdi-public-catalogue" ;
+dct:issued "2012-01-01"^^xsd:date ;
+dct:license &lt;https://creativecommons.org/licenses/by/2.5/dk/&gt; ;
+dct:spatial [
+    rdf:type dct:Location ;
+    locn:geometry "&lt;gml:Envelope srsName=\"http://www.opengis.net/def/crs/OGC/1.3/CRS84\"&gt;&lt;gml:lowerCorner&gt;-180 -90&lt;/gml:lowerCorner&gt;&lt;gml:upperCorner&gt;180 90&lt;/gml:upperCorner&gt;&lt;/gml:Envelope&gt;"^^gsp:gmlLiteral ;
+    locn:geometry "POLYGON((-180 90,180 90,180 -90,-180 -90,-180 90))"^^gsp:wktLiteral ;
+  ] ;
+dct:title "European Environment Agency's public catalogue of spatial datasets."@en ;
+dct:type &lt;http://inspire.ec.europa.eu/metadata-codelist/ResourceType/service&gt; ;
+dct:type &lt;http://inspire.ec.europa.eu/metadata-codelist/SpatialDataServiceType/discovery&gt; ;
+dcat:contactPoint a:EEA ;
+dcat:endpointDescription &lt;https://sdi.eea.europa.eu/catalogue/srv/eng/csw?service=CSW&request=GetCapabilities&gt; ;
+dcat:endpointURL &lt;http://sdi.eea.europa.eu/catalogue/srv/eng/csw&gt; ;
+.
+</pre></div>
+      <p>
+          The next example shows a dataset hosted by Geoscience Australia, which is available from three distinct services, as indicated by the value of the <a href="#Property:datadistributionservice_servesdataset">dcat:servesDataset</a> property of each of the service descriptions.
+          These are classified as a <a href="#Class:Data_Distribution_Service">dcat:DataDistributionService</a> and also have the <code>dct:type</code> set to <a href="http://inspire.ec.europa.eu/metadata-codelist/SpatialDataServiceType/download">download</a> and <a href="http://inspire.ec.europa.eu/metadata-codelist/SpatialDataServiceType/view">view</a> from the <a href="http://inspire.ec.europa.eu/metadata-codelist/SpatialDataServiceType/">INSPIRE classification of spatial data service types</a>.
+      </p>
+      <p>
+          This example is available from the <a href="https://github.com/w3c/dxwg/tree/gh-pages/dcat/examples">DXWG code repository</a> at <a href="https://raw.githubusercontent.com/w3c/dxwg/gh-pages/dcat/examples/ga-courts.ttl">ga-courts.ttl</a>
+      </p>
+      <div class="example">
+<pre class="nohighlight turtle" aria-busy="false" aria-live="polite">
+ga-courts:jc
+rdf:type dcat:Dataset ;
+dct:description "The dataset contains spatial locations, in point format, of the Australian High Court, Australian Federal Courts and the Australian Magistrates Courts." ;
+dct:spatial [
+    rdf:type dct:Location ;
+    locn:geometry "&lt;gml:Envelope srsName=\"http://www.opengis.net/def/crs/EPSG/0/4283\"&gt;&lt;gml:lowerCorner&gt;115.864566 -42.885989&lt;/gml:lowerCorner&gt;&lt;gml:upperCorner&gt;153.276835 -12.460578&lt;/gml:upperCorner&gt;&lt;/gml:Envelope&gt;"^^gsp:gmlLiteral ;
+  ] ;
+dct:title "Judicial Courts" ;
+dct:type &lt;http://purl.org/dc/dcmitype/Dataset&gt; ;
+dcat:landingPage &lt;https://ecat.ga.gov.au/geonetwork/srv/eng/catalog.search#/metadata/cc365600-294a-597d-e044-00144fdd4fa6&gt; ;
+.
+ga-courts:jc-esri
+rdf:type dcat:DataDistributionService ;
+dct:conformsTo &lt;https://developers.arcgis.com/rest/&gt; ;
+dct:description "This web service provides access to the National Judicial Courts dataset and presents the spatial locations of all the known Australian High Courts, Australian Federal Courts and the Australian Federal Circuit Courts located within Australia, all complemented with feature attribution." ;
+dct:identifier "2b8540c8-4a43-144d-e053-12a3070a3ff7" ;
+dct:title "National Judicial Courts MapServer" ;
+dct:type &lt;http://purl.org/dc/dcmitype/Service&gt; ;
+dct:type &lt;https://inspire.ec.europa.eu/metadata-codelist/SpatialDataServiceType/download&gt; ;
+dct:type &lt;https://inspire.ec.europa.eu/metadata-codelist/SpatialDataServiceType/view&gt; ;
+dcat:endpointURL &lt;http://services.ga.gov.au/gis/rest/services/Judicial_Courts/MapServer&gt; ;
+dcat:landingPage &lt;https://ecat.ga.gov.au/geonetwork/srv/eng/catalog.search#/metadata/2b8540c8-4a43-144d-e053-12a3070a3ff7&gt; ;
+dcat:servesDataset ga-courts:jc ;
+.
+ga-courts:jc-wfs
+rdf:type dcat:DataDistributionService ;
+dct:conformsTo &lt;http://www.opengis.net/def/serviceType/ogc/wfs/2.0.0&gt; ;
+dct:conformsTo &lt;http://www.opengis.net/def/serviceType/ogc/wfs/1.1.0&gt; ;
+dct:conformsTo &lt;http://www.opengis.net/def/serviceType/ogc/wfs/1.0.0&gt; ;
+dct:description "This web service provides access to the National Judicial Courts dataset and presents the spatial locations of all the known Australian High Courts, Australian Federal Courts and the Australian Federal Circuit Courts located within Australia, all complemented with feature attribution." ;
+dct:identifier "2b8540c8-4a42-144d-e053-12a3070a3ff7" ;
+dct:title "National Judicial Courts WFS" ;
+dct:type &lt;http://purl.org/dc/dcmitype/Service&gt; ;
+dct:type &lt;https://inspire.ec.europa.eu/metadata-codelist/SpatialDataServiceType/download&gt; ;
+dcat:endpointDescription &lt;http://services.ga.gov.au/gis/services/Judicial_Courts/MapServer/WFSServer?request=GetCapabilities&service=WFS&gt; ;
+dcat:endpointURL &lt;http://services.ga.gov.au/gis/services/Judicial_Courts/MapServer/WFSServer&gt; ;
+dcat:landingPage &lt;https://ecat.ga.gov.au/geonetwork/srv/eng/catalog.search#/metadata/2b8540c8-4a42-144d-e053-12a3070a3ff7&gt; ;
+dcat:servesDataset ga-courts:jc ;
+.
+ga-courts:jc-wms
+rdf:type dcat:DataDistributionService ;
+dct:conformsTo &lt;http://www.opengis.net/def/serviceType/ogc/wms/1.3&gt; ;
+dct:description "This web service provides access to the National Judicial Courts dataset and presents the spatial locations of all the known Australian High Courts, Australian Federal Courts and the Australian Federal Circuit Courts located within Australia, all complemented with feature attribution." ;
+dct:identifier "2b8540c8-4a41-144d-e053-12a3070a3ff7" ;
+dct:title "National Judicial Courts WMS" ;
+dct:type &lt;http://purl.org/dc/dcmitype/Service&gt; ;
+dct:type &lt;https://inspire.ec.europa.eu/metadata-codelist/SpatialDataServiceType/view&gt; ;
+dcat:endpointDescription &lt;http://services.ga.gov.au/gis/services/Judicial_Courts/MapServer/WMSServer?request=GetCapabilities&service=WMS&gt; ;
+dcat:endpointURL &lt;http://services.ga.gov.au/gis/services/Judicial_Courts/MapServer/WMSServer&gt; ;
+dcat:landingPage &lt;https://ecat.ga.gov.au/geonetwork/srv/eng/catalog.search#/metadata/2b8540c8-4a41-144d-e053-12a3070a3ff7&gt; ;
+dcat:servesDataset ga-courts:jc ;
+.
+</pre></div>
+
+  </section>
+
+  <section id="more-examples-needed">
+      <h3>More examples needed</h3>
+
+      <p class="note">
+          This section will contain more examples on the use of DCAT.
+      </p>
+
+  </section>
+
+</section>
+
+
 
 <section class="appendix" id="changes">
     <h2>Change history</h2>


### PR DESCRIPTION
1. move extended examples to Annex
2. Add a basic data distribution service example in the overview

See https://rawgit.com/w3c/dxwg/dcat-issue470/dcat/#a-dataset-available-from%20a%20service 
https://rawgit.com/w3c/dxwg/dcat-issue470/dcat/#collection-of-examples 

Responding to #470 