### PR TITLE
Profile ontology editorial suggestion by riccardo

### DIFF
--- a/profilesont/index.html
+++ b/profilesont/index.html
@@ -316,7 +316,7 @@
       <h4>profileOf</h4>
       <table class="definition">
         <thead>
-        <tr><th>RDF Property:</th><th><a href="#Property:profileOf">profileOf</a></th></tr>
+        <tr><th>RDF Property:</th><th><a href="#Property:profileOf">prof:profileOf</a></th></tr>
         </thead>
         <tbody>
           <tr><td class="prop">OWL type:</td><td><a href="http://www.w3.org/2002/07/owl#ObjectProperty">owl:ObjectProperty</a></td></tr>

--- a/profilesont/index.html
+++ b/profilesont/index.html
@@ -302,7 +302,7 @@
       <h4>resource</h4>
       <table class="definition">
         <thead>
-        <tr><th>RDF Property:</th><th><a href="#Property:hasResource">prof:hasResource</a></th></tr>
+        <tr><th>RDF Property:</th><th><a href="#Property:hasResource">prof:resource</a></th></tr>
         </thead>
         <tbody>
           <tr><td class="prop">OWL type:</td><td><a href="http://www.w3.org/2002/07/owl#ObjectProperty">owl:ObjectProperty</a></td></tr>

--- a/profilesont/index.html
+++ b/profilesont/index.html
@@ -54,7 +54,7 @@
 <section id="introduction" class="informative">
   <h2>Introduction</h2>
   <p>
-    The profiles ontology is designed to provide a structure to describe profiles of information standards. Its
+    The profiles ontology provides a structure to describe profiles of information standards. Its
     development was triggered by the appearance of multiple profiles of the Dataset Catalog Vocabulary (DCAT)
     [[vocab-dcat-20140116]], and also influenced by work on profiles of the Dublin Core metadata vocabulary [[DCAP]].
   </p>

--- a/profilesont/index.html
+++ b/profilesont/index.html
@@ -262,7 +262,7 @@
     <h4>Class: Profile</h4>
     <table class="definition">
       <thead>
-      <tr><th>RDF Class:</th><th><a href="http://www.w3.org/ns/prof/ResourceRole">prof:ResourceRole</a></th></tr>
+      <tr><th>RDF Class:</th><th><a href="http://www.w3.org/ns/prof/Profile">prof:Profile</a></th></tr>
       </thead>
       <tbody>
       <tr><td class="prop">Label:</td><td>Profile</td></tr>


### PR DESCRIPTION
 Please consider to merge it or to address yourself the issues listed below:

-Section 1: rephasing “The profiles ontology is designed to provide a structure to describe profiles of information standards.”  into “The profiles ontology provides a structure to describe profiles of information standards”
- section 6.4: The class Profile was inconsistently having  RDF Class  prof:ResourceRole  
- section 6.4.3: RDF class should be “prof:profileOf” not “profileOf”
-section 6.4.2: The RDFProperty should be <<resource>> not << hasResource>> to be consistent with the Turtle and the figure. 

