### PR TITLE
Editorial changes

### DIFF
--- a/profilesont/index.html
+++ b/profilesont/index.html
@@ -40,7 +40,7 @@
   <p>
     The profiles ontology provides a structure to describe profiles of information standards. Its
     development was triggered by the appearance of multiple profiles of the Dataset Catalog Vocabulary (DCAT)
-    [[vocab-dcat-20140116]], and also influenced by work on profiles of the Dublin Core metadata vocabulary [[DCAP]].
+    [[VOCAB-DCAT-20140116]], and also influenced by work on profiles of the Dublin Core Application Profiles guidelines [[DCAP]].
   </p>
   <p>
     Profiles of DCAT &amp; DCAP aim to increase interoperability within a specified community of users by introducing
@@ -53,7 +53,7 @@
     and can also be used generally for any profiles of any standards.
   </p>
   <p>
-    This model starts with <code><a href="http://www.dublincore.org/documents/dcmi-terms/#terms-Standard">dcterms:Standard</a></code> entities
+    This model starts with <code><a href="http://www.dublincore.org/documents/dcmi-terms/#terms-Standard">dct:Standard</a></code> entities
     which can either be <code>Base Specifications</code> (a Standard not profiling any other Standard) or <code>Profiles</code> (Standards which
     do profile others). <code>Base Specifications</code> or <code>Profiles</code> can have <code>Resource Descriptors</code> associated with
     them that define rules for implementing it. <code>Resource Descriptors</code> must indicate the role they
@@ -119,8 +119,8 @@
   <p>
     There are a multitude of ways to describe the components <em>within</em> or defining a profile,
     such as documents (PDF documents [[PDF]]; any human-readable resources) to offer guidance, constraint languages
-    from the abstract (Dublin Core's Description Set Profiles [[DCDSP]]) to the concrete (SHACL [[shacl]] &amp; ShEx
-    [[shex]])) to offer mechanisms for validation of profile instances.
+    from the abstract (Dublin Core's Description Set Profiles [[DCDSP]]) to the concrete (SHACL [[SHACL]] &amp; ShEx
+    [[SHEX]])) to offer mechanisms for validation of profile instances.
   <p>
     Describing only the components within a profile via documents or constraint languages does not indicate many things
     either important or interesting to know about a profile such as:
@@ -190,7 +190,7 @@
     <a href="profilesont.png">
       <img src="profilesont.png" alt="Ontology overview diagram" />
     </a>
-    <figcaption>OWL [[owl2-overview]] overview diagram of this ontology</figcaption>
+    <figcaption>OWL [[OWL2-OVERVIEW]] overview diagram of this ontology</figcaption>
   </figure>
   <div class="issue" data-number="404"></div>
   <p>
@@ -340,13 +340,13 @@
       <p>
         The property <a href="#Property:isTransitiveProfileOf">prof:isTransitiveProfileOf</a> defined here performs a role
         similar to that of the property <a href="https://www.w3.org/TR/skos-reference/#semantic-relations">skos:broaderTransitive</a>
-        defined in [[skos-reference]]. That property "...allows communities of practice to exploit transitive
+        defined in [[SKOS-REFERENCE]]. That property "...allows communities of practice to exploit transitive
         interpretations of hierarchical networks..." while freeing the simpler hierarchy property of
         <a href="https://www.w3.org/TR/skos-reference/#semantic-relations">skos:broader</a> from having to enforce
         transitivity which would prevent broader but non-transitive relationships.
       </p>
       <p>
-        Figure 4.5.2 from [[skos-primer]], reproduced below, illustrates the general principle of use of
+        Figure 4.5.2 from [[SKOS-PRIMER]], reproduced below, illustrates the general principle of use of
         <code>skos:broaderTransitive</code>.
       </p>
       <figure id="fig-skos-4.5.2">
@@ -354,7 +354,7 @@
         <figcaption>
           Inferring a transitive hierarchy from asserted skos:broader statements. Dotted arrows represent statements
           inferred from the SKOS data model. Solid arrows represent asserted statements. Reproduction of Figure 4.5.2
-          in [[skos-primer]]
+          in [[SKOS-PRIMER]]
         </figcaption>
       </figure>
       <p>
@@ -707,11 +707,11 @@
     <p>The RDF file giving the formal alignment is avauilable here: <a href="https://w3c.github.io/dxwg/profilesont/alignment_dcat.ttl">profilesont_dcat_alignment.ttl</a>.</p>
     <figure id="fig-dcat-classes">
       <img src="alignment_dcat_classes.png" alt="Alignment of PROF classes with DCAT 1.1 classes" style="width:90%;" />
-      <figcaption>Alignment of PROF classes with DCAT 1.1 [[vocab-dcat-2-20180508]] classes. PROF classes are indicated with their rdfs:label text and no namespace prefix.</figcaption>
+      <figcaption>Alignment of PROF classes with DCAT 1.1 [[VOCAB-DCAT-2-20180508]] classes. PROF classes are indicated with their rdfs:label text and no namespace prefix.</figcaption>
     </figure>
     <figure id="fig-dcat-properties">
       <img src="alignment_dcat_properties.png" alt="Alignment of PROF properties with DCAT 1.1 properties" style="width:90%;" />
-      <figcaption>Alignment of PROF classes with DCAT 1.1 [[vocab-dcat-2-20180508]] properties. PROF properties are indicated with their rdfs:label text and no namespace prefix.</figcaption>
+      <figcaption>Alignment of PROF classes with DCAT 1.1 [[VOCAB-DCAT-2-20180508]] properties. PROF properties are indicated with their rdfs:label text and no namespace prefix.</figcaption>
     </figure>
     <p>The following table summarieses the mappings shown graphically in Fig. 2 & 3.</p>
     <table id="alignment-dcat-table">
@@ -720,8 +720,8 @@
       </thead>
       <tbody>
       <tr><td>prof:hasResource</td><td style="text-align: center;"><code>rdfs:subPropertyOf</code></td><td>dcat:distribution</td><td></td>
-      <tr><td>dcterms:conformsTo</td><td style="text-align: center;">-</td><td>-</td><td>Used similarly</td>
-      <tr><td>dcterms:format</td><td style="text-align: center;">-</td><td>-</td><td>Used similarly</td>
+      <tr><td>dct:conformsTo</td><td style="text-align: center;">-</td><td>-</td><td>Used similarly</td>
+      <tr><td>dct:format</td><td style="text-align: center;">-</td><td>-</td><td>Used similarly</td>
       <tr><td>prof:hasResourceRole</td><td style="text-align: center;"><code>rdfs:subClassOf</code></td><td>dcat:Distribution</td><td></td></tr>
       <tr><td>prof:Profile</td><td style="text-align: center;"><code>rdfs:subClassOf</code></td><td>dcat:Resource</td><td>Generic association</td></tr>
       </tbody>
@@ -730,6 +730,12 @@
   <section id="alignment-adms">
     <h3>Alignment with ADMS</h3>
     <p></p>
+    <div class="issue" data-number="240"></div>
+  </section>
+  <section id="alignment-voaf">
+    <h3>Alignment with VOAF</h3>
+    <p></p>
+    <div class="issue" data-number="235"></div>
   </section>
   <section id="alignment-modspec">
     <h3>Alignment with OGC/ISO Modular specification model</h3>


### PR DESCRIPTION
- Introduction: Replaced "Dublin Core metadata vocabulary [[DCAP]]" with "Dublin Core Application Profiles guidelines (DCAP) [[DCAP]]"
- Replaced namespace prefix dcterms: with dct:
- Added pointer to issue https://github.com/w3c/dxwg/issues/240 in Section 9.2 (Alignment with ADMS)
- Added new section (9.3) for alignment with VOAF, and pointer to relevant issue (https://github.com/w3c/dxwg/issues/235)
- Fixed inconsistent case in citation keys