### PR TITLE
Editorial changes

### DIFF
--- a/conneg-by-ap/config.js
+++ b/conneg-by-ap/config.js
@@ -1,5 +1,5 @@
 var respecConfig = {
-    specStatus: "FPWD",
+    specStatus: "ED",
     shortName: "conneg-by-ap",
     edDraftURI: "https://w3c.github.io/dxwg/conneg-by-ap/",
     previousURI: "https://w3c.github.io/dxwg/conneg-by-ap/",
@@ -81,18 +81,6 @@ var respecConfig = {
             title: "Negotiating Profiles in HTTP",
             date: "2017-10-24",
             status: "IETF Internet Draft"
-        },
-        "vocab-dcat-2": {
-            editors: [
-                "Alejandra Gonzalez Beltran",
-                "Dave Browning",
-                "Simon Cox",
-                "Peter Winstanley"
-            ],
-            href: "https://www.w3.org/TR/vocab-dcat-2/",
-            title: "Data Catalog Vocabulary (DCAT) - revised edition",
-            date: "2018-10-16",
-            status: "W3C Working Draft"
         }
     }
 };


### PR DESCRIPTION
- Change specStatus to ED: All documents on GH are of type "W3C Editor's Draft" (see, e.g., https://w3c.github.io/dxwg/dcat/). The change of type into FPWD will be done when the document is moved to TR space. 
- Remove bib entry about VOCAB-DCAT-2, as it is already available in SpecRef (https://api.specref.org/bibrefs?refs=vocab-dcat-2)