### PR TITLE
Remove duplicate text in conformance section

### DIFF
--- a/conneg-by-ap/index.html
+++ b/conneg-by-ap/index.html
@@ -76,11 +76,10 @@
   <section id="conformance">
     <p>
       For the purpose of compliance, the normative sections of this document are
-      <a href="#notationalconventions">Section 1.2</a>,
-      <a href="#definitions">Section 2</a>,
-      <a href="#abstractmodel">Section 5</a>,
-      <a href="#realisations">Section 6</a> &amp;
-      <a href="#testsuite">Section 7</a>.
+      <a href="#definitions">Section 3</a>,
+      <a href="#abstractmodel">Section 6</a>,
+      <a href="#realisations">Section 7</a> and
+      <a href="#testsuite">Section 8</a>.
     </p>
   </section>
   <section id="definitions">

--- a/conneg-by-ap/index.html
+++ b/conneg-by-ap/index.html
@@ -72,29 +72,8 @@
       as when manually entering requests into web browsers. This document also provides guidance for both HTTP and non-HTTP methods
       of content negotiation and ensures they all adhere to a single functional specification, ensuring their functional equivalency.
     </p>
-    <section id="compliance">
-      <h3>Compliance with this Document</h3>
-      <p>
-        For the purpose of compliance, the normative sections of this document are
-        <a href="#definitions">Section 2</a>,
-        <a href="#abstractmodel">Section 5</a>,
-        <a href="#realizations">Section 6</a>, and
-        <a href="#testsuites">Section 7</a>.
-      </p>
-    </section>
-    <section id="notationalconventions">
-      <h3>Notational Conventions</h3>
-      <p>
-	The key words <em class="rfc2119">MAY</em>, <em class="rfc2119">MUST</em>, <em class="rfc2119">MUST NOT</em>,
-	<em class="rfc2119">OPTIONAL</em>, <em class="rfc2119">SHALL</em>, <em class="rfc2119">SHALL NOT</em>,
-	<em class="rfc2119">SHOULD</em>, <em class="rfc2119">SHOULD NOT</em>, <em class="rfc2119">RECOMMENDED</em>,
-	and <em class="rfc2119">REQUIRED</em>,
-        in this document are to be interpreted as described in [[RFC2119]].
-      </p>
-    </section>
   </section>
   <section id="conformance">
-    <!-- boilerplate will be added here -->
     <p>
       For the purpose of compliance, the normative sections of this document are
       <a href="#notationalconventions">Section 1.2</a>,
@@ -103,14 +82,6 @@
       <a href="#realisations">Section 6</a> &amp;
       <a href="#testsuite">Section 7</a>.
     </p>
-    <section id="notationalconventions">
-      <h3>Notational Conventions</h3>
-      <p>
-        The key words <dfn>may</dfn>, <dfn>must</dfn>, <dfn>must not</dfn>, <dfn>optional</dfn>, <dfn>shall</dfn>,
-        <dfn>shall not</dfn>, <dfn>should</dfn>, <dfn>should not</dfn>, <dfn>recommended</dfn>, <dfn>required</dfn>,
-        in this document are to be interpreted as described in [[RFC2119]].
-      </p>
-    </section>
   </section>
   <section id="definitions">
     <h2>Definitions</h2>


### PR DESCRIPTION
Removed section 'id=compliance` (there is no such section)
Removed sub-section `id=notationalconventions` from `conformance`
Visible in https://raw.githack.com/w3c/dxwg/larsgsvensson-conformance/conneg-by-ap/index.html
Fixes #560 