### PR TITLE
Updated headings for §7.1 and §7.2

### DIFF
--- a/conneg-by-ap/index.html
+++ b/conneg-by-ap/index.html
@@ -78,8 +78,8 @@
       For the purpose of compliance, the normative sections of this document are
       <a href="#definitions">Section 3</a>,
       <a href="#abstractmodel">Section 6</a>,
-      <a href="#realisations">Section 7</a> and
-      <a href="#testsuite">Section 8</a>.
+      <a href="#realizations">Section 7</a> and
+      <a href="#testsuites">Section 8</a>.
     </p>
   </section>
   <section id="definitions">
@@ -340,9 +340,9 @@
       This section describes <em>realization</em>s of the abstract model in multiple implementation domains.
     </p>
     <section id="http">
-      <h3>Hypertext Transfer Protocol</h3>
+      <h3>Hypertext Transfer Protocol Headers</h3>
       <p>
-        A realization of the Abstract Model using the Hypertext Transfer Protocol (HTTP) is presented here.
+        A realization of the Abstract Model using Hypertext Transfer Protocol (HTTP) headers is presented here.
         This implementation is based on HTTP content negotiation and uses two new HTTP headers,
 	      <code>Accept-Profile</code> and <code>Content-Profile</code>
 	      that are to be defined in an upcoming Internet-Draft [[PROF-IETF]].
@@ -468,7 +468,7 @@ Content-Profile: urn:example:profile:1
       </section>
     </section>
     <section id="qsa">
-      <h2>Query String Arguments</h2>
+      <h2>URI Query String Arguments</h2>
 	    <div class="issue" data-number="511"></div>
       <div class="issue" data-number="538"></div>
       <p>


### PR DESCRIPTION
Updated headings for §7.1 and §7.2 to reflect that one is http headers and the other is URI query string arguments (so that it doesn't seem that QSA is independent of http)
This fixes #553 
Visible in https://raw.githack.com/w3c/dxwg/larsgsvensson-naming-realization-headers/conneg-by-ap/index.html