### PR TITLE
Editorial changes through 6.1.2

### DIFF
--- a/conneg-by-ap/index.html
+++ b/conneg-by-ap/index.html
@@ -46,10 +46,10 @@
   <section id="introduction" class="informative">
     <h1>Introduction</h1>
     <p>
-      Content delivered by dereferencing Internet identifiers has long been able to be negotiated for in different
+      Content delivered by dereferencing Internet identifiers can be negotiated for in different
       ways. When using the HTTP protocol [[RFC7230]], a client may set an <code>Accept</code> header specifying
-      preferred Media Types which the server may or may not supply. Thus, resources available in different languages
-      may be requested by setting an HTTP <code>Accept-Language</code> header. Until now, clients have not had a
+      preferred Media Types which the server may or may not supply. For example, resources available in different languages
+      may be requested by setting an HTTP <code>Accept-Language</code> header. However, clients have not had a
       defined way to negotiate for content based on its adherence to an information model - a standard, a specification or
       a <a>profile</a> - and this document addresses this functionality.
     </p>
@@ -161,14 +161,14 @@
   <section id="relatedwork" class="informative">
     <h2>Related Work</h2>
     <p>
-      What a <a>profile</a> is and how to create one is detailed in the [[PROF-GUIDE]] document created
-      alongside this document, also by the Dataset Exchange Working Group (DXWG).
+      Guidance for the creation of <a>profile</a>s is provided in the [[PROF-GUIDE]] document created
+      by the Dataset Exchange Working Group (DXWG).
     </p>
     <p>
-      The necessary standardization of the content-negotiation HTTP headers is done within the IETF. A first proposal
+      The standardization of the content-negotiation HTTP headers is the purview of the IETF. A first proposal
       for an <a href="https://profilenegotiation.github.io/I-D-Accept--Schema/I-D-accept-schema">Internet Draft
       for Negotiating Profiles in HTTP</a> [[PROF-IETF]] is available but has not yet been submitted to the IETF. The
-      current version of the draft (-00) is expected to be completely re-written in course of the process and should
+      current version of the IETF draft (-00) is expected to be completely re-written in parallel work with this document and should
       not be seen as anything but work-in-progress.
     </p>
     <p class="issue" data-number="380">
@@ -184,7 +184,7 @@
 	    will be listed and discussed here.
     </p>
     <p>
-      Describing the parts of profiles and their relation to other profiles is done within the Profiles Ontology
+      Describing the parts of profiles and their relation to other profiles is the function of the Profiles Ontology
       [[PROF-ONT]], also produced by the DXWG.
     </p>
     <div class="issue" data-number="383"></div>
@@ -196,20 +196,20 @@
     <h2>Abstract Model</h2>
     <p>
       This section describes an abstract conceptual model for content negotiation by profile, independent of any
-      specific implementation - here termed realizations.
+      specific implementation. To maintain the abstract nature of this description we refer here to <em>realizations</em> of the model, not implementations.
     </p>
     <section id="abstractmodelcontext">
       <h3>Context</h3>
       <p>
         All content negotiation takes place between a <a>client</a> and a <a>server</a> over the Internet with the
-        former requesting a representation of a <a>resource</a> or <em>resource</em>'s <em>metadata</em> through a
+        former requesting a representation of a <a>resource</a> or a <em>resource</em>'s <em>metadata</em> through a
         <em>request</em> and receiving it via a <em>response</em>. In some cases, a <em>server</em> may have to make a 
         <em>request</em> of a <em>client</em> and receive a <em>response</em>.
       </p>
       <p>
         An Internet <em>resource</em> may have many aspects over which a <em>client</em>/<em>server</em> pair of
         agents might negotiate for content. These aspects are to be treated independently so content negotiation for a 
-        resource involving negotiation by profile and potentially multiple other aspects of a resource will not affect
+        resource involving negotiation by profile and any other aspects of a resource will not affect
         each other. For this reason, other than a directive to maintain independence, no further discussion of 
         negotiation by profile and the relations to other forms of negotiation are given. Specific realizations might
         require special handling of profile and other forms of negotiation.
@@ -230,13 +230,13 @@
       <h3>Requests and Responses</h3>
       <p>
         There are two main types of <em>request</em> that a <em>client</em> might make of a <em>server</em> regarding
-        content negotiation by profile. A <em>client</em> wishing to negotiate for content via profile adhering to this
+        content negotiation by profile. A <em>client</em> wishing to negotiate for content via a profile adhering to this
         specification MUST be able to implement these two request types.</p>
       <ol>
         <li>
           <strong>list profiles</strong><br />
-          a <em>client</em> requests the list of URIs for <em>profile</em>s a <em>server</em> is able to deliver
-          <em>resource</em> representations conforming to
+          a <em>client</em> requests the list of URIs of <em>profile</em>s for which a <em>server</em> is able to deliver
+          conformant <em>resource</em>s
         </li>
         <li>
           <strong>get resource by profile</strong>
@@ -251,8 +251,8 @@
       <ol start="3">
         <li>
           <strong>list profiles tokens</strong><br />
-          a <em>client</em> requests the list of <em>token</em>s the <em>server</em> uses for <em>profile</em>s a
-          <em>server</em> is able to deliver <em>resource</em> representations conforming to and their mapping to
+          a <em>client</em> requests the list of <em>token</em>s that the <em>server</em> uses for <em>profile</em>s and for which the
+          <em>server</em> is able to deliver <em>resource</em> representations that conform to the profile. The server also provides a mapping from tokens to
           <em>profile</em> URIs
         </li>
       </ol>
@@ -263,27 +263,27 @@
       <ol>
         <li>
           <strong>list profiles</strong><br />
-          a <em>server</em> responds to a <em>client</em> with the list of <em>profile</em> URIs for the <em>profile</em>s it is able to
-          deliver <em>resource</em> representations conforming to
+          a <em>server</em> responds to a <em>client</em> with the list of <em>profile</em> URIs for the <em>profile</em>s for which it is able to
+		deliver conformant <em>resource</em> representations 
         </li>
         <li>
           <strong>get resource by profile</strong><br />
           a <em>server</em> responds with either a specific <em>profile</em> for a <em>resource</em> conforming to a
-          requested <em>profile</em> identified by the <em>client</em> or a default <em>profile</em>
+          requested <em>profile</em> identified by the <em>client</em> or it responds with a default <em>profile</em>
         </li>
         <li>
           <strong>list profiles tokens</strong><br />
-          a <em>server</em> responds the list of <em>profile </em> <em>token</em>s it is able to deliver
-          <em>resource</em> representations conforming to and their mapping to <em>profile</em> URIs.
+          a <em>server</em> responds with the list of <em>profile </em> <em>token</em>s for which it is able to deliver
+		conformant <em>resource</em> representations and the mapping of the tokens to <em>profile</em> URIs.
         </li>
       </ol>
       <p>More detailed descriptions of these requests and their responses are given next.</p>
       <section id="listprofiles">
         <h4>list profiles</h4>
         <p>
-          A <em>client</em> wishes to know what <em>profile</em>s a <em>server</em> is able to deliver conformant
-          representations of a <em>resource</em> for. This may need to be known either before a <em>request</em> for a 
-          particular <em>resource</em> representation is made or perhaps after an initial <em>request</em> for a
+          A <em>client</em> wishes to know for which <em>profile</em>s a <em>server</em> is able to deliver conformant
+          representations of a <em>resource</em>. The content of the list can be known either before a <em>request</em> for a 
+          particular <em>resource</em> representation is made or it is known after an initial <em>request</em> for a
           <em>resource</em> representation is made.
         </p>
         <p>
@@ -292,11 +292,11 @@
         </p>
         <p>
           The <strong>list profiles</strong> <em>request</em> MAY result in a <em>response</em> in one of a
-          number of structures or formats provided the <em>profile</em>s representations of a <em>resource</em>
-          conforming to are unambiguously identified either by URI or a <em>token</em> mappable to a URI.
+          number of structures or formats provided that the <em>profile</em>s representations
+          conforming to the request are unambiguously identified either by URI or a <em>token</em> mappable to a URI.
         </p>
         <p>
-          A <em>server</em> MUST NOT list <em>profile</em>s which <em>resource</em> representations conform to if
+          A <em>server</em> MUST NOT list <em>profile</em>s that <em>resource</em> representations conform to if
           it is unable to deliver those representations when presented with a <strong>get resource by profile</strong>
           <em>request</em>.
         </p>
@@ -399,7 +399,7 @@ Content-Profile: urn:example:profile:1;q=0.8,http://example.org/profiles/2;q=0.5
           both available in the profiles <code>urn:example:profile:1</code> and <code>urn:example:profile:2</code>.
         </p>
         <p>
-          All representations of <code>/a/resource</code> have own content-location URLs which leaves us with the following matrix:
+          All representations of <code>/a/resource</code> have content-location URLs. This results in the following matrix:
         </p>
         <table>
           <tr><th>Media type / profile</th><th>urn:example:profile:1</th><th>urn:example:profile:2</th></tr>
@@ -411,7 +411,7 @@ Content-Profile: urn:example:profile:1;q=0.8,http://example.org/profiles/2;q=0.5
           Assuming that a request without an <code>Accept-Profile</code> header per default delivers content conforming to
           <code>urn:example:profile:1</code> a request/response pair would look as follows:
         </p>
-        <pre class="example nohighlight" aria-busy="false" aria-live="polite" title="Using a Link-header to point list available profiles">
+        <pre class="example nohighlight" aria-busy="false" aria-live="polite" title="Using a Link-header to point to a list of available profiles">
 HEAD /a/resource HTTP/1.1
 Accept: text/turtle
 [more request headers]
@@ -455,7 +455,7 @@ Content-Profile: urn:example:profile:1
 [more response headers]
         </pre>
         <p>
-          Having performed content negotiation and returning a resource representation, it is RECOMMENDED
+          Having performed content negotiation and returned a resource representation, it is RECOMMENDED
           that the server also include a Link header indicating the availability of alternate resources
           encoded in other media types and conforming to other profiles, as described above.
         </p>
@@ -491,7 +491,7 @@ Content-Profile: urn:example:profile:1
 	      However there is some flexibility in how this may be done:
 	      QSA key/value pairs must be implemented but the specific key terms may be changed.
 	      In this realization, <code>_profile</code> and <code>_mediatype</code> are used
-	      to indicate a single or a list of
+	      to indicate a single profile or a list of
         preference-ordered profiles or Media types respectively with profiles or Media Types indicated by either URI or
         token.
       </p>


### PR DESCRIPTION
- "Thus" change to "For example"
- Wording changed to remove dangling "conforming to" in sentences (check this carefully to make sure the sense is the same)
- some "which" to "that" (which makes it clearer)
- added some words that seemed to be missing