### PR TITLE
Revised Section 9 (License and rights statements)

### DIFF
--- a/dcat/config.js
+++ b/dcat/config.js
@@ -172,6 +172,20 @@ var respecConfig = {
             date:"15 March 2018",
             publisher:"Hydra W3C Community Group",
             status:"Unofficial Draft"
-      }
+      },
+      "ODRS": {
+            authors: [
+                "Leigh Dodds"
+            ],
+            href:"http://schema.theodi.org/odrs",
+            title:"Open Data Rights Statement Vocabulary",
+            date:"29 July 2013",
+            publisher:"ODI"
+      },
+      "MDR-AR":{
+        "href":"http://publications.europa.eu/mdr/authority/access-right/",
+        "title":"Named Authority List: Access rights",
+        "publisher":"Publications Office of the European Union"
+       }
     }
   };

--- a/dcat/index.html
+++ b/dcat/index.html
@@ -2359,8 +2359,7 @@ a:TestingActivity a prov:Activity;
 	<p class="note">
 		DCAT 2014 handling of license and rights do not appear to satisfy all requirements [[VOCAB-DCAT-20140116]].
 		The recently completed W3C ODRL vocabulary [[ODRL-VOCAB]] provides a rich language for describing many kinds of rights and obligations.
-		In this chapter it is planned to describe some patterns for linking DCAT Datasets and/or Distributions to suitable rights expressions.
-		See the wiki page on <a href="https://github.com/w3c/dxwg/wiki/License-and-rights">License and rights</a> for more discussion.
+		In this chapter, we describe some patterns for linking DCAT Datasets and/or Distributions to suitable rights expressions.
 	</p>
 	
 	<p>

--- a/dcat/index.html
+++ b/dcat/index.html
@@ -2362,10 +2362,14 @@ a:TestingActivity a prov:Activity;
 		In this chapter it is planned to describe some patterns for linking DCAT Datasets and/or Distributions to suitable rights expressions.
 		See the wiki page on <a href="https://github.com/w3c/dxwg/wiki/License-and-rights">License and rights</a> for more discussion.
 	</p>
+	
 	<p>
 		Selecting the right way to express conditions for access to and re-use of resources can be complex.
 		Implementers should always seek legal advice before deciding which conditions apply to the resource being described.
 	</p>
+<!--	
+	<div class="ednote" title="Original text">
+	
 	<p>
 		This specification distinguishes three main situations: one where a statement is associated with the resource that is explicitly declared as a 'licence';
 		a second where the statement is not explicitly declared as a 'licence'; and a third where the conditions are explicitly expressed as an ODRL Policy.
@@ -2382,6 +2386,49 @@ a:TestingActivity a prov:Activity;
 			The Open Digital Rights Language (ODRL) is a policy expression language that provides a flexible and interoperable information model, vocabulary, and encoding mechanisms for representing statements about usage (i.e. permissions, prohibitions, and obligations) of content and services.</li>
 		</ol>
 	</p>
+	
+	</div>
+-->
+	<p>
+    This specification distinguishes three main situations: 
+    one where a statement is associated with the resource that is explicitly declared as a 'license', i.e., when the rights statement is only about use conditions; 
+    a second, where the statement is associated with a resource denoting only access rights; 
+    a third, covering all the other cases - i.e., statements not concerning use conditions and access rights (e.g., copyright statements) and/or mixing use conditions and access rights.	
+	</p>
+	
+	<p class="note">
+	  It is worth noting that the provision of use conditions and access rights complies with the [[DWBP]]'s Best Practices 4 ("<a data-cite="DWBP#licenses">Provide data license information</a>") and 22 ("<a data-cite="DWBP#DataUnavailabilityReference">Provide an explanation for data that is not available</a>"), respectively.
+	</p>
+	
+	<p>
+		The following approach is recommended:
+		<ol>
+			<li>
+			  <p>use <a href="http://dublincore.org/documents/dcmi-terms/#terms-license">dct:license</a> to refer to rights statements concerning only use conditions, and specified, preferably, by using well-known licenses such as <a href="https://creativecommons.org/share-your-work/licensing-types-examples/">those defined by Creative Commons</a></p>
+			<p>The object of dct:license, a <a href="http://dublincore.org/documents/dcmi-terms/#terms-LicenseDocument">dct:LicenseDocument</a>, is "A legal document giving official permission to do something with a Resource."</p>
+			</li>
+			<li>
+			  <p>use <a href="http://dublincore.org/documents/dcmi-terms/#terms-accessRights">dct:accessRights</a>  to refer to statements concerning only access rights (e.g., whether data can be accessed by anyone or just by authorized parties).</p>
+        <p>The object of dct:accessRights is a dct:RightsStatement providing "Information about who can access the resource or an indication of its security status."</p>
+        <p class="note">
+          Access rights can also be expressed as code lists / taxonomies. Examples include the access rights code list  [[MDR-AR]] used in [[DCAT-AP]] and the <a href="http://purl.org/eprint/accessRights/">Eprints Access Rights Vocabulary Encoding Scheme</a>.
+        </p>
+      </li>
+			<li>
+			  <p>use <a href="http://dublincore.org/documents/dcmi-terms/#terms-rights">dct:rights</a> for all the other types of rights statements - those which are not covered by dct:license and dct:accessRights, such as copyright statements, and/or mixing use conditions and access rights.</p>
+			  <p>The object of dct:rights, a <a href="http://dublincore.org/documents/dcmi-terms/#terms-RightsStatement">dct:RightsStatement</a>, is "A statement about the intellectual property rights (IPR) held in or over a Resource, a legal document giving official permission to do something with a resource, or a statement about access rights." 
+			This is more general than a <a href="http://dublincore.org/documents/dcmi-terms/#terms-LicenseDocument">dct:LicenseDocument</a> and therefore should be used if it the statement contains more general information about rights.</p>
+			  <p class="note">
+			    A more sophisticated approach to express rights, based on and extending [[DCTERMS]], is provided by the Open Data Rights Statement Vocabulary (ODRS) [[ODRS]], which defines properties for specifying, among others, copyright statements and copyright notices.
+			  </p>
+			</li>
+		</ol>
+	</p>
+
+	<p>Finally, in the particular case when rights are expressed via <a href="https://www.w3.org/TR/odrl-vocab/#term-Policy">ODRL policies</a>, the recommendation is to use use <a href="https://www.w3.org/TR/odrl-vocab/#term-hasPolicy">odrl:hasPolicy</a>.</p>
+  <p>The Open Digital Rights Language (ODRL) [[ODRL-VOCAB]] is a policy expression language that provides a flexible and interoperable information model, vocabulary, and encoding mechanisms for representing statements about usage (i.e. permissions, prohibitions, and obligations) of content and services.</p>
+
+  <p>Recommendations on the use of these properties on the different types of resources defined in DCAT are provided in the relevant class descriptions.</p>
 
 </section>
 

--- a/dcat/index.html
+++ b/dcat/index.html
@@ -2391,42 +2391,51 @@ a:TestingActivity a prov:Activity;
 -->
 	<p>
     This specification distinguishes three main situations: 
-    one where a statement is associated with the resource that is explicitly declared as a 'license', i.e., when the rights statement is only about use conditions; 
+    one where a statement is associated with a resource that is explicitly declared as a 'license'; 
     a second, where the statement is associated with a resource denoting only access rights; 
-    a third, covering all the other cases - i.e., statements not concerning use conditions and access rights (e.g., copyright statements) and/or mixing use conditions and access rights.	
+    a third, covering all the other cases - i.e., statements not concerning licensing conditions and/or access rights (e.g., copyright statements).	
 	</p>
 	
 	<p class="note">
-	  It is worth noting that the provision of use conditions and access rights complies with the [[DWBP]]'s Best Practices 4 ("<a data-cite="DWBP#licenses">Provide data license information</a>") and 22 ("<a data-cite="DWBP#DataUnavailabilityReference">Provide an explanation for data that is not available</a>"), respectively.
+	  It is worth noting that the provision of licensing conditions and access rights complies with the [[DWBP]]'s Best Practices 4 ("<a data-cite="DWBP#licenses">Provide data license information</a>") and 22 ("<a data-cite="DWBP#DataUnavailabilityReference">Provide an explanation for data that is not available</a>"), respectively.
 	</p>
 	
 	<p>
-		The following approach is recommended:
+		To address these scenarios, the recommendation is to use property dct:rights, and its sub-properties dct:license and dct:accessRights. More precisely:
+  </p>
 		<ol>
 			<li>
-			  <p>use <a href="http://dublincore.org/documents/dcmi-terms/#terms-license">dct:license</a> to refer to rights statements concerning only use conditions, and specified, preferably, by using well-known licenses such as <a href="https://creativecommons.org/share-your-work/licensing-types-examples/">those defined by Creative Commons</a></p>
+			  <p>use <a href="http://dublincore.org/documents/dcmi-terms/#terms-license">dct:license</a> to refer to licenses;</p>
+<!--			  
 			<p>The object of dct:license, a <a href="http://dublincore.org/documents/dcmi-terms/#terms-LicenseDocument">dct:LicenseDocument</a>, is "A legal document giving official permission to do something with a Resource."</p>
+-->			
+        <p class="note">
+          For interoperability, it is recommended to use canonical URIs of well-known licenses such as <a href="https://creativecommons.org/share-your-work/licensing-types-examples/">those defined by Creative Commons</a>.
+        </p>
 			</li>
 			<li>
-			  <p>use <a href="http://dublincore.org/documents/dcmi-terms/#terms-accessRights">dct:accessRights</a>  to refer to statements concerning only access rights (e.g., whether data can be accessed by anyone or just by authorized parties).</p>
+			  <p>use <a href="http://dublincore.org/documents/dcmi-terms/#terms-accessRights">dct:accessRights</a>  to express statements concerning only access rights (e.g., whether data can be accessed by anyone or just by authorized parties);</p>
+<!--			  
         <p>The object of dct:accessRights is a dct:RightsStatement providing "Information about who can access the resource or an indication of its security status."</p>
+-->        
         <p class="note">
           Access rights can also be expressed as code lists / taxonomies. Examples include the access rights code list  [[MDR-AR]] used in [[DCAT-AP]] and the <a href="http://purl.org/eprint/accessRights/">Eprints Access Rights Vocabulary Encoding Scheme</a>.
         </p>
       </li>
 			<li>
-			  <p>use <a href="http://dublincore.org/documents/dcmi-terms/#terms-rights">dct:rights</a> for all the other types of rights statements - those which are not covered by dct:license and dct:accessRights, such as copyright statements, and/or mixing use conditions and access rights.</p>
+			  <p>use <a href="http://dublincore.org/documents/dcmi-terms/#terms-rights">dct:rights</a> for all the other types of rights statements - those which are not covered by dct:license and dct:accessRights, such as copyright statementss.</p>
+<!--			  
 			  <p>The object of dct:rights, a <a href="http://dublincore.org/documents/dcmi-terms/#terms-RightsStatement">dct:RightsStatement</a>, is "A statement about the intellectual property rights (IPR) held in or over a Resource, a legal document giving official permission to do something with a resource, or a statement about access rights." 
 			This is more general than a <a href="http://dublincore.org/documents/dcmi-terms/#terms-LicenseDocument">dct:LicenseDocument</a> and therefore should be used if it the statement contains more general information about rights.</p>
+-->			
 			  <p class="note">
 			    A more sophisticated approach to express rights, based on and extending [[DCTERMS]], is provided by the Open Data Rights Statement Vocabulary (ODRS) [[ODRS]], which defines properties for specifying, among others, copyright statements and copyright notices.
 			  </p>
 			</li>
 		</ol>
-	</p>
 
 	<p>Finally, in the particular case when rights are expressed via <a href="https://www.w3.org/TR/odrl-vocab/#term-Policy">ODRL policies</a>, it is recommended to use use the <a href="https://www.w3.org/TR/odrl-vocab/#term-hasPolicy">odrl:hasPolicy</a> property as the link from the description of the catalogued resource or distribution to the ODRL policy.</p>
-  <p>The Open Digital Rights Language (ODRL) [[ODRL-VOCAB]] is a policy expression language that provides a flexible and interoperable information model, vocabulary, and encoding mechanisms for representing statements about usage (i.e. permissions, prohibitions, and obligations) of content and services.</p>
+  <p class="note">The Open Digital Rights Language (ODRL) [[ODRL-VOCAB]] is a policy expression language that provides a flexible and interoperable information model, vocabulary, and encoding mechanisms for representing statements about usage (i.e. permissions, prohibitions, and obligations) of content and services.</p>
 
   <p>Recommendations on the use of these properties on the different types of resources defined in DCAT are provided in the relevant class descriptions.</p>
 
@@ -3466,4 +3475,4 @@ dcat:servesDataset ga-courts:jc ;
 </section>
 
 </body>
-</html>
+</html> 

--- a/dcat/index.html
+++ b/dcat/index.html
@@ -2359,7 +2359,7 @@ a:TestingActivity a prov:Activity;
 	<p class="note">
 		DCAT 2014 handling of license and rights do not appear to satisfy all requirements [[VOCAB-DCAT-20140116]].
 		The recently completed W3C ODRL vocabulary [[ODRL-VOCAB]] provides a rich language for describing many kinds of rights and obligations.
-		In this chapter, we describe some patterns for linking DCAT Datasets and/or Distributions to suitable rights expressions.
+		In this chapter, we describe some patterns for linking DCAT Datasets and/or Distributions to suitable license and rights expressions.
 	</p>
 	
 	<p>
@@ -3371,6 +3371,10 @@ dcat:servesDataset ga-courts:jc ;
         <p>The document has undergone the following changes since the W3C Recommendation of 16 January 2014 [[VOCAB-DCAT-20140116]]:</p>
 
         <ul>
+
+            <li>
+               The section <a href="#license-rights">License and rights statements</a> was added to describe patterns for linking dcat:Datasets and dcat:Distributions to the relevant license and rights expressions.
+            </li>
 
             <li>
                 <a href="#Property:dataset_creator">Property: dataset creator</a>: The property dct:creator is recommended for use in the context of a dataset to allow the entity responsible for generating the dataset to be recorded - see <a href="https://github.com/w3c/dxwg/issues/61">Issue #61</a>

--- a/dcat/index.html
+++ b/dcat/index.html
@@ -2433,7 +2433,7 @@ a:TestingActivity a prov:Activity;
 			</li>
 		</ol>
 
-	<p>Finally, in the particular case when rights are expressed via <a href="https://www.w3.org/TR/odrl-vocab/#term-Policy">ODRL policies</a>, it is recommended to use use the <a href="https://www.w3.org/TR/odrl-vocab/#term-hasPolicy">odrl:hasPolicy</a> property as the link from the description of the catalogued resource or distribution to the ODRL policy.</p>
+	<p>Finally, in the particular case when rights are expressed via <a href="https://www.w3.org/TR/odrl-vocab/#term-Policy">ODRL policies</a>, it is recommended to use use the <a href="https://www.w3.org/TR/odrl-vocab/#term-hasPolicy">odrl:hasPolicy</a> property as the link from the description of the catalogued resource or distribution to the ODRL policy, in addition to the relevant <code>dct</code> property.</p>
   <p class="note">The Open Digital Rights Language (ODRL) [[ODRL-VOCAB]] is a policy expression language that provides a flexible and interoperable information model, vocabulary, and encoding mechanisms for representing statements about usage (i.e. permissions, prohibitions, and obligations) of content and services.</p>
 
   <p>Recommendations on the use of these properties on the different types of resources defined in DCAT are provided in the relevant class descriptions.</p>

--- a/dcat/index.html
+++ b/dcat/index.html
@@ -2425,7 +2425,7 @@ a:TestingActivity a prov:Activity;
 		</ol>
 	</p>
 
-	<p>Finally, in the particular case when rights are expressed via <a href="https://www.w3.org/TR/odrl-vocab/#term-Policy">ODRL policies</a>, the recommendation is to use use <a href="https://www.w3.org/TR/odrl-vocab/#term-hasPolicy">odrl:hasPolicy</a>.</p>
+	<p>Finally, in the particular case when rights are expressed via <a href="https://www.w3.org/TR/odrl-vocab/#term-Policy">ODRL policies</a>, it is recommended to use use the <a href="https://www.w3.org/TR/odrl-vocab/#term-hasPolicy">odrl:hasPolicy</a> property as the link from the description of the catalogued resource or distribution to the ODRL policy.</p>
   <p>The Open Digital Rights Language (ODRL) [[ODRL-VOCAB]] is a policy expression language that provides a flexible and interoperable information model, vocabulary, and encoding mechanisms for representing statements about usage (i.e. permissions, prohibitions, and obligations) of content and services.</p>
 
   <p>Recommendations on the use of these properties on the different types of resources defined in DCAT are provided in the relevant class descriptions.</p>


### PR DESCRIPTION
> :warning: To be reviewed and revised by the WG before merging.

Tentative revision to Section 9, as per decision taken during the DCAT subgroup meeting of 21 Nov 2018:

https://www.w3.org/2018/11/21-dxwgdcat-minutes#x03

Related actions: [ACTION-85](https://www.w3.org/2017/dxwg/track/actions/85) & [ACTION-86](https://www.w3.org/2017/dxwg/track/actions/86)

The proposed revision includes the following changes:
- Restructured recommendations to include guidance on the use of dct:accessRights for statement concerning only access rights (see #59, #160, #248)
- Incorporated additional text, in the form of notes, covering the following points: compliance with DWBP, examples of code lists used for access rights, reference to ODRS as an example of a vocabulary defining additional rights-related properties (see #224)
- Add concluding paragraph saying that the actual use of these properties is illustrated in the relevant class definitions

This revision can be previewed here:

https://rawgit.com/w3c/dxwg/andrea-perego-dcat-sec-rights-rev/dcat/index.html#license-rights

To see the HTML diff highlighting the changes:

https://services.w3.org/htmldiff?doc1=https%3A%2F%2Fw3c.github.io%2Fdxwg%2Fdcat%2Findex.html&doc2=https%3A%2F%2Frawgit.com%2Fw3c%2Fdxwg%2Fandrea-perego-dcat-sec-rights-rev%2Fdcat%2Findex.html#license-rights