### PR TITLE
Dcat issue79 datasets (don't merge yet)

### DIFF
--- a/dcat/index.html
+++ b/dcat/index.html
@@ -2024,6 +2024,10 @@
           </tbody>
         </table>
 
+        <p class="note">
+            Property added in this revision of DCAT.
+        </p>
+
         <p>
           This DCAT property complements <a href="http://www.w3.org/ns/prov#hadRole">prov:hadRole</a> which provides the function of an entity or agent with respect to an activity.
         </p>
@@ -2351,8 +2355,12 @@ a:TestingActivity a prov:Activity;
   <h2>Attribution roles</h2>
   <p>
     The standard Dublin Core properties <a href="http://purl.org/dc/terms/contributor">dct:contributor</a>, <a href="http://purl.org/dc/terms/creator">dct:creator</a> and <a href="http://purl.org/dc/terms/publisher">dct:publisher</a>, support basic associations of responsible agents with a catalogued resource.
-    However, there are many other roles of importance in relation to datasets and services, such as those enumerated in the CI_RoleCode values from [[ISO-19115-1]] (available as <a href="http://registry.it.csiro.au/def/isotc211/CI_RoleCode">linked-data</a>), in the [[DataCite]] metadata schema, and included within the <a href="https://id.loc.gov/vocabulary/relators">MARC relators</a>.
-    A generic method for assigning an agent to a resource with a specified relationship is provided by using the qualified form <a href="https://www.w3.org/TR/prov-o/#qualifiedAttribution">prov:qualifiedAttribution</a> from [[PROV-O]], as shown in the following example:
+    However, there are many other roles of importance in relation to datasets and services - e.g. funder, distributor, custodian, editor.
+    Some of these roles are enumerated in the CI_RoleCode values from [[ISO-19115-1]], in the [[DataCite]] metadata schema, and included within the <a href="https://id.loc.gov/vocabulary/relators">MARC relators</a>.
+  <p>
+  </p>
+    A general method for assigning an agent to a resource with a specified relationship is provided by using the qualified form <a href="https://www.w3.org/TR/prov-o/#qualifiedAttribution">prov:qualifiedAttribution</a> from [[PROV-O]].
+    The following provides an illustration:
   </p>
 <div class="example">
 <pre class="nohighlight turtle" aria-busy="false" aria-live="polite">
@@ -2371,6 +2379,10 @@ ex:DS987
 .
 </pre>
 </div>
+
+<p>
+  In this example the roles are taken from [[ISO-19115-1]] which are available as linked data in a <a href="http://registry.it.csiro.au/def/isotc211/CI_RoleCode">discrete list</a>. 
+</p>
 
 <p class="note">
   Note: The domain of <a href="http://www.w3.org/ns/prov#hadRole">prov:hadRole</a> property is <a href="http://www.w3.org/ns/prov#Association">prov:Association</a> [[PROV-O]] i.e. PROV-O roles relate to activities, not entities.
@@ -2425,7 +2437,7 @@ ex:DS987
 			<li>use <a href="http://dublincore.org/documents/dcmi-terms/#terms-license">dct:license</a> to refer to well-known licences such as <a href="https://creativecommons.org/share-your-work/licensing-types-examples/">those defined by Creative Commons</a></br>
 			The object of dct:license, a <a href="http://dublincore.org/documents/dcmi-terms/#terms-LicenseDocument">dct:LicenseDocument</a>, is "A legal document giving official permission to do something with a Resource."</li>
 			<li>use <a href="http://dublincore.org/documents/dcmi-terms/#terms-rights">dct:rights</a> to refer to rights statements that are not licences, such as copyright statements</br>
-			The object of dct:rights, a <a href="http://dublincore.org/documents/dcmi-terms/#terms-RightsStatement">dct:RightsStatement</a>, is "A statement about the intellectual property rights (IPR) held in or over a Resource, a legal document giving official permission to do something with a resource, or a statement about access rights." 
+			The object of dct:rights, a <a href="http://dublincore.org/documents/dcmi-terms/#terms-RightsStatement">dct:RightsStatement</a>, is "A statement about the intellectual property rights (IPR) held in or over a Resource, a legal document giving official permission to do something with a resource, or a statement about access rights."
 			This is more general than a <a href="http://dublincore.org/documents/dcmi-terms/#terms-LicenseDocument">dct:LicenseDocument</a> and therefore should be used if it the statement contains more general information about rights.</li>
 			<li>use <a href="https://www.w3.org/TR/odrl-vocab/#term-hasPolicy">odrl:hasPolicy</a> for linking to <a href="https://www.w3.org/TR/odrl-vocab/#term-Policy">ODRL policies</a></br>
 			The Open Digital Rights Language (ODRL) is a policy expression language that provides a flexible and interoperable information model, vocabulary, and encoding mechanisms for representing statements about usage (i.e. permissions, prohibitions, and obligations) of content and services.</li>

--- a/dcat/index.html
+++ b/dcat/index.html
@@ -2012,6 +2012,25 @@
         </table>
     </section>
 
+    <section id="Property:hadRole">
+        <h3>Property: had role</h3>
+        <table class="definition">
+          <thead><tr><th>RDF Property:</th><th><a href="http://www.w3.org/ns/dcat#hadRole">dcat:hadRole</a></th></tr></thead>
+          <tbody>
+          <tr><td class="prop">Definition:</td><td>A role is the function of an entity or agent with respect to an entity or resource.</td></tr>
+          <tr><td class="prop">Domain:</td><td><a href="http://www.w3.org/ns/prov#Attribution">prov:Attribution</a></td></tr>
+          <tr><td class="prop">Usage note:</td><td>Used in a qualified-attribution to specify the role of an Agent with respect to an Entity.
+            It is recommended that the value be taken from a controlled vocabulary of agent roles, such as http://registry.it.csiro.au/def/isotc211/CI_RoleCode.</td></tr>
+          </tbody>
+        </table>
+
+        <p>
+          This DCAT property complements <a href="http://www.w3.org/ns/prov#hadRole">prov:hadRole</a> which provides the function of an entity or agent with respect to an activity.
+        </p>
+    </section>
+
+</section>
+
 </section>
 
 <section id="quality-information" class="informative">
@@ -2328,6 +2347,36 @@ a:TestingActivity a prov:Activity;
     </section>
 </section>
 
+<section id="qualified-attribution">
+  <h2>Attribution roles</h2>
+  <p>
+    The standard Dublin Core properties <a href="http://purl.org/dc/terms/contributor">dct:contributor</a>, <a href="http://purl.org/dc/terms/creator">dct:creator</a> and <a href="http://purl.org/dc/terms/publisher">dct:publisher</a>, support basic associations of responsible agents with a catalogued resource.
+    However, there are many other roles of importance in relation to datasets and services, such as those enumerated in the CI_RoleCode values from [[ISO-19115-1]] (available as <a href="http://registry.it.csiro.au/def/isotc211/CI_RoleCode">linked-data</a>), in the [[DataCite]] metadata schema, and included within the <a href="https://id.loc.gov/vocabulary/relators">MARC relators</a>.
+    A generic method for assigning an agent to a resource with a specified relationship is provided by using the qualified form <a href="https://www.w3.org/TR/prov-o/#qualifiedAttribution">prov:qualifiedAttribution</a> from [[PROV-O]], as shown in the following example:
+  </p>
+<div class="example">
+<pre class="nohighlight turtle" aria-busy="false" aria-live="polite">
+ex:DS987
+  a dcat:Dataset ;
+  prov:qualifiedAttribution [
+    a prov:Attribution ;
+    prov:agent <https://www.ala.org.au/> ;
+    dcat:hadRole <https://inspire.ec.europa.eu/metadata-codelist/ResponsiblePartyRole/distributor>
+  ] ;
+  prov:qualifiedAttribution [
+    a prov:Attribution ;
+    prov:agent <https://www.education.gov.au/> ;
+    dcat:hadRole <http://registry.it.csiro.au/def/isotc211/CI_RoleCode/funder>
+  ] ;
+.
+</pre>
+</div>
+
+<p class="note">
+  Note: The domain of <a href="http://www.w3.org/ns/prov#hadRole">prov:hadRole</a> property is <a href="http://www.w3.org/ns/prov#Association">prov:Association</a> [[PROV-O]] i.e. PROV-O roles relate to activities, not entities.
+  Therefore, a new property <a href="http://www.w3.org/ns/dcat#hadRole">dcat:hadRole</a> is used to attach a specific role to the association-class <a href="http://www.w3.org/ns/prov#Attribution">prov:Attribution</a>.
+</p>
+</section>
 
 <section id="prov-patterns">
 

--- a/dcat/index.html
+++ b/dcat/index.html
@@ -902,6 +902,10 @@
                 added to the dcat:Resource class, as the Dataset superclass.
             </p>
 
+            <p class="issue" data-number="80">
+                The use of the [[PROV-O]] qualified-attribution pattern is <a href="#qualified-attribution">described below</a>.
+                `dct:creator` corresponds with a general attribution with the role 'creator'.
+            </p>
 
             <table class="definition">
                 <thead><tr><th>RDF Property:</th><th><a href="http://purl.org/dc/terms/creator">dct:creator</a></th></tr></thead>
@@ -967,7 +971,8 @@
             <h4>Property: publisher</h4>
 
             <p class="issue" data-number="80">
-                The desire to have qualified forms of properties (as done in [[PROV-O]]) has been raised. If dcat:Dataset is a prov:Entity (not decided yet) then `publisher` could be a qualified prov:Entity &rarr; prov:Agent relationship.
+                The use of the [[PROV-O]] qualified-attribution pattern is <a href="#qualified-attribution">described below</a>.
+                `dct:publisher` corresponds with a general attribution with the role 'publisher'.
             </p>
 
             <table class="definition">

--- a/dcat/index.html
+++ b/dcat/index.html
@@ -2017,19 +2017,20 @@
         <table class="definition">
           <thead><tr><th>RDF Property:</th><th><a href="http://www.w3.org/ns/dcat#hadRole">dcat:hadRole</a></th></tr></thead>
           <tbody>
-          <tr><td class="prop">Definition:</td><td>A role is the function of an entity or agent with respect to an entity or resource.</td></tr>
+          <tr><td class="prop">Definition:</td><td>The function of an entity or agent with respect to another entity or resource.</td></tr>
           <tr><td class="prop">Domain:</td><td><a href="http://www.w3.org/ns/prov#Attribution">prov:Attribution</a></td></tr>
+          <tr><td class="prop">Range:</td><td><a href="http://www.w3.org/ns/prov#Role">prov:Role</a></td></tr>
           <tr><td class="prop">Usage note:</td><td>Used in a qualified-attribution to specify the role of an Agent with respect to an Entity.
-            It is recommended that the value be taken from a controlled vocabulary of agent roles, such as http://registry.it.csiro.au/def/isotc211/CI_RoleCode.</td></tr>
+            It is recommended that the value be taken from a controlled vocabulary of agent roles, such as <a href="http://registry.it.csiro.au/def/isotc211/CI_RoleCode">ISO 19115 CI_RoleCode</a>.</td></tr>
           </tbody>
         </table>
 
-        <p class="note">
-            Property added in this revision of DCAT.
-        </p>
-
         <p>
           This DCAT property complements <a href="http://www.w3.org/ns/prov#hadRole">prov:hadRole</a> which provides the function of an entity or agent with respect to an activity.
+        </p>
+
+        <p class="note">
+          Property added in this revision of DCAT.
         </p>
     </section>
 
@@ -2381,7 +2382,7 @@ ex:DS987
 </div>
 
 <p>
-  In this example the roles are taken from [[ISO-19115-1]] which are available as linked data in a <a href="http://registry.it.csiro.au/def/isotc211/CI_RoleCode">discrete list</a>. 
+  In this example the roles are taken from [[ISO-19115-1]] which are available as linked data in a <a href="http://registry.it.csiro.au/def/isotc211/CI_RoleCode">discrete list</a>.
 </p>
 
 <p class="note">

--- a/dcat/index.html
+++ b/dcat/index.html
@@ -2360,13 +2360,13 @@ ex:DS987
   a dcat:Dataset ;
   prov:qualifiedAttribution [
     a prov:Attribution ;
-    prov:agent <https://www.ala.org.au/> ;
-    dcat:hadRole <https://inspire.ec.europa.eu/metadata-codelist/ResponsiblePartyRole/distributor>
+    prov:agent &lt;https://www.ala.org.au/&gt; ;
+    dcat:hadRole &lt;http://registry.it.csiro.au/def/isotc211/CI_RoleCode/distributor&gt;
   ] ;
   prov:qualifiedAttribution [
     a prov:Attribution ;
-    prov:agent <https://www.education.gov.au/> ;
-    dcat:hadRole <http://registry.it.csiro.au/def/isotc211/CI_RoleCode/funder>
+    prov:agent &lt;https://www.education.gov.au/&gt; ;
+    dcat:hadRole &lt;http://registry.it.csiro.au/def/isotc211/CI_RoleCode/funder&gt;
   ] ;
 .
 </pre>

--- a/dcat/index.html
+++ b/dcat/index.html
@@ -2012,16 +2012,69 @@
         </table>
     </section>
 
+    <section id="Class:Relationship">
+        <h3>Class: Relationship</h3>
+
+        <p class="note">
+            The class <a href="#Class:Relationship">dcat:Relationship</a> has been added to the DCAT vocabulary in this revision.
+        </p>
+
+        <p>The following properties are recommended for use on this class:
+          <a href="#Property:relationship_relation">relation</a>,
+          <a href="#Property:relationship_hadRole">hadRole</a>,
+        </p>
+
+        <table class="definition">
+            <thead><tr><th>RDF Class:</th><th><a href="http://www.w3.org/ns/dcat#Relationship">dcat:Relationship</a></th></tr></thead>
+            <tbody>
+            <tr><td class="prop">Definition:</td><td>An association class for attaching additional information to a relationship between DCAT Resources</td></tr>
+            <tr><td class="prop">Sub class of:</td><td><a href="http://www.w3.org/ns/prov#EntityInfluence">prov:EntityInfluence</a></td></tr>
+            <tr><td class="prop">Usage note:</td><td></td></tr>
+            </tbody>
+        </table>
+
+        <section id="Property:relationship_relation">
+            <h4>Property: relation</h4>
+            <table class="definition">
+                <thead><tr><th>RDF Property:</th><th><a href="http://purl.org/dc/terms/relation">dct:relation</a></th></tr></thead>
+                <tbody>
+                <tr><td class="prop">Definition:</td><td>The resource related to the source resource</td></tr>
+                <tr><td class="prop">Usage note:</td><td>In the context of a dcat:Relationship this is expected to point to another dcat:Dataset or other catalogued resource</td></tr>
+                </tbody>
+            </table>
+
+        <section id="Property:relationship_hadRole">
+            <h4>Property: hadRole</h4>
+            <table class="definition">
+                <thead><tr><th>RDF Property:</th><th><a href="http://www.w3.org/ns/dcat#hadRole">dcat:hadRole</a></th></tr></thead>
+                <tbody>
+                <tr><td class="prop">Definition:</td><td>The function of an entity or agent with respect to another entity or resource.</td></tr>
+                <tr><td class="prop">Usage note:</td><td>Used in a qualified-relationship to specify the role of an Entity with respect to another Entity.
+                  It is recommended that the value be taken from a controlled vocabulary of relation types,
+                  such as <a href="http://registry.it.csiro.au/def/isotc211/DS_AssociationTypeCode">ISO 19115 DS_AssociationTypeCode</a>,
+                   or those included in the <a href="https://www.iana.org/assignments/link-relations">IANA Registry of Link Relations</a>,
+                   the [[DataCite]] metadata schema, or the <a href="https://id.loc.gov/vocabulary/relators">MARC relators</a>.
+                </td></tr>
+                </tbody>
+            </table>
+
+        </section>
+
+    </section> <!-- end class Relationship -->
+
     <section id="Property:hadRole">
         <h3>Property: had role</h3>
         <table class="definition">
           <thead><tr><th>RDF Property:</th><th><a href="http://www.w3.org/ns/dcat#hadRole">dcat:hadRole</a></th></tr></thead>
           <tbody>
           <tr><td class="prop">Definition:</td><td>The function of an entity or agent with respect to another entity or resource.</td></tr>
-          <tr><td class="prop">Domain:</td><td><a href="http://www.w3.org/ns/prov#Attribution">prov:Attribution</a></td></tr>
+          <tr><td class="prop">Domain:</td><td><a href="http://www.w3.org/ns/prov#Attribution">prov:Attribution</a> OR <a href="http://www.w3.org/ns/dcat#Relationship">dcat:Relationship</a></td></tr>
           <tr><td class="prop">Range:</td><td><a href="http://www.w3.org/ns/prov#Role">prov:Role</a></td></tr>
           <tr><td class="prop">Usage note:</td><td>Used in a qualified-attribution to specify the role of an Agent with respect to an Entity.
-            It is recommended that the value be taken from a controlled vocabulary of agent roles, such as <a href="http://registry.it.csiro.au/def/isotc211/CI_RoleCode">ISO 19115 CI_RoleCode</a>.</td></tr>
+            Used in a qualified-relationship to specify the role of an Entity with respect to another Entity.
+            It is recommended that the value be taken from a controlled vocabulary of relation-types or agent roles,
+            such as <a href="http://registry.it.csiro.au/def/isotc211/CI_RoleCode">ISO 19115 CI_RoleCode</a>,
+            or entity relations, such as <a href="https://www.iana.org/assignments/link-relations/link-relations.xhtml">IANA Link Relations</a>.</td></tr>
           </tbody>
         </table>
 
@@ -2033,6 +2086,29 @@
           Property added in this revision of DCAT.
         </p>
     </section>
+
+    <section id="Property:qualifiedRelation">
+        <h3>Property: qualified relation</h3>
+        <table class="definition">
+          <thead><tr><th>RDF Property:</th><th><a href="http://www.w3.org/ns/dcat#qualifiedRelation">dcat:qualifiedRelation</a></th></tr></thead>
+          <tbody>
+          <tr><td class="prop">Definition:</td><td>v</td></tr>
+          <tr><td class="prop">Sub-property of:</td><td><a href="http://www.w3.org/ns/prov#qualifiedInfluence">prov:qualifiedInfluence</a></td></tr>
+          <tr><td class="prop">Domain:</td><td><a href="http://www.w3.org/ns/dcat#Resource">dcat:Resource</a></td></tr>
+          <tr><td class="prop">Range:</td><td><a href="http://www.w3.org/ns/dcat#Relationship">prov:Relationship</a></td></tr>
+          <tr><td class="prop">Usage note:</td><td>Used to link to another resource where the nature of the relationship does not match one of the standard Dublin Core, DCAT or PROV-O relationships.</td></tr>
+          </tbody>
+        </table>
+
+        <p>
+          This DCAT property follows the pattern of <a href="https://www.w3.org/TR/prov-o/#description-qualified-terms">Qualification Properties</a> defined in [[PROV-O]].
+        </p>
+
+        <p class="note">
+          Property added in this revision of DCAT.
+        </p>
+    </section>
+
 
 </section>
 
@@ -2388,6 +2464,52 @@ ex:DS987
 <p class="note">
   Note: The domain of <a href="http://www.w3.org/ns/prov#hadRole">prov:hadRole</a> property is <a href="http://www.w3.org/ns/prov#Association">prov:Association</a> [[PROV-O]] i.e. PROV-O roles relate to activities, not entities.
   Therefore, a new property <a href="http://www.w3.org/ns/dcat#hadRole">dcat:hadRole</a> is used to attach a specific role to the association-class <a href="http://www.w3.org/ns/prov#Attribution">prov:Attribution</a>.
+</p>
+</section>
+
+<section id="qualified-relationship">
+  <h2>Relationships between datasets and other catalogued resources</h2>
+  <p>
+    The standard Dublin Core properties <a href="http://purl.org/dc/terms/relation">dct:relation</a> and sub-properties such as
+    <a href="http://purl.org/dc/terms/hasPart">dct:hasPart</a>/<a href="http://purl.org/dc/terms/isPartOf">dct:isPartOf</a>,
+    <a href="http://purl.org/dc/terms/hasVersion">dct:hasVersion</a>/<a href="http://purl.org/dc/terms/isVersionOf">dct:isVersionOf</a>,
+    <a href="http://purl.org/dc/terms/replaces">dct:replaces</a>/<a href="http://purl.org/dc/terms/isReplacedBy">dct:isReplacedBy</a>,
+    <a href="http://purl.org/dc/terms/requires">dct:requires</a>/<a href="http://purl.org/dc/terms/isRequiredBy">dct:isRequiredBy</a>,
+    <a href="http://www.w3.org/ns/prov#wasDerivedFrom">prov:wasDerivedFrom</a>,
+    <a href="http://www.w3.org/ns/prov#wasQuotedFrom">prov:wasQuotedFrom</a>,
+    support the description of relationships between datasets and other catalogued resources.
+    However, there are many other relationships of importance - e.g. alternate, canonical, original, preview, stereo-mate, working-copy-of.
+    Some of these roles are enumerated in the DS_AssociationTypeCode values from [[ISO-19115-1]], the <a href="https://www.iana.org/assignments/link-relations">IANA Registry of Link Relations</a>, in the [[DataCite]] metadata schema, and included within the <a href="https://id.loc.gov/vocabulary/relators">MARC relators</a>.
+  <p>
+  </p>
+    A general method for relating a resource to another resource with a specified relationship is provided by using the qualified form <a href="http://www.w3.org/ns/dcat#Relationship">dcat:Relationship</a>.
+    The following provides illustrations:
+  </p>
+<div class="example">
+<pre class="nohighlight turtle" aria-busy="false" aria-live="polite">
+ex:Test987
+  a dcat:Dataset ;
+  dcat:qualifiedRelation [
+    a dcat:Relationship ;
+    dct:relation &lt;http://example.org/Original987&gt; ;
+    dcat:hadRole &lt;http://www.iana.org/assignments/relation/original&gt;
+  ] ;
+.
+
+ex:Test543L
+  a dcat:Dataset ;
+  dcat:qualifiedRelation [
+    a dcat:Relationship ;
+    dct:relation &lt;http://example.org/Test543R&gt; ;
+    dcat:hadRole &lt;http://registry.it.csiro.au/def/isotc211/DS_AssociationTypeCode/stereoMate&gt;
+  ] ;
+.
+</pre>
+</div>
+
+<p class="note">
+  Note: The property <a href="http://www.w3.org/ns/dcat#qualifiedRelation">dcat:qualifiedRelation</a> and association-class <a href="http://www.w3.org/ns/dcat#Relationship">dcat:Relationship</a> follow the pattern established in W3C [[PROV-O]] and described in the section <a href="https://www.w3.org/TR/prov-o/#description-qualified-terms">Qualified Terms</a>.
+  However, PROV-O is activity-centric, and does not support Entity-Entity relations except for the single case of 'was derived from', thus necessitating the new elements shown here to support the general case.
 </p>
 </section>
 

--- a/dcat/rdf/dcat.ttl
+++ b/dcat/rdf/dcat.ttl
@@ -18,6 +18,14 @@
 @prefix v: <http://www.w3.org/2006/vcard/ns#> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
+dct:hasPart
+  skos:scopeNote "See also: Sub-properties of dct:hasPart in particular dcat:dataset, dcat:catalog, dcat:service." ;
+  skos:scopeNote "This is the most general predicate for membership of a catalog. Use of a more specific sub-property is recommended when available. " ;
+.
+dct:relation
+  skos:scopeNote "See also: Sub-properties of dct:relation in particular dcat:distribution, dct:hasPart, dct:isPartOf, dct:conformsTo, dct:isFormatOf, dct:hasFormat, dct:isVersionOf, dct:hasVersion, dct:replaces, dct:isReplacedBy, dct:references, dct:isReferencedBy, dct:requires, dct:isRequiredBy" ;
+  skos:scopeNote "dct:relation SHOULD be used where the nature of the relationship between a catalogued item and related resources is not known. A more specific sub-property SHOULD be used if the nature of the relationship of the link is known. The property dcat:distribution SHOULD be used to link from a dcat:Dataset to a representation of the dataset, described as a dcat:Distribution" ;
+.
 <http://www.w3.org/ns/dcat>
   rdf:type owl:Ontology ;
   dct:contributor [
@@ -346,6 +354,19 @@ dcat:Distribution
 					  μέσω API ή μέσω μίας ιστοσελίδας. Η χρήση της ιδιότητας dcat:downloadURL δείχνει μόνο άμεσα μεταφορτώσιμες διανομές."""@el ;
   skos:scopeNote "これは、データセットの一般的な利用可能性を表わし、データの実際のアクセス方式に関する情報（つまり、直接ダウンロードなのか、APIなのか、ウェブページを介したものなのか）を意味しません。dcat:downloadURLプロパティーの使用は、直接ダウンロード可能な配信を意味します。"@ja ;
 .
+dcat:Relationship
+  rdf:type owl:Class ;
+  rdfs:comment "An association class for attaching additional information to a relationship between DCAT Resources" ;
+  rdfs:label "Relationship" ;
+  rdfs:subClassOf [
+      rdf:type owl:Restriction ;
+      owl:minCardinality "1"^^xsd:nonNegativeInteger ;
+      owl:onProperty dct:relation ;
+    ] ;
+  skos:changeNote "New class in this revision" ;
+  skos:editorialNote "Status: Class accepted by DCAT revision team, but details of definition and constraints not yet resolved." ;
+  skos:scopeNote "  " ;
+.
 dcat:Resource
   rdf:type owl:Class ;
   rdfs:comment "Resource published or curated by a single agent" ;
@@ -592,12 +613,18 @@ dcat:endpointURL
 dcat:hadRole
   rdf:type owl:ObjectProperty ;
   rdfs:comment "The function of an entity or agent with respect to another entity or resource."@en ;
-  rdfs:domain prov:Attribution ;
+  rdfs:domain [
+      rdf:type owl:Class ;
+      owl:unionOf (
+          prov:Attribution
+          dcat:Relationship
+        ) ;
+    ] ;
   rdfs:label "hadRole" ;
   rdfs:range prov:Role ;
   skos:changeNote "New property in this revision of DCAT" ;
   skos:editorialNote "Introduced into DCAT to complement prov:hadRole, whose use is limited to roles in the context of an activity, with the domain of prov:Association" ;
-  skos:scopeNote "Used in a qualified-attribution to specify the role of an Agent with respect to an Entity. It is recommended that the value be taken from a controlled vocabulary of agent roles, such as http://registry.it.csiro.au/def/isotc211/CI_RoleCode " ;
+  skos:scopeNote "Used in a qualified-attribution to specify the role of an Agent or Entity with respect to an Entity. It is recommended that the value be taken from a controlled vocabulary of agent roles, such as http://registry.it.csiro.au/def/isotc211/CI_RoleCode, or relation-types, such as https://www.iana.org/assignments/link-relations " ;
 .
 dcat:keyword
   rdf:type rdf:Property ;
@@ -682,9 +709,20 @@ dcat:mediaType
   rdfs:label "メディア・タイプ"@ja ;
   rdfs:range dct:MediaType ;
   rdfs:subPropertyOf dct:format ;
-  skos:scopeNote "This property SHOULD be used when the media type of the distribution is defined in the IANA media types registry https://www.iana.org/assignments/media-types/, otherwise dct:format MAY be used with different values.";
-  skos:editorialNote "The range of dcat:mediaType has been tightened as part of the revision of DCAT." ;
   skos:editorialNote "Status: English Definition text modified by DCAT revision team, translations pending. Note some inconsistency on def vs. usage" ;
+  skos:editorialNote "The range of dcat:mediaType has been tightened as part of the revision of DCAT." ;
+  skos:scopeNote "This property SHOULD be used when the media type of the distribution is defined in the IANA media types registry https://www.iana.org/assignments/media-types/, otherwise dct:format MAY be used with different values." ;
+.
+dcat:qualifiedRelation
+  rdf:type owl:ObjectProperty ;
+  rdfs:comment "Link to a description of a relationship with another resource."@en ;
+  rdfs:domain dcat:Resource ;
+  rdfs:label "hadRole" ;
+  rdfs:range dcat:Relationship ;
+  rdfs:subPropertyOf prov:qualifiedInfluence ;
+  skos:changeNote "New property in this revision of DCAT" ;
+  skos:editorialNote "Introduced into DCAT to complement the other PROV qualified relations" ;
+  skos:scopeNote "Used in a qualified-relation to specify a relationship of an Entity to another Entity. It is recommended that the value be taken from a controlled vocabulary of agent roles, such as https://www.iana.org/assignments/link-relations" ;
 .
 dcat:record
   rdf:type rdf:Property ;
@@ -798,12 +836,4 @@ prov:wasGeneratedBy
   rdfs:subPropertyOf dct:relation ;
   skos:scopeNote "The activity associated with generation of a dataset will typically be an initiative, project, mission, survey, on-going activity ('business as usual') etc. Multiple prov:wasGeneratedBy properties can be used to indicate the dataset production context at various levels of granularity." ;
   skos:scopeNote "Use prov:qualifiedGeneration to attach additional details about the relationship between the dataset and the activity, e.g. the exact time that the dataset was produced during the lifetime of a project" ;
-.
-dct:hasPart
-  skos:scopeNote "See also: Sub-properties of dct:hasPart in particular dcat:dataset, dcat:catalog, dcat:service." ;
-  skos:scopeNote "This is the most general predicate for membership of a catalog. Use of a more specific sub-property is recommended when available. " ;
-.
-dct:relation
-  skos:scopeNote "See also: Sub-properties of dct:relation in particular dcat:distribution, dct:hasPart, dct:isPartOf, dct:conformsTo, dct:isFormatOf, dct:hasFormat, dct:isVersionOf, dct:hasVersion, dct:replaces, dct:isReplacedBy, dct:references, dct:isReferencedBy, dct:requires, dct:isRequiredBy" ;
-  skos:scopeNote "dct:relation SHOULD be used where the nature of the relationship between a catalogued item and related resources is not known. A more specific sub-property SHOULD be used if the nature of the relationship of the link is known. The property dcat:distribution SHOULD be used to link from a dcat:Dataset to a representation of the dataset, described as a dcat:Distribution" ;
 .

--- a/dcat/rdf/dcat.ttl
+++ b/dcat/rdf/dcat.ttl
@@ -589,6 +589,16 @@ dcat:endpointURL
   skos:changeNote "New property in this revision of DCAT" ;
   skos:editorialNote "Status: Property accepted by DCAT revision team, but details of definition and constraints not yet resolved." ;
 .
+dcat:hadRole
+  rdf:type owl:ObjectProperty ;
+  rdfs:comment "The Role that an Entity (usually an Agent) assumed in the context of another Entity (such as a Dataset)."@en ;
+  rdfs:domain prov:Attribution ;
+  rdfs:label "hadRole" ;
+  rdfs:range prov:Role ;
+  skos:changeNote "New property in this revision of DCAT" ;
+  skos:editorialNote "Introduced into DCAT to complement prov:hadRole, whose use is limited to roles in the context of an activity, with the domain of prov:Association" ;
+  skos:scopeNote "Used in a qualified-attribution to specify the role of an Agent with respect to an Entity. It is recommended that the value be taken from a controlled vocabulary of agent roles, such as http://registry.it.csiro.au/def/isotc211/CI_RoleCode " ;
+.
 dcat:keyword
   rdf:type rdf:Property ;
   rdf:type owl:DatatypeProperty ;

--- a/dcat/rdf/dcat.ttl
+++ b/dcat/rdf/dcat.ttl
@@ -591,7 +591,7 @@ dcat:endpointURL
 .
 dcat:hadRole
   rdf:type owl:ObjectProperty ;
-  rdfs:comment "The Role that an Entity (usually an Agent) assumed in the context of another Entity (such as a Dataset)."@en ;
+  rdfs:comment "The function of an entity or agent with respect to another entity or resource."@en ;
   rdfs:domain prov:Attribution ;
   rdfs:label "hadRole" ;
   rdfs:range prov:Role ;


### PR DESCRIPTION
Started to describe dataset-dataset qualified pattern, in parallel with the dataset-agent pattern I already did. As suspected it raised more issues and more work is required to properly integrate it. 

Also a question of whether these PROV-O-based extensions belong in the main dcat.ttl graph or should be moved over to the dcat-prov alignment graph. 