### PR TITLE
Fixed spec status on GH

### DIFF
--- a/profilesont/config.js
+++ b/profilesont/config.js
@@ -1,5 +1,5 @@
 var respecConfig = {
-    specStatus: "FPWD",
+    specStatus: "ED",
     shortName: "dx-prof",
     edDraftURI: "https://w3c.github.io/dxwg/profilesont/",
     canonicalURI: "TR",


### PR DESCRIPTION
Changed specStatus to ED: All documents on GH are *always* of type "W3C Editor's Draft" - see also feedback from W3C staff reported in https://www.w3.org/2018/12/11-dxwg-minutes#x03

Re-implements part of PR #557