### PR TITLE
Addressing text of the conformsTo property in both: dcat:Resource and…

### DIFF
--- a/dcat/index.html
+++ b/dcat/index.html
@@ -818,7 +818,7 @@
     <section id="Class:Resource">
         <h3>Class: Catalogued Resource</h3>
 
-        <p>The following properties are recommended for use on this class:
+        <p>The following properties are recommended for use on this class (<code>dcat:Resource</code>):
             <a href="#Property:resource_conformsto">conformsTo</a>,
             <a href="#Property:resource_contact_point">contact point</a>,
             <a href="#Property:resource_creator">creator</a>,
@@ -1107,11 +1107,18 @@
             <table class="definition">
                 <thead><tr><th>RDF Property:</th><th><a href="http://purl.org/dc/terms/conformsTo">dct:conformsTo</a></th></tr></thead>
                 <tbody>
-                <tr><td class="prop">Definition:</td><td>An established standard to which the described resource conforms.</td></tr>
+                <tr><td class="prop">Definition:</td><td>An established standard to which the described catalogued resource conforms.</td></tr>
                 <tr><td class="prop">Range:</td><td><a href="http://purl.org/dc/terms/Standard">dct:Standard</a> (A basis for comparison; a reference point against which other things can be evaluated.)</td></tr>
+                <tr><td class="prop">Usage note:</td><td>This property <em title="SHOULD" class="rfc2119">SHOULD</em> be used to indicate the model, schema, ontology, view or profile that the catalogued resource content conforms to. </td></tr>
                 </tbody>
             </table>
         </section>
+
+        <p class="note">
+            <a href="http://purl.org/dc/terms/Standard">dct:Standard</a> is defined as "A basis for comparison; a reference point against which other things can be evaluated." The target resource is not restricted to formal standards issued by bodies like ISO and W3C. In this context, it is any resource that specifies one or more aspects of the catalogued resource content, for example schema, semantics, syntax, usage guidelines, file format, or specific serialization. The meaning of conformance is determined by provisions in the target standard.
+        </p>
+
+
 
         <section id="Property:resource_keyword">
             <h4>Property: keyword/tag</h4>
@@ -1174,7 +1181,7 @@
 
     <section id="Class:Catalog_Record">
         <h3>Class: Catalog Record</h3>
-        <p>The following properties are recommended for use on this class:
+        <p>The following properties are recommended for use on this class (<code>dcat:CatalogRecord</code>):
             <a href="#Property:record_conformsto">conforms to</a>,
             <a href="#Property:record_description">description</a>,
             <a href="#Property:record_listing_date">listing date</a>,
@@ -1295,7 +1302,7 @@
 
             <!-- this note is repeated from above, should we remove here or repeat for clarification in this context? -->
             <p class="note">
-                <a href="http://purl.org/dc/terms/Standard">dct:Standard</a> is defined as "A basis for comparison; a reference point against which other things can be evaluated." It is not restricted to formal standards issued by bodies like ISO and W3C. In this context it will usually be used for a schema, ontology, data model or profile which specifies the structure of a dataset. This is not necessarily tied to a single encoding or serialization.
+                <a href="http://purl.org/dc/terms/Standard">dct:Standard</a> is defined as "A basis for comparison; a reference point against which other things can be evaluated." The target resource is not restricted to formal standards issued by bodies like ISO and W3C. In this context, it is any resource that specifies one or more aspects of the catalog record content, for example schema, semantics, syntax, usage guidelines, file format, or specific serialization. The meaning of conformance is determined by provisions in the target standard.
             </p>
         </section>
 


### PR DESCRIPTION
… dcat:CatalogRecord context

This should close issue #502, as the remaining point was about editorial changes to the description of dct:conformsTo in the context of dcat:Resource and dcat:CatalogRecord.

The remaining description for Distribution should be deleted as per #621 

The changes in this PR can be seen here:

https://rawgit.com/w3c/dxwg/dcat-issue502/dcat/index.html#Property:resource_conformsto

and the comparison with the ED here:

https://services.w3.org/htmldiff?doc1=https%3A%2F%2Fw3c.github.io%2Fdxwg%2Fdcat%2F&doc2=https%3A%2F%2Frawgit.com%2Fw3c%2Fdxwg%2Fdcat-issue502%2Fdcat%2Findex.html