### PR TITLE
Editorial revision to Section 12.1 - Schema.org

### DIFF
--- a/dcat/index.html
+++ b/dcat/index.html
@@ -2544,7 +2544,7 @@ ex:DS987
             Schema.org [[SCHEMA-ORG]] includes a number of types and properties based on the original DCAT work (see <a href="https://schema.org/Dataset">schema:Dataset</a> as a starting point),
             and the index for Google's <a href="https://g.co/datasetsearch">Dataset Search service</a> relies on structured description in web pages about datasets based on both
             <a href="https://developers.google.com/search/docs/data-types/dataset">schema.org and DCAT</a>.
-            A comparison of the DCAT backbone, showed in <a href="#vocabulary-overview">Figure 1. above</a> with related classes from schema.org shows the similarity:
+            A comparison of the DCAT backbone, showed in <a href="#vocabulary-overview">Figure 1. above</a> with related classes from [[SCHEMA-ORG]] shows the similarity:
         </p>
         <figure id="fig2"><img alt="UML model of schema.org classes and properties related to dataset catalogs" src="UML/schema.org-dataset.png">
             <figcaption>
@@ -2552,18 +2552,18 @@ ex:DS987
             </figcaption>
         </figure>
         <p>
-            General purpose web search services that use metadata at all rely primarily on schema.org, so the relationship of DCAT to schema.org is of interest for data providers
+            General purpose web search services that use metadata at all rely primarily on [[SCHEMA-ORG]], so the relationship of DCAT to [[SCHEMA-ORG]] is of interest for data providers
             who wish their datasets and services to be exposed through those indexes.
         </p>
         <p>
-            A <a href="https://www.w3.org/wiki/WebSchemas/Datasets">mapping between DCAT 2014 and schema.org</a> was discussed on the original proposal to extend schema.org for describing datasets and data catalogs.
-            Partial mappings between DCAT 2014 [[VOCAB-DCAT-20140116]] and schema.org were provided earlier by the
-            <a href="https://ec-jrc.github.io/dcat-ap-to-schema-org/">European Commission</a> and the <a href="https://www.w3.org/2015/spatial/wiki/ISO_19115_-_DCAT_-_Schema.org_mapping">Spatial Data on the Web Working Group</a>.
+            A <a href="https://www.w3.org/wiki/WebSchemas/Datasets">mapping between DCAT 2014 and schema.org</a> was discussed on the original proposal to extend [[SCHEMA-ORG]] for describing datasets and data catalogs.
+            Partial mappings between DCAT 2014 [[VOCAB-DCAT-20140116]] and [[SCHEMA-ORG]] were provided earlier by the
+            <a href="https://www.w3.org/2015/spatial/wiki/ISO_19115_-_DCAT_-_Schema.org_mapping">Spatial Data on the Web Working Group</a>, building upon previous work.
         </p>
         <p>
-            A recommended mapping from the revised DCAT (this document) to schema.org is <a href="https://raw.githubusercontent.com/w3c/dxwg/gh-pages/dcat/rdf/dcat-schema.ttl">available in an RDF file</a>.
+            A recommended mapping from the revised DCAT (this document) to [[SCHEMA-ORG]] is <a href="https://raw.githubusercontent.com/w3c/dxwg/gh-pages/dcat/rdf/dcat-schema.ttl">available in an RDF file</a>.
             This mapping is axiomatized using the predicates <code>rdfs:subClassOf</code>, <code>rdfs:subPropertyOf</code>, <code>owl:equivalentClass</code>, <code>owl:equivalentProperty</code>, <code>skos:closeMatch</code>,
-            and also using the annotation properties <code>schema:domainIncludes</code> and <code>schema:rangeIncludes</code> to match schema.org semantics. The mapping is summarized in the table below, considering the prefix <code>schema</code> as <code>http://schema.org/</code>.
+            and also using the annotation properties <code>schema:domainIncludes</code> and <code>schema:rangeIncludes</code> to match [[SCHEMA-ORG]] semantics. The mapping is summarized in the table below, considering the prefix <code>schema</code> as <code>http://schema.org/</code>.
         </p>
         <p class="issue" data-number="251">
             This alignment of DCAT with schema.org is provisional and non-normative. Feedback is invited in the <a href="https://github.com/w3c/dxwg/issues/251">issue tracker</a>.


### PR DESCRIPTION
- Removed sentence about and linking to JRC mapping exercise between DCAT-AP and schema.org
- Added a sentence saying that the mappings proposed by the SDWWG are based on existing work (including the JRC one) - which are linked from the SDWWG page