### PR TITLE
Tidy up for closed issue #114

### DIFF
--- a/dcat/index.html
+++ b/dcat/index.html
@@ -3641,8 +3641,8 @@ dcat:servesDataset ga-courts:jc ;
                 - see <a href="https://github.com/w3c/dxwg/issues/502">Issue #502</a>.
             </li>
             <li>
-                A new  section, <a href="#licence-rights">Licence and rights statements</a>, is added to provide guidance and recommendations for the use of <a href="http://dublincore.org/documents/dcmi-terms/#terms-license>dct:license</a>, <a href="http://dublincore.org/documents/dcmi-terms/#terms-accessRights>dct:accessRights</a>,
-		and <a href="http://dublincore.org/documents/dcmi-terms/#terms-rights>dct:rights</a> in the context of dcat catalogs and distributions.
+                A new  section, <a href="#licence-rights">Licence and rights statements</a>, is added to provide guidance and recommendations for the use of <a href="http://dublincore.org/documents/dcmi-terms/#terms-license">dct:license</a>, <a href="http://dublincore.org/documents/dcmi-terms/#terms-accessRights">dct:accessRights</a>,
+		and <a href="http://dublincore.org/documents/dcmi-terms/#terms-rights">dct:rights</a> in the context of dcat catalogs and distributions.
 		See <a href="https://github.com/w3c/dxwg/issues/114">Issue #114</a> for the background discussion.
             </li>
 

--- a/dcat/index.html
+++ b/dcat/index.html
@@ -3640,6 +3640,11 @@ dcat:servesDataset ga-courts:jc ;
                 DCAT 2014 [[VOCAB-DCAT-20140116]] had no way of representing the conformance of a record metadata with a metadata standard. This revision has added the property dct:conformsTo for dcat:CatalogRecord to cover this requirement.
                 - see <a href="https://github.com/w3c/dxwg/issues/502">Issue #502</a>.
             </li>
+            <li>
+                A new  section, <a href="#licence-rights">Licence and rights statements</a>, is added to provide guidance and recommendations for the use of <a href="http://dublincore.org/documents/dcmi-terms/#terms-license>dct:license>, <a href="http://dublincore.org/documents/dcmi-terms/#terms-accessRights>dct:accessRights>,
+		and <a href="http://dublincore.org/documents/dcmi-terms/#terms-rights>dct:rights> in the context of dacat catalogs and distributions.
+		See <a href="https://github.com/w3c/dxwg/issues/114">Issue #114</a> for the background discussion.
+            </li>
 
         </ul>
 

--- a/dcat/index.html
+++ b/dcat/index.html
@@ -1318,7 +1318,7 @@
         </p>
 
         <p>
-            Information about licences and rights <em title="SHOULD" class="rfc2119">SHOULD</em> be provided on the level of Distribution. Information about licences and rights MAY be provided for a Dataset in addition to but not instead of the information provided for the Distributions of that Dataset. Providing licence or rights information for a Dataset that is different from information provided for a Distribution of that Dataset <em title="SHOULD" class="rfc2119">SHOULD</em> be avoided as this can create legal conflicts.
+            Information about licenses and rights <em title="SHOULD" class="rfc2119">SHOULD</em> be provided on the level of Distribution. Information about licenses and rights MAY be provided for a Dataset in addition to but not instead of the information provided for the Distributions of that Dataset. Providing license or rights information for a Dataset that is different from information provided for a Distribution of that Dataset <em title="SHOULD" class="rfc2119">SHOULD</em> be avoided as this can create legal conflicts.
         </p>
 
 
@@ -1604,7 +1604,7 @@
                 <tbody>
                 <tr><td class="prop">Definition:</td><td>A legal document under which the distribution is made available.</td></tr>
                 <tr><td class="prop">Range:</td><td><a href="http://purl.org/dc/terms/LicenseDocument">dct:LicenseDocument</a></td></tr>
-                <tr><td class="prop">Usage note:</td><td>Information about licences and rights <em title="SHOULD" class="rfc2119">SHOULD</em> be provided on the level of Distribution. Information about licences and rights <em title="MAY" class="rfc2119">MAY</em> be provided for a Dataset in addition to but not instead of the information provided for the Distributions of that Dataset. Providing licence or rights information for a Dataset that is different from information provided for a Distribution of that Dataset <em title="SHOULD" class="rfc2119">SHOULD</em> be avoided as this can create legal conflicts. See also guidance at <a href="#license-rights">License and rights statements</a>.</td></tr>
+                <tr><td class="prop">Usage note:</td><td>Information about licenses and rights <em title="SHOULD" class="rfc2119">SHOULD</em> be provided on the level of Distribution. Information about licenses and rights <em title="MAY" class="rfc2119">MAY</em> be provided for a Dataset in addition to but not instead of the information provided for the Distributions of that Dataset. Providing license or rights information for a Dataset that is different from information provided for a Distribution of that Dataset <em title="SHOULD" class="rfc2119">SHOULD</em> be avoided as this can create legal conflicts. See also guidance at <a href="#license-rights">License and rights statements</a>.</td></tr>
 
 		<tr><td class="prop">See also:</td><td><a href="#Property:distribution_rights" title=""> distribution rights</a>,
                     <a href="#Property:catalog_license" title="">catalog license</a></td></tr>
@@ -1622,8 +1622,8 @@
                 <tr><td class="prop">Range:</td><td><a href="http://purl.org/dc/terms/RightsStatement">dct:RightsStatement</a></td></tr>
                 <tr><td class="prop">Usage note:</td><td>dct:license, which is a sub-property of dct:rights, can be used to link
                     a distribution to a license document. However, dct:rights allows linking to a rights statement that
-                    can include licensing information as well as other information that supplements the licence such as attribution.<br/>
-                    Information about licences and rights <em title="SHOULD" class="rfc2119">SHOULD</em> be provided on the level of Distribution. Information about licences and rights MAY be provided for a Dataset in addition to but not instead of the information provided for the Distributions of that Dataset. Providing licence or rights information for a Dataset that is different from information provided for a Distribution of that Dataset <em title="SHOULD" class="rfc2119">SHOULD</em> be avoided as this can create legal conflicts. See also guidance at <a href="#license-rights">License and rights statements</a>.</td></tr>
+                    can include licensing information as well as other information that supplements the license such as attribution.<br/>
+                    Information about licenses and rights <em title="SHOULD" class="rfc2119">SHOULD</em> be provided on the level of Distribution. Information about licenses and rights MAY be provided for a Dataset in addition to but not instead of the information provided for the Distributions of that Dataset. Providing license or rights information for a Dataset that is different from information provided for a Distribution of that Dataset <em title="SHOULD" class="rfc2119">SHOULD</em> be avoided as this can create legal conflicts. See also guidance at <a href="#license-rights">License and rights statements</a>.</td></tr>
                 <tr><td class="prop">See also:</td><td><a href="#Property:distribution_license" title=""> distribution license</a>,
                     <a href="#Property:catalog_rights" title="">catalog rights</a></td></tr>
                 </tbody>
@@ -2514,15 +2514,15 @@ ex:DS987
 	<div class="ednote" title="Original text">
 
 	<p>
-		This specification distinguishes three main situations: one where a statement is associated with the resource that is explicitly declared as a 'licence';
-		a second where the statement is not explicitly declared as a 'licence'; and a third where the conditions are explicitly expressed as an ODRL Policy.
+		This specification distinguishes three main situations: one where a statement is associated with the resource that is explicitly declared as a 'license';
+		a second where the statement is not explicitly declared as a 'license'; and a third where the conditions are explicitly expressed as an ODRL Policy.
 	</p>
 	<p>
 		The following approach is recommended:
 		<ol>
-			<li>use <a href="http://dublincore.org/documents/dcmi-terms/#terms-license">dct:license</a> to refer to well-known licences such as <a href="https://creativecommons.org/share-your-work/licensing-types-examples/">those defined by Creative Commons</a></br>
+			<li>use <a href="http://dublincore.org/documents/dcmi-terms/#terms-license">dct:license</a> to refer to well-known licenses such as <a href="https://creativecommons.org/share-your-work/licensing-types-examples/">those defined by Creative Commons</a></br>
 			The object of dct:license, a <a href="http://dublincore.org/documents/dcmi-terms/#terms-LicenseDocument">dct:LicenseDocument</a>, is "A legal document giving official permission to do something with a Resource."</li>
-			<li>use <a href="http://dublincore.org/documents/dcmi-terms/#terms-rights">dct:rights</a> to refer to rights statements that are not licences, such as copyright statements</br>
+			<li>use <a href="http://dublincore.org/documents/dcmi-terms/#terms-rights">dct:rights</a> to refer to rights statements that are not licenses, such as copyright statements</br>
 			The object of dct:rights, a <a href="http://dublincore.org/documents/dcmi-terms/#terms-RightsStatement">dct:RightsStatement</a>, is "A statement about the intellectual property rights (IPR) held in or over a Resource, a legal document giving official permission to do something with a resource, or a statement about access rights."
 			This is more general than a <a href="http://dublincore.org/documents/dcmi-terms/#terms-LicenseDocument">dct:LicenseDocument</a> and therefore should be used if it the statement contains more general information about rights.</li>
 			<li>use <a href="https://www.w3.org/TR/odrl-vocab/#term-hasPolicy">odrl:hasPolicy</a> for linking to <a href="https://www.w3.org/TR/odrl-vocab/#term-Policy">ODRL policies</a></br>
@@ -3641,7 +3641,7 @@ dcat:servesDataset ga-courts:jc ;
                 - see <a href="https://github.com/w3c/dxwg/issues/502">Issue #502</a>.
             </li>
             <li>
-                A new  section, <a href="#licence-rights">Licence and rights statements</a>, is added to provide guidance and recommendations for the use of <a href="http://dublincore.org/documents/dcmi-terms/#terms-license">dct:license</a>, <a href="http://dublincore.org/documents/dcmi-terms/#terms-accessRights">dct:accessRights</a>,
+                A new  section, <a href="#license-rights">License and rights statements</a>, is added to provide guidance and recommendations for the use of <a href="http://dublincore.org/documents/dcmi-terms/#terms-license">dct:license</a>, <a href="http://dublincore.org/documents/dcmi-terms/#terms-accessRights">dct:accessRights</a>,
 		and <a href="http://dublincore.org/documents/dcmi-terms/#terms-rights">dct:rights</a> in the context of dcat catalogs and distributions.
 		See <a href="https://github.com/w3c/dxwg/issues/114">Issue #114</a> for the background discussion.
             </li>

--- a/dcat/index.html
+++ b/dcat/index.html
@@ -1599,17 +1599,14 @@
         <section id="Property:distribution_license">
             <h4>Property: license</h4>
 
-            <p class="issue" data-number="114">
-                Models for the kind of license or rights representation indicated by the dct:license and dct:rights property are being considered as part of the revision of DCAT. See also <a href="#license-rights">License and rights statements</a>.
-            </p>
-
             <table class="definition">
                 <thead><tr><th>RDF Property:</th><th><a href="http://purl.org/dc/terms/license">dct:license</a></th></tr></thead>
                 <tbody>
                 <tr><td class="prop">Definition:</td><td>A legal document under which the distribution is made available.</td></tr>
                 <tr><td class="prop">Range:</td><td><a href="http://purl.org/dc/terms/LicenseDocument">dct:LicenseDocument</a></td></tr>
-                <tr><td class="prop">Usage note:</td><td>Information about licences and rights <em title="SHOULD" class="rfc2119">SHOULD</em> be provided on the level of Distribution. Information about licences and rights <em title="MAY" class="rfc2119">MAY</em> be provided for a Dataset in addition to but not instead of the information provided for the Distributions of that Dataset. Providing licence or rights information for a Dataset that is different from information provided for a Distribution of that Dataset <em title="SHOULD" class="rfc2119">SHOULD</em> be avoided as this can create legal conflicts.</td></tr>
-                <tr><td class="prop">See also:</td><td><a href="#Property:distribution_rights" title=""> distribution rights</a>,
+                <tr><td class="prop">Usage note:</td><td>Information about licences and rights <em title="SHOULD" class="rfc2119">SHOULD</em> be provided on the level of Distribution. Information about licences and rights <em title="MAY" class="rfc2119">MAY</em> be provided for a Dataset in addition to but not instead of the information provided for the Distributions of that Dataset. Providing licence or rights information for a Dataset that is different from information provided for a Distribution of that Dataset <em title="SHOULD" class="rfc2119">SHOULD</em> be avoided as this can create legal conflicts. See also guidance at <a href="#license-rights">License and rights statements</a>.</td></tr>
+
+		<tr><td class="prop">See also:</td><td><a href="#Property:distribution_rights" title=""> distribution rights</a>,
                     <a href="#Property:catalog_license" title="">catalog license</a></td></tr>
                 </tbody>
             </table>
@@ -1617,10 +1614,6 @@
 
         <section id="Property:distribution_rights">
             <h4>Property: rights</h4>
-
-            <p class="issue" data-number="114">
-                Models for the kind of license or rights representation indicated by the dct:license and dct:rights property are being considered as part of the revision of DCAT. See also <a href="#license-rights">License and rights statements</a>.
-            </p>
 
             <table class="definition">
                 <thead><tr><th>RDF Property:</th><th><a href="http://purl.org/dc/terms/rights">dct:rights</a></th></tr></thead>
@@ -1630,7 +1623,7 @@
                 <tr><td class="prop">Usage note:</td><td>dct:license, which is a sub-property of dct:rights, can be used to link
                     a distribution to a license document. However, dct:rights allows linking to a rights statement that
                     can include licensing information as well as other information that supplements the licence such as attribution.<br/>
-                    Information about licences and rights <em title="SHOULD" class="rfc2119">SHOULD</em> be provided on the level of Distribution. Information about licences and rights MAY be provided for a Dataset in addition to but not instead of the information provided for the Distributions of that Dataset. Providing licence or rights information for a Dataset that is different from information provided for a Distribution of that Dataset <em title="SHOULD" class="rfc2119">SHOULD</em> be avoided as this can create legal conflicts.</td></tr>
+                    Information about licences and rights <em title="SHOULD" class="rfc2119">SHOULD</em> be provided on the level of Distribution. Information about licences and rights MAY be provided for a Dataset in addition to but not instead of the information provided for the Distributions of that Dataset. Providing licence or rights information for a Dataset that is different from information provided for a Distribution of that Dataset <em title="SHOULD" class="rfc2119">SHOULD</em> be avoided as this can create legal conflicts. See also guidance at <a href="#license-rights">License and rights statements</a>.</td></tr>
                 <tr><td class="prop">See also:</td><td><a href="#Property:distribution_license" title=""> distribution license</a>,
                     <a href="#Property:catalog_rights" title="">catalog rights</a></td></tr>
                 </tbody>

--- a/dcat/index.html
+++ b/dcat/index.html
@@ -3641,8 +3641,8 @@ dcat:servesDataset ga-courts:jc ;
                 - see <a href="https://github.com/w3c/dxwg/issues/502">Issue #502</a>.
             </li>
             <li>
-                A new  section, <a href="#licence-rights">Licence and rights statements</a>, is added to provide guidance and recommendations for the use of <a href="http://dublincore.org/documents/dcmi-terms/#terms-license>dct:license>, <a href="http://dublincore.org/documents/dcmi-terms/#terms-accessRights>dct:accessRights>,
-		and <a href="http://dublincore.org/documents/dcmi-terms/#terms-rights>dct:rights> in the context of dacat catalogs and distributions.
+                A new  section, <a href="#licence-rights">Licence and rights statements</a>, is added to provide guidance and recommendations for the use of <a href="http://dublincore.org/documents/dcmi-terms/#terms-license>dct:license</a>, <a href="http://dublincore.org/documents/dcmi-terms/#terms-accessRights>dct:accessRights</a>,
+		and <a href="http://dublincore.org/documents/dcmi-terms/#terms-rights>dct:rights</a> in the context of dcat catalogs and distributions.
 		See <a href="https://github.com/w3c/dxwg/issues/114">Issue #114</a> for the background discussion.
             </li>
 

--- a/dcat/index.html
+++ b/dcat/index.html
@@ -689,10 +689,6 @@
         <section id="Property:catalog_license">
             <h4>Property: license</h4>
 
-            <p class="issue" data-number="114">
-                Models for the kind of license or rights representation indicated by the dct:license and dct:rights property are being considered as part of the revision of DCAT. See also <a href="#license-rights">License and rights statements</a>.
-            </p>
-
             <table class="definition">
                 <thead><tr><th>RDF Property:</th><th><a href="http://purl.org/dc/terms/license">dct:license</a></th></tr></thead>
                 <tbody>
@@ -700,7 +696,9 @@
                     is made available and <strong>not the datasets or services</strong></td></tr>
                 <tr><td class="prop">Range:</td><td><a href="http://purl.org/dc/terms/LicenseDocument">dct:LicenseDocument</a></td></tr>
                 <tr><td class="prop">Usage note:</td><td>If the license of the catalog applies to all of its
-                    datasets and distributions, it <em title="SHOULD" class="rfc2119">SHOULD</em> also be replicated on each distribution.</td></tr>
+                    datasets and distributions, it <em title="SHOULD" class="rfc2119">SHOULD</em> also be replicated on each distribution.
+		    <br>See the additional guidance at <a href="#license-rights">License and rights statements</a>.
+			</td></tr>
                 <tr><td class="prop">See also:</td><td><a href="#Property:catalog_rights">catalog rights</a>,
                     <a href="#Property:distribution_license">distribution license</a></td></tr>
                 </tbody>
@@ -710,10 +708,6 @@
         <section id="Property:catalog_rights">
             <h4>Property: rights</h4>
 
-            <p class="issue" data-number="114">
-                Models for the kind of license or rights representation indicated by the dct:license and dct:rights property are being considered as part of the revision of DCAT. See also <a href="#license-rights">License and rights statements</a>.
-            </p>
-
             <table class="definition">
                 <thead><tr><th>RDF Property:</th><th><a href="http://purl.org/dc/terms/rights">dct:rights</a></th></tr></thead>
                 <tbody>
@@ -721,7 +715,8 @@
                     can be used/reused, but <strong>not the datasets or services</strong> listed.</td></tr>
                 <tr><td class="prop">Range:</td><td><a href="http://purl.org/dc/terms/RightsStatement">dct:RightsStatement</a></td></tr>
                 <tr><td class="prop">Usage note:</td><td>If the rights associated with the catalog applies to all of its
-                    datasets and distributions, it <em title="SHOULD" class="rfc2119">SHOULD</em> also be replicated on each distribution.</td></tr>
+                    datasets and distributions, it <em title="SHOULD" class="rfc2119">SHOULD</em> also be replicated on each distribution.
+			<br>See the additional guidance at <a href="#license-rights">License and rights statements</a>.	</td></tr>
                 <tr><td class="prop">See also:</td><td><a href="#Property:catalog_license">catalog license</a>,
                     <a href="#Property:distribution_rights">distribution rights</a></td></tr>
                 </tbody>


### PR DESCRIPTION
This removes the open issue tag, and updates the change history (having compared with what the 2014 standard said),  I've also standardised on the US spelling for `license`, I hope