### PR TITLE
Editorial revisions

### DIFF
--- a/dcat/index.html
+++ b/dcat/index.html
@@ -45,7 +45,7 @@
     <p>This revised version of DCAT was developed by the <a href="https://www.w3.org/2017/dxwg/">Dataset Exchange Working Group</a> in response to a new set of Use Cases and Requirements [[DCAT-UCR]] submitted on the basis of experience with the DCAT vocabulary from the time of the original version, and new applications not originally considered. A summary of the changes from  [[VOCAB-DCAT-20140116]] can be found at <a href="#changes">Change History</a></p>
 
     <h3 id="external_terms">External terms</h3>
-    <p>DCAT incorporates terms from pre-existing vocabularies where stable terms with appropriate meanings could be found, such as foaf:homepage and dct:title.  Informal summary definitions of the externally-defined terms are included here for convenience, while authoritative definitions are available in the normative references.  Changes to definitions in the references, if any, supersede the summaries given in this specification.  Note that conformance to DCAT (Section 4) concerns usage of only the terms in the DCAT namespace itself, so possible changes to the external definitions will not affect the conformance of DCAT implementations.</p>
+    <p>DCAT incorporates terms from pre-existing vocabularies where stable terms with appropriate meanings could be found, such as <code>foaf:homepage</code> and <code>dct:title</code>.  Informal summary definitions of the externally-defined terms are included here for convenience, while authoritative definitions are available in the normative references.  Changes to definitions in the references, if any, supersede the summaries given in this specification.  Note that conformance to DCAT (Section 4) concerns usage of only the terms in the DCAT namespace itself, so possible changes to the external definitions will not affect the conformance of DCAT implementations.</p>
 
     <h3 id="please_send_comments">Please send comments</h3>
 
@@ -141,7 +141,7 @@
       DCAT is based around eight main classes:</p>
     <ul>
         <li>
-          <code><a href="#Class:Catalog">dcat:Catalog</a></code> represents a catalog, which is a dataset in which each individual item is a metadata record describing some resource; the scope of dcat:catalog is collections of metadata about <b>datasets</b> or <b>data services</b>.
+          <code><a href="#Class:Catalog">dcat:Catalog</a></code> represents a catalog, which is a dataset in which each individual item is a metadata record describing some resource; the scope of <code>dcat:catalog</code> is collections of metadata about <b>datasets</b> or <b>data services</b>.
         </li>
         <li>
           <code><a href="#Class:Resource">dcat:Resource</a></code> represents an individual item description in a catalog.
@@ -283,7 +283,7 @@
   rdfs:label "Transparency Office"&nbsp;;
   .
 </pre></div>
-        <p>The catalog lists each of its datasets via the dcat:dataset property. In the example above, an example dataset was mentioned with the relative URI&nbsp;:dataset-001. A possible description of it using DCAT is shown below:
+        <p>The catalog lists each of its datasets via the <code>dcat:dataset</code> property. In the example above, an example dataset was mentioned with the relative URI&nbsp;:dataset-001. A possible description of it using DCAT is shown below:
         </p>
         <div class="example">
   <pre class="nohighlight turtle" aria-busy="false" aria-live="polite">
@@ -308,7 +308,7 @@
             of the <abbr title="World Wide Web Consortium">W3C</abbr> Data Cube Vocabulary [[VOCAB-DATA-CUBE]] efforts. Additionally, we chose to describe the spatial and temporal coverage of the example dataset using URIs from <a href="http://www.geonames.org/">Geonames</a> and the Interval dataset (originally available from http://reference.data.gov.uk/id/interval) from data.gov.uk, respectively. A contact point is also provided where comments and feedback about the dataset can be sent. Further details about the contact point, such as email address or telephone number, can be provided using vCard [[VCARD-RDF]].</p>
 
         <p>The dataset distribution :dataset-001-csv can be downloaded as a 5Kb CSV file. This information is
-            represented via an RDF resource of type dcat:Distribution.
+            represented via an RDF resource of type <code>dcat:Distribution</code>.
         </p>
         <div class="example">
   <pre class="nohighlight turtle" aria-busy="false" aria-live="polite">
@@ -354,7 +354,7 @@
         <h3>Classifying dataset types</h3>
 
         <p>
-            The type or genre of a dataset can be indicated using the <a href="http://purl.org/dc/terms/type">dct:type</a> property.
+            The type or genre of a dataset can be indicated using the <a href="http://purl.org/dc/terms/type"><code>dct:type</code></a> property.
             It is recommended that the value of the property is be taken from a well governed and broadly recognised set of resource types,
             such as the <a href="http://dublincore.org/documents/dcmi-terms/#section-7">DCMI Type Vocabulary</a>,
             the <a href="https://id.loc.gov/vocabulary/marcgt.html">MARC Genre/Terms Scheme</a>,
@@ -407,7 +407,7 @@
         <h3>Describing catalog records metadata</h3>
         <p>If the catalog publisher decides to keep metadata
             describing its records (i.e. the records containing metadata
-            describing the datasets), dcat:CatalogRecord can be used. For example,
+            describing the datasets), <code>dcat:CatalogRecord</code> can be used. For example,
             while &nbsp;:dataset-001 was issued on 2011-12-05, its description on Imaginary Catalog was added on 2011-12-11. This can be represented by DCAT as in the following:
         </p>
         <div class="example">
@@ -442,7 +442,7 @@
   .
 </pre></div>
 
-        Notice the use of a dcat:landingPage and the definition of the dcat:Distribution instance.
+        Notice the use of a <code>dcat:landingPage</code> and the definition of the <code>dcat:Distribution</code> instance.
     </section>
 
     <section id="a-dataset-available-as-download-and-behind-some-web-page">
@@ -462,8 +462,8 @@
   dcat:mediaType &lt;https://www.iana.org/assignments/media-types/text/csv&gt; ;
   .
 </pre></div>
-        Notice that we used dcat:downloadURL with the downloadable distribution and that the other distribution accessible through the landing page
-        does not have to be defined as a separate dcat:Distribution instance.
+        Notice that we used <code>dcat:downloadURL</code> with the downloadable distribution and that the other distribution accessible through the landing page
+        does not have to be defined as a separate <code>dcat:Distribution</code> instance.
     </section>
 
     <section id="a-dataset-available-from a service">
@@ -591,14 +591,14 @@
             <a href="#Property:catalog_rights">rights</a>,
             <a href="#Property:catalog_themes">themes</a>
         </p>
-        <p>The following properties are inherited from the super-class <a href="http://www.w3.org/ns/dcat#Dataset">dcat:Dataset</a>:
+        <p>The following properties are inherited from the super-class <a href="http://www.w3.org/ns/dcat#Dataset"><code>dcat:Dataset</code></a>:
             <a href="#Property:dataset_distribution">distribution</a>,
             <a href="#Property:dataset_frequency">frequency</a>,
             <a href="#Property:catalog_spatial">spatial/geographic coverage</a>,
             <a href="#Property:dataset_temporal">temporal coverage</a>,
             <a href="#Property:dataset_wasgeneratedby">was generated by</a>
         </p>
-        <p>The following properties are inherited from the super-class <a href="http://www.w3.org/ns/dcat#Resource">dcat:Resource</a>:
+        <p>The following properties are inherited from the super-class <a href="http://www.w3.org/ns/dcat#Resource"><code>dcat:Resource</code></a>:
             <a href="#Property:resource_conformsto">conformsTo</a>,
             <a href="#Property:resource_contact_point">contact point</a>,
             <a href="#Property:resource_creator">creator</a>,
@@ -643,7 +643,7 @@
                 <thead><tr><th>RDF Property:</th><th><a href="http://purl.org/dc/terms/title">dct:title</a></th></tr></thead>
                 <tbody>
                 <tr><td class="prop">Definition:</td><td>A name given to the catalog.</td></tr>
-                <tr><td class="prop">Range:</td><td><a href="http://www.w3.org/2000/01/rdf-schema#Literal">rdfs:Literal</a></td></tr>
+                <tr><td class="prop">Range:</td><td><a href="http://www.w3.org/2000/01/rdf-schema#Literal"><code>rdfs:Literal</code></a></td></tr>
                 </tbody>
             </table>
         </section>
@@ -654,7 +654,7 @@
                 <thead><tr><th>RDF Property:</th><th><a href="http://purl.org/dc/terms/description">dct:description</a></th></tr></thead>
                 <tbody>
                 <tr><td class="prop">Definition:</td><td>A free-text account of the catalog.</td></tr>
-                <tr><td class="prop">Range:</td><td><a href="http://www.w3.org/2000/01/rdf-schema#Literal">rdfs:Literal</a></td></tr>
+                <tr><td class="prop">Range:</td><td><a href="http://www.w3.org/2000/01/rdf-schema#Literal"><code>rdfs:Literal</code></a></td></tr>
                 </tbody>
             </table>
         </section>
@@ -665,7 +665,7 @@
                 <thead><tr><th>RDF Property:</th><th><a href="http://purl.org/dc/terms/issued">dct:issued</a></th></tr></thead>
                 <tbody>
                 <tr><td class="prop">Definition:</td><td>Date of formal issuance (e.g., publication) of the catalog.</td></tr>
-                <tr><td class="prop">Range:</td><td><a href="http://www.w3.org/2000/01/rdf-schema#Literal">rdfs:Literal</a>
+                <tr><td class="prop">Range:</td><td><a href="http://www.w3.org/2000/01/rdf-schema#Literal"><code>rdfs:Literal</code></a>
                     encoded using the relevant ISO 8601 Date and Time compliant string [[!DATETIME]] and typed using the appropriate XML Schema datatype [[XMLSCHEMA11-2]]
                 </td></tr>
                 <tr><td class="prop">See also:</td><td><a href="#Property:resource_release_date" title=""> resource release date</a>, <a href="#Property:record_listing_date" title=""> catalog record listing date</a> and <a href="#Property:distribution_release_date" title=""> distribution release date</a></td></tr>
@@ -679,7 +679,7 @@
                 <thead><tr><th>RDF Property:</th><th><a href="http://purl.org/dc/terms/modified">dct:modified</a></th></tr></thead>
                 <tbody>
                 <tr><td class="prop">Definition:</td><td>Most recent date on which the catalog was changed, updated or modified.</td></tr>
-                <tr><td class="prop">Range:</td><td><a href="http://www.w3.org/2000/01/rdf-schema#Literal">rdfs:Literal</a>
+                <tr><td class="prop">Range:</td><td><a href="http://www.w3.org/2000/01/rdf-schema#Literal"><code>rdfs:Literal</code></a>
                     encoded using the relevant ISO 8601 Date and Time compliant string [[!DATETIME]] and typed using the appropriate XML Schema datatype [[XMLSCHEMA11-2]]
                 </td></tr>
                 <tr><td class="prop">See also:</td><td><a href="#Property:resource_update_date" title=""> resource modification date</a>, <a href="#Property:record_update_date" title=""> catalog record modification date</a> and <a href="#Property:distribution_update_date" title=""> distribution modification date</a></td></tr>
@@ -694,7 +694,7 @@
                 <tbody>
                 <tr><td class="prop">Definition:</td><td>A language of the catalog. This refers to the language used in the textual metadata describing titles, descriptions, etc. of the resources (i.e. datasets and services) in the catalog.</td></tr>
                 <tr><td class="prop">Range:</td><td>
-                    <a href="http://purl.org/dc/terms/LinguisticSystem">dct:LinguisticSystem</a>
+                    <a href="http://purl.org/dc/terms/LinguisticSystem"><code>dct:LinguisticSystem</code></a>
                     <br>
                     Resources defined by the Library of Congress (<a href="http://id.loc.gov/vocabulary/iso639-1.html">1</a>,
                     <a href="http://id.loc.gov/vocabulary/iso639-2.html">2</a>) <em title="SHOULD" class="rfc2119">SHOULD</em> be used.
@@ -711,8 +711,8 @@
                 <thead><tr><th>RDF Property:</th><th><a href="http://xmlns.com/foaf/0.1/homepage">foaf:homepage</a></th></tr></thead>
                 <tbody>
                 <tr><td class="prop">Definition:</td><td>A homepage of the catalog  (a public web document usually available in HTML).</td></tr>
-                <tr><td class="prop">Range:</td><td><a href="http://xmlns.com/foaf/0.1/Document">foaf:Document</a></td></tr>
-                <tr><td class="prop">Usage note:</td><td><a href="http://xmlns.com/foaf/0.1/homepage">foaf:homepage</a> is an inverse functional property (IFP) which means that it <em title="SHOULD" class="rfc2119">SHOULD</em> be unique and precisely identify the catalog. This allows smushing various descriptions of the catalog when different URIs are used.</td></tr>
+                <tr><td class="prop">Range:</td><td><a href="http://xmlns.com/foaf/0.1/Document"><code>foaf:Document</code></a></td></tr>
+                <tr><td class="prop">Usage note:</td><td><a href="http://xmlns.com/foaf/0.1/homepage"><code>foaf:homepage</code></a> is an inverse functional property (IFP) which means that it <em title="SHOULD" class="rfc2119">SHOULD</em> be unique and precisely identify the catalog. This allows smushing various descriptions of the catalog when different URIs are used.</td></tr>
                 </tbody>
             </table>
         </section>
@@ -724,7 +724,7 @@
                 <thead><tr><th>RDF Property:</th><th><a href="http://purl.org/dc/terms/publisher">dct:publisher</a></th></tr></thead>
                 <tbody>
                 <tr><td class="prop">Definition:</td><td>The entity responsible for making the catalog available.</td></tr>
-                <tr><td class="prop">Usage note:</td><td>Resources of type <a href="http://xmlns.com/foaf/0.1/Agent">foaf:Agent</a>
+                <tr><td class="prop">Usage note:</td><td>Resources of type <a href="http://xmlns.com/foaf/0.1/Agent"><code>foaf:Agent</code></a>
                     are recommended as values for this property.</td></tr>
                 <tr><td class="prop">See also:</td><td><a href="#Class:Organization_Person">Class: Organization/Person</a></td></tr>
                 </tbody>
@@ -737,7 +737,7 @@
                 <thead><tr><th>RDF Property:</th><th><a href="http://purl.org/dc/terms/spatial">dct:spatial</a></th></tr></thead>
                 <tbody>
                 <tr><td class="prop">Definition:</td><td>The geographical area covered by the catalog.</td></tr>
-                <tr><td class="prop">Range:</td><td><a href="http://purl.org/dc/terms/Location">dct:Location</a></td></tr>
+                <tr><td class="prop">Range:</td><td><a href="http://purl.org/dc/terms/Location"><code>dct:Location</code></a></td></tr>
                 </tbody>
             </table>
         </section>
@@ -749,8 +749,8 @@
                 <thead><tr><th>RDF Property:</th><th><a href="http://www.w3.org/ns/dcat#themeTaxonomy">dcat:themeTaxonomy</a></th></tr></thead>
                 <tbody>
                 <tr><td class="prop">Definition:</td><td>A knowledge organization system (KOS) used to classify catalog's datasets and services.</td></tr>
-                <tr><td class="prop">Domain:</td><td><a href="http://www.w3.org/ns/dcat#Catalog">dcat:Catalog</a></td></tr>
-                <tr><td class="prop">Range:</td><td><a href="http://www.w3.org/2004/02/skos/core#ConceptScheme">skos:ConceptScheme</a></td></tr>
+                <tr><td class="prop">Domain:</td><td><a href="http://www.w3.org/ns/dcat#Catalog"><code>dcat:Catalog</code></a></td></tr>
+                <tr><td class="prop">Range:</td><td><a href="http://www.w3.org/2004/02/skos/core#ConceptScheme"><code>skos:ConceptScheme</code></a></td></tr>
                 </tbody>
             </table>
         </section>
@@ -763,7 +763,7 @@
                 <tbody>
                 <tr><td class="prop">Definition:</td><td>A legal document under which the <strong>catalog</strong>
                     is made available and <strong>not the datasets or services</strong></td></tr>
-                <tr><td class="prop">Range:</td><td><a href="http://purl.org/dc/terms/LicenseDocument">dct:LicenseDocument</a></td></tr>
+                <tr><td class="prop">Range:</td><td><a href="http://purl.org/dc/terms/LicenseDocument"><code>dct:LicenseDocument</code></a></td></tr>
                 <tr><td class="prop">Usage note:</td><td>If the license of the catalog applies to all of its
                     datasets and distributions, it <em title="SHOULD" class="rfc2119">SHOULD</em> also be replicated on each distribution.
 		    <br>See the additional guidance at <a href="#license-rights">License and rights statements</a>.
@@ -782,7 +782,7 @@
                 <tbody>
                 <tr><td class="prop">Definition:</td><td>Information about the rights under which the <strong>catalog</strong>
                     can be used/reused, but <strong>not the datasets or services</strong> listed.</td></tr>
-                <tr><td class="prop">Range:</td><td><a href="http://purl.org/dc/terms/RightsStatement">dct:RightsStatement</a></td></tr>
+                <tr><td class="prop">Range:</td><td><a href="http://purl.org/dc/terms/RightsStatement"><code>dct:RightsStatement</code></a></td></tr>
                 <tr><td class="prop">Usage note:</td><td>If the rights associated with the catalog applies to all of its
                     datasets and distributions, it <em title="SHOULD" class="rfc2119">SHOULD</em> also be replicated on each distribution.
 			<br>See the additional guidance at <a href="#license-rights">License and rights statements</a>.	</td></tr>
@@ -804,10 +804,10 @@
                 <thead><tr><th>RDF Property:</th><th><a href="http://purl.org/dc/terms/hasPart">dct:hasPart</a></th></tr></thead>
                 <tbody>
                 <tr><td class="prop">Definition:</td><td>An item that is listed in the catalog.</td></tr>
-                <tr><td class="prop">Domain:</td><td><a href="http://www.w3.org/ns/dcat#Catalog">dcat:Catalog</a></td></tr>
-                <tr><td class="prop">Range:</td><td><a href="http://www.w3.org/ns/dcat#Resource">dcat:Resource</a></td></tr>
+                <tr><td class="prop">Domain:</td><td><a href="http://www.w3.org/ns/dcat#Catalog"><code>dcat:Catalog</code></a></td></tr>
+                <tr><td class="prop">Range:</td><td><a href="http://www.w3.org/ns/dcat#Resource"><code>dcat:Resource</code></a></td></tr>
                 <tr><td class="prop">Usage note:</td><td>This is the most general predicate for membership of a catalog. Use of a more specific sub-property is recommended when available. </td></tr>
-                <tr><td class="prop">See also:</td><td>Sub-properties of dct:hasPart in particular <a href="http://www.w3.org/ns/dcat#/dataset">dcat:dataset</a>, <a href="http://www.w3.org/ns/dcat#catalog">dcat:catalog</a>, <a href="http://www.w3.org/ns/dcat#service">dcat:service</a>. </td></tr>
+                <tr><td class="prop">See also:</td><td>Sub-properties of <code>dct:hasPart</code> in particular <a href="http://www.w3.org/ns/dcat#/dataset"><code>dcat:dataset</code></a>, <a href="http://www.w3.org/ns/dcat#catalog"><code>dcat:catalog</code></a>, <a href="http://www.w3.org/ns/dcat#service"><code>dcat:service</code></a>. </td></tr>
                 </tbody>
             </table>
         </section>
@@ -819,9 +819,9 @@
                 <thead><tr><th>RDF Property:</th><th><a href="http://www.w3.org/ns/dcat#dataset">dcat:dataset</a></th></tr></thead>
                 <tbody>
                 <tr><td class="prop">Definition:</td><td>A collection of data that is listed in the catalog.</td></tr>
-                <tr><td class="prop">Sub property of:</td><td><a href="http://purl.org/dc/terms/hasPart">dct:hasPart</a></td></tr>
-                <tr><td class="prop">Domain:</td><td><a href="http://www.w3.org/ns/dcat#Catalog">dcat:Catalog</a></td></tr>
-                <tr><td class="prop">Range:</td><td><a href="http://www.w3.org/ns/dcat#Dataset">dcat:Dataset</a></td></tr>
+                <tr><td class="prop">Sub property of:</td><td><a href="http://purl.org/dc/terms/hasPart"><code>dct:hasPart</code></a></td></tr>
+                <tr><td class="prop">Domain:</td><td><a href="http://www.w3.org/ns/dcat#Catalog"><code>dcat:Catalog</code></a></td></tr>
+                <tr><td class="prop">Range:</td><td><a href="http://www.w3.org/ns/dcat#Dataset"><code>dcat:Dataset</code></a></td></tr>
                 </tbody>
             </table>
         </section>
@@ -837,9 +837,9 @@
                 <thead><tr><th>RDF Property:</th><th><a href="http://www.w3.org/ns/dcat#service">dcat:service</a></th></tr></thead>
                 <tbody>
                 <tr><td class="prop">Definition:</td><td>A site or end-point that is listed in the catalog.</td></tr>
-                <tr><td class="prop">Sub property of:</td><td><a href="http://purl.org/dc/terms/hasPart">dct:hasPart</a></td></tr>
-                <tr><td class="prop">Domain:</td><td><a href="http://www.w3.org/ns/dcat#Catalog">dcat:Catalog</a></td></tr>
-                <tr><td class="prop">Range:</td><td><a href="http://www.w3.org/ns/dcat#Dataset">dcat:DataService</a></td></tr>
+                <tr><td class="prop">Sub property of:</td><td><a href="http://purl.org/dc/terms/hasPart"><code>dct:hasPart</code></a></td></tr>
+                <tr><td class="prop">Domain:</td><td><a href="http://www.w3.org/ns/dcat#Catalog"><code>dcat:Catalog</code></a></td></tr>
+                <tr><td class="prop">Range:</td><td><a href="http://www.w3.org/ns/dcat#Dataset"><code>dcat:DataService</code></a></td></tr>
                 </tbody>
             </table>
         </section>
@@ -855,9 +855,9 @@
                 <thead><tr><th>RDF Property:</th><th><a href="http://www.w3.org/ns/dcat#catalog">dcat:catalog</a></th></tr></thead>
                 <tbody>
                 <tr><td class="prop">Definition:</td><td>A catalog whose contents are of interest in the context of this catalog</td></tr>
-                <tr><td class="prop">Sub property of:</td><td><a href="http://purl.org/dc/terms/hasPart">dct:dataset</a></td></tr>
-                <tr><td class="prop">Domain:</td><td><a href="http://www.w3.org/ns/dcat#Catalog">dcat:Catalog</a></td></tr>
-                <tr><td class="prop">Range:</td><td><a href="http://www.w3.org/ns/dcat#Dataset">dcat:Catalog</a></td></tr>
+                <tr><td class="prop">Sub property of:</td><td><a href="http://purl.org/dc/terms/hasPart"><code>dct:dataset</code></a></td></tr>
+                <tr><td class="prop">Domain:</td><td><a href="http://www.w3.org/ns/dcat#Catalog"><code>dcat:Catalog</code></a></td></tr>
+                <tr><td class="prop">Range:</td><td><a href="http://www.w3.org/ns/dcat#Dataset"><code>dcat:Catalog</code></a></td></tr>
                 </tbody>
             </table>
         </section>
@@ -869,8 +869,8 @@
                 <thead><tr><th>RDF Property:</th><th><a href="http://www.w3.org/ns/dcat#record">dcat:record</a></th></tr></thead>
                 <tbody>
                 <tr><td class="prop">Definition:</td><td>A record describing the registration of a single dataset or dataservice that is part of the catalog.</td></tr>
-                <tr><td class="prop">Domain:</td><td><a href="http://www.w3.org/ns/dcat#Catalog">dcat:Catalog</a></td></tr>
-                <tr><td class="prop">Range:</td><td><a href="http://www.w3.org/ns/dcat#CatalogRecord">dcat:CatalogRecord</a></td></tr>
+                <tr><td class="prop">Domain:</td><td><a href="http://www.w3.org/ns/dcat#Catalog"><code>dcat:Catalog</code></a></td></tr>
+                <tr><td class="prop">Range:</td><td><a href="http://www.w3.org/ns/dcat#CatalogRecord"><code>dcat:CatalogRecord</code></a></td></tr>
                 </tbody>
             </table>
         </section>
@@ -921,17 +921,17 @@
             <tbody>
             <tr><td class="prop">Definition:</td><td>Resource published or curated by a single agent.</td></tr>
             <tr><td class="prop">Usage note:</td><td>The class of all catalogued resources, the superclass of
-            <a href="#Class:Dataset">dcat:Dataset</a>, <a href="#Class:Data_Service">dcat:DataService</a>, <a href="#Class:Catalog">dcat:Catalog</a> and any other member of a <a href="#Class:Catalog">dcat:Catalog</a>.
+            <a href="#Class:Dataset"><code>dcat:Dataset</code></a>, <a href="#Class:Data_Service"><code>dcat:DataService</code></a>, <a href="#Class:Catalog"><code>dcat:Catalog</code></a> and any other member of a <a href="#Class:Catalog"><code>dcat:Catalog</code></a>.
             This class carries properties common to all catalogued resources, including datasets and data services.
 
             It is strongly recommended to use a more specific sub-class when available.</td></tr>
-            <tr><td class="prop">Usage note:</td><td><code><a href="#Class:Resource">dcat:Resource</a></code> is an extension point that enables the definition of any kind of catalog. Additional subclasses may be defined in a DCAT application profile or other DCAT application for catalogs of other kinds of resources</td></tr>
+            <tr><td class="prop">Usage note:</td><td><code><a href="#Class:Resource"><code>dcat:Resource</code></a></code> is an extension point that enables the definition of any kind of catalog. Additional subclasses may be defined in a DCAT application profile or other DCAT application for catalogs of other kinds of resources</td></tr>
             <tr><td class="prop">See also:</td><td><a href="#Class:Catalog_Record" title="">Catalog record</a></td></tr>
             </tbody>
         </table>
 
         <p class="note">
-            The class <a href="#Class:Resource">dcat:Resource</a> has been added to the DCAT vocabulary in this revision.
+            The class <a href="#Class:Resource"><code>dcat:Resource</code></a> has been added to the DCAT vocabulary in this revision.
         </p>
 
         <section id="Property:resource_title">
@@ -940,7 +940,7 @@
                 <thead><tr><th>RDF Property:</th><th><a href="http://purl.org/dc/terms/title">dct:title</a></th></tr></thead>
                 <tbody>
                 <tr><td class="prop">Definition:</td><td>A name given to the item.</td></tr>
-                <tr><td class="prop">Range:</td><td><a href="http://www.w3.org/2000/01/rdf-schema#Literal">rdfs:Literal</a></td></tr>
+                <tr><td class="prop">Range:</td><td><a href="http://www.w3.org/2000/01/rdf-schema#Literal"><code>rdfs:Literal</code></a></td></tr>
                 </tbody>
             </table>
         </section>
@@ -951,7 +951,7 @@
                 <thead><tr><th>RDF Property:</th><th><a href="http://purl.org/dc/terms/description">dct:description</a></th></tr></thead>
                 <tbody>
                 <tr><td class="prop">Definition:</td><td>free-text account of the item.</td></tr>
-                <tr><td class="prop">Range:</td><td><a href="http://www.w3.org/2000/01/rdf-schema#Literal">rdfs:Literal</a></td></tr>
+                <tr><td class="prop">Range:</td><td><a href="http://www.w3.org/2000/01/rdf-schema#Literal"><code>rdfs:Literal</code></a></td></tr>
                 </tbody>
             </table>
         </section>
@@ -961,7 +961,7 @@
 
             <p class="note">
                 New property added in this revision of DCAT, specifically added when considering the data citation requirement and
-                added to the <code><a href="#Class:Resource">dcat:Resource</a></code> class, as the Dataset superclass.
+                added to the <code><a href="#Class:Resource"><code>dcat:Resource</code></a></code> class, as the Dataset superclass.
             </p>
 
 
@@ -969,8 +969,8 @@
                 <thead><tr><th>RDF Property:</th><th><a href="http://purl.org/dc/terms/creator">dct:creator</a></th></tr></thead>
                 <tbody>
                 <tr><td class="prop">Definition:</td><td>The entity responsible for producing the resource.</td></tr>
-                <tr><td class="prop">Range:</td><td><a href="http://xmlns.com/foaf/0.1/Agent">foaf:Agent</a></td></tr>
-                <tr><td class="prop">Usage note:</td><td>Resources of type <a href="http://xmlns.com/foaf/0.1/Agent">foaf:Agent</a>
+                <tr><td class="prop">Range:</td><td><a href="http://xmlns.com/foaf/0.1/Agent"><code>foaf:Agent</code></a></td></tr>
+                <tr><td class="prop">Usage note:</td><td>Resources of type <a href="http://xmlns.com/foaf/0.1/Agent"><code>foaf:Agent</code></a>
                     are recommended as values for this property.</td></tr>
                 <tr><td class="prop">See also:</td><td><a href="#Class:Organization_Person">Class: Organization/Person</a></td></tr>
                 </tbody>
@@ -984,7 +984,7 @@
                 <thead><tr><th>RDF Property:</th><th><a href="http://purl.org/dc/terms/issued">dct:issued</a></th></tr></thead>
                 <tbody>
                 <tr><td class="prop">Definition:</td><td>Date of formal issuance (e.g., publication) of the item.</td></tr>
-                <tr><td class="prop">Range:</td><td><a href="http://www.w3.org/2000/01/rdf-schema#Literal">rdfs:Literal</a>
+                <tr><td class="prop">Range:</td><td><a href="http://www.w3.org/2000/01/rdf-schema#Literal"><code>rdfs:Literal</code></a>
                     encoded using the relevant ISO 8601 Date and Time compliant string [[!DATETIME]] and typed using the appropriate XML Schema datatype [[XMLSCHEMA11-2]]
                 </td></tr>
                 <tr><td class="prop">Usage note:</td><td>This property <em title="SHOULD" class="rfc2119">SHOULD</em> be set using the first known date of issuance.</td></tr>
@@ -998,7 +998,7 @@
                 <thead><tr><th>RDF Property:</th><th><a href="http://purl.org/dc/terms/modified">dct:modified</a></th></tr></thead>
                 <tbody>
                 <tr><td class="prop">Definition:</td><td>Most recent date on which the item was changed, updated or modified.</td></tr>
-                <tr><td class="prop">Range:</td><td><a href="http://www.w3.org/2000/01/rdf-schema#Literal">rdfs:Literal</a>
+                <tr><td class="prop">Range:</td><td><a href="http://www.w3.org/2000/01/rdf-schema#Literal"><code>rdfs:Literal</code></a>
                     encoded using the relevant ISO 8601 Date and Time compliant string [[!DATETIME]] and typed using the appropriate XML Schema datatype [[XMLSCHEMA11-2]]
                 </td></tr>
                 <tr><td class="prop">Usage note:</td><td>The value of this property indicates a change to the actual item, not a change to the catalog record. An absent value <em title="MAY" class="rfc2119">MAY</em> indicate that the item has never changed after its initial publication, or that the date of last modification is not known, or that the item is continuously updated.</td></tr>
@@ -1013,14 +1013,14 @@
                 <thead><tr><th>RDF Property:</th><th><a href="http://purl.org/dc/terms/language">dct:language</a></th></tr></thead>
                 <tbody>
                 <tr><td class="prop">Definition:</td><td>The language of the item.</td></tr>
-                <tr><td class="prop">Range:</td><td><a href="http://purl.org/dc/terms/LinguisticSystem">dct:LinguisticSystem</a>
+                <tr><td class="prop">Range:</td><td><a href="http://purl.org/dc/terms/LinguisticSystem"><code>dct:LinguisticSystem</code></a>
                     <br>
                     Resources defined by the Library of Congress (<a href="http://id.loc.gov/vocabulary/iso639-1.html">1</a>,
                     <a href="http://id.loc.gov/vocabulary/iso639-2.html">2</a>) <em title="SHOULD" class="rfc2119">SHOULD</em> be used.
                     <br>
                     If a ISO 639-1 (two-letter) code is defined for language, then its corresponding IRI <em title="SHOULD" class="rfc2119">SHOULD</em> be used; if no ISO 639-1 code is defined, then IRI corresponding to the ISO 639-2 (three-letter) code <em title="SHOULD" class="rfc2119">SHOULD</em> be used.</td></tr>
                 <tr><td class="prop">Usage note:</td><td>This overrides the value of the <a href="#Property:catalog_language">catalog language</a> in case of conflict.
-                    If the item is available in multiple languages, use multiple values for this property. If each language is available separately for a dataset, define an instance of dcat:Distribution for each language and describe the specific language of each distribution using dct:language (i.e. the dataset will have multiple dct:language values and each distribution will have one of these languages as value of its dct:language property).</td></tr>
+                    If the item is available in multiple languages, use multiple values for this property. If each language is available separately for a dataset, define an instance of <code>dcat:Distribution</code> for each language and describe the specific language of each distribution using <code>dct:language</code> (i.e. the dataset will have multiple <code>dct:language</code> values and each distribution will have one of these languages as value of its <code>dct:language</code> property).</td></tr>
                 </tbody>
             </table>
         </section>
@@ -1036,7 +1036,7 @@
                 <thead><tr><th>RDF Property:</th><th><a href="http://purl.org/dc/terms/publisher">dct:publisher</a></th></tr></thead>
                 <tbody>
                 <tr><td class="prop">Definition:</td><td>The entity responsible for making the item available.</td></tr>
-                <tr><td class="prop">Usage note:</td><td>Resources of type <a href="http://xmlns.com/foaf/0.1/Agent">foaf:Agent</a>
+                <tr><td class="prop">Usage note:</td><td>Resources of type <a href="http://xmlns.com/foaf/0.1/Agent"><code>foaf:Agent</code></a>
                     are recommended as values for this property.</td></tr>
                 <tr><td class="prop">See also:</td><td><a href="#Class:Organization_Person">Class: Organization/Person</a></td></tr>
                 </tbody>
@@ -1051,7 +1051,7 @@
                 <thead><tr><th>RDF Property:</th><th><a href="http://purl.org/dc/terms/identifier">dct:identifier</a></th></tr></thead>
                 <tbody>
                 <tr><td class="prop">Definition:</td><td>A unique identifier of the item.</td></tr>
-                <tr><td class="prop">Range:</td><td><a href="http://www.w3.org/2000/01/rdf-schema#Literal">rdfs:Literal</a></td></tr>
+                <tr><td class="prop">Range:</td><td><a href="http://www.w3.org/2000/01/rdf-schema#Literal"><code>rdfs:Literal</code></a></td></tr>
                 <tr><td class="prop">Usage note:</td><td>The identifier might be used as part of the URI of the item, but still having it represented explicitly is useful.</td></tr>
                 </tbody>
             </table>
@@ -1061,7 +1061,7 @@
             <h4>Property: theme/category</h4>
 
             <p class="note">
-                In DCAT 2014 [[VOCAB-DCAT-20140116]] the domain of dcat:theme was dcat:Dataset,
+                In DCAT 2014 [[VOCAB-DCAT-20140116]] the domain of <code>dcat:theme</code> was <code>dcat:Dataset</code>,
                 which limited use of this property in other contexts. The domain has been relaxed in this revision -
                 see <a href="https://github.com/w3c/dxwg/issues/123">Issue #123</a>.
             </p>
@@ -1070,9 +1070,9 @@
                 <thead><tr><th>RDF Property:</th><th><a href="http://www.w3.org/ns/dcat#theme">dcat:theme</a></th></tr></thead>
                 <tbody>
                 <tr><td class="prop">Definition:</td><td>A main category of the resource. A resource can have multiple themes.</td></tr>
-                <tr><td class="prop">Sub property of:</td><td><a href="http://purl.org/dc/terms/subject">dct:subject</a></td></tr>
-                <tr><td class="prop">Range:</td><td><a href="http://www.w3.org/2004/02/skos/core#Concept">skos:Concept</a></td></tr>
-                <tr><td class="prop">Usage note:</td><td>The set of <a href="http://www.w3.org/2004/02/skos/core#Concept">skos:Concept</a>s used to categorize the resources are organized in a <a href="http://www.w3.org/2004/02/skos/core#ConceptScheme">skos:ConceptScheme</a> describing all the categories and their relations in the catalog.</td></tr>
+                <tr><td class="prop">Sub property of:</td><td><a href="http://purl.org/dc/terms/subject"><code>dct:subject</code></a></td></tr>
+                <tr><td class="prop">Range:</td><td><a href="http://www.w3.org/2004/02/skos/core#Concept"><code>skos:Concept</code></a></td></tr>
+                <tr><td class="prop">Usage note:</td><td>The set of <a href="http://www.w3.org/2004/02/skos/core#Concept"><code>skos:Concept</code></a>s used to categorize the resources are organized in a <a href="http://www.w3.org/2004/02/skos/core#ConceptScheme"><code>skos:ConceptScheme</code></a> describing all the categories and their relations in the catalog.</td></tr>
                 <tr><td>See also:</td><td><a href="#Property:catalog_themes">catalog themes</a></td></tr>
                 </tbody>
             </table>
@@ -1089,8 +1089,8 @@
               <thead><tr><th>RDF Property:</th><th><a href="http://purl.org/dc/terms/type">dct:type</a></th></tr></thead>
               <tbody>
                 <tr><td class="prop">Definition:</td><td>The nature or genre of the resource.</td></tr>
-                <tr><td class="prop">Sub property of:</td><td><a href="http://purl.org/dc/elements/1.1/type">dc:type</a></td></tr>
-                <tr><td class="prop">Range:</td><td><a href="http://www.w3.org/2000/01/rdf-schema#Class">rdfs:Class</a></td></tr>
+                <tr><td class="prop">Sub property of:</td><td><a href="http://purl.org/dc/elements/1.1/type"><code>dc:type</code></a></td></tr>
+                <tr><td class="prop">Range:</td><td><a href="http://www.w3.org/2000/01/rdf-schema#Class"><code>rdfs:Class</code></a></td></tr>
                 <tr><td class="prop">Usage note:</td><td>The value <em title="SHOULD" class="rfc2119">SHOULD</em> be taken from a well governed and broadly recognised controlled vocabulary, such as:
                     <ol>
                         <li><a href="http://dublincore.org/documents/dcmi-terms/#section-7">DCMI Type vocabulary</a> [[DCTERMS]]</li>
@@ -1100,7 +1100,7 @@
                         <li><a href="http://id.loc.gov/vocabulary/marcgt.html">MARC intellectual resource types</a></li>
                   </ol>
                 Some members of these controlled vocabularies are not strictly suitable for datasets or data services (e.g. DCMI Type <i>Event</i>, <i>PhysicalObject</i>; ISO 19115 <i>CollectionHardware</i>, <i>CollectionSession</i>, <i>Initiative</i>, <i>Sample</i>, <i>Repository</i>), but might be used in the context of other kinds of catalogs defined in DCAT profiles or applications. </td></tr>
-                <tr><td class="prop">Usage note:</td><td>To describe the file format, physical medium, or dimensions of the resource, use the <a href="http://purl.org/dc/terms/format">dct:format element</a>.</td></tr>
+                <tr><td class="prop">Usage note:</td><td>To describe the file format, physical medium, or dimensions of the resource, use the <a href="http://purl.org/dc/terms/format"><code>dct:format</code></a> element.</td></tr>
               </tbody>
             </table>
         </section>
@@ -1112,40 +1112,40 @@
                 <thead><tr><th>RDF Property:</th><th><a href="http://purl.org/dc/terms/relation">dct:relation</a></th></tr></thead>
                 <tbody>
                 <tr><td class="prop">Definition:</td><td>A resource with an unspecified relationship to the catalogued item.</td></tr>
-                <tr><td class="prop">Usage note:</td><td><a href="http://purl.org/dc/terms/relation">dct:relation</a> <em title="SHOULD" class="rfc2119">SHOULD</em> be used where the nature of the relationship between a catalogued item and related resources is not known. A more specific sub-property <em title="SHOULD" class="rfc2119">SHOULD</em> be used if the nature of the relationship of the link is known.
-                    The property <a href="http://www.w3.org/ns/dcat#distribution">dcat:distribution</a> <em title="SHOULD" class="rfc2119">SHOULD</em> be used to link from a <a href="http://www.w3.org/ns/dcat#Dataset">dcat:Dataset</a> to a representation of the dataset, described as a <a href="http://www.w3.org/ns/dcat#Distribution">dcat:Distribution</a></td></tr>
-                <tr><td class="prop">See also:</td><td>Sub-properties of dct:relation in particular
-                    <a href="http://www.w3.org/ns/dcat#distribution">dcat:distribution</a>,
-                    <a href="http://purl.org/dc/terms/hasPart">dct:hasPart</a>,
+                <tr><td class="prop">Usage note:</td><td><a href="http://purl.org/dc/terms/relation"><code>dct:relation</code></a> <em title="SHOULD" class="rfc2119">SHOULD</em> be used where the nature of the relationship between a catalogued item and related resources is not known. A more specific sub-property <em title="SHOULD" class="rfc2119">SHOULD</em> be used if the nature of the relationship of the link is known.
+                    The property <a href="http://www.w3.org/ns/dcat#distribution"><code>dcat:distribution</code></a> <em title="SHOULD" class="rfc2119">SHOULD</em> be used to link from a <a href="http://www.w3.org/ns/dcat#Dataset"><code>dcat:Dataset</code></a> to a representation of the dataset, described as a <a href="http://www.w3.org/ns/dcat#Distribution"><code>dcat:Distribution</code></a></td></tr>
+                <tr><td class="prop">See also:</td><td>Sub-properties of <code>dct:relation</code> in particular
+                    <a href="http://www.w3.org/ns/dcat#distribution"><code>dcat:distribution</code></a>,
+                    <a href="http://purl.org/dc/terms/hasPart"><code>dct:hasPart</code></a>,
                     (and its sub-properties
-                    <a href="http://www.w3.org/ns/dcat#catalog">dcat:catalog</a>,
-                    <a href="http://www.w3.org/ns/dcat#dataset">dcat:dataset</a>,
-                    <a href="http://www.w3.org/ns/dcat#service">dcat:service</a>
+                    <a href="http://www.w3.org/ns/dcat#catalog"><code>dcat:catalog</code></a>,
+                    <a href="http://www.w3.org/ns/dcat#dataset"><code>dcat:dataset</code></a>,
+                    <a href="http://www.w3.org/ns/dcat#service"><code>dcat:service</code></a>
                     ),
-                    <a href="http://purl.org/dc/terms/isPartOf">dct:isPartOf</a>,
-                    <a href="http://purl.org/dc/terms/conformsTo">dct:conformsTo</a>,
-                    <a href="http://purl.org/dc/terms/isFormatOf">dct:isFormatOf</a>,
-                    <a href="http://purl.org/dc/terms/hasFormat">dct:hasFormat</a>,
-                    <a href="http://purl.org/dc/terms/isVersionOf">dct:isVersionOf</a>,
-                    <a href="http://purl.org/dc/terms/hasVersion">dct:hasVersion</a>,
-                    <a href="http://purl.org/dc/terms/replaces">dct:replaces</a>,
-                    <a href="http://purl.org/dc/terms/isReplacedBy">dct:isReplacedBy</a>,
-                    <a href="http://purl.org/dc/terms/references">dct:references</a>,
-                    <a href="http://purl.org/dc/terms/isReferencedBy">dct:isReferencedBy</a>,
-                    <a href="http://purl.org/dc/terms/requires">dct:requires</a>,
-                    <a href="http://purl.org/dc/terms/isRequiredBy">dct:isRequiredBy</a></td>
+                    <a href="http://purl.org/dc/terms/isPartOf"><code>dct:isPartOf</code></a>,
+                    <a href="http://purl.org/dc/terms/conformsTo"><code>dct:conformsTo</code></a>,
+                    <a href="http://purl.org/dc/terms/isFormatOf"><code>dct:isFormatOf</code></a>,
+                    <a href="http://purl.org/dc/terms/hasFormat"><code>dct:hasFormat</code></a>,
+                    <a href="http://purl.org/dc/terms/isVersionOf"><code>dct:isVersionOf</code></a>,
+                    <a href="http://purl.org/dc/terms/hasVersion"><code>dct:hasVersion</code></a>,
+                    <a href="http://purl.org/dc/terms/replaces"><code>dct:replaces</code></a>,
+                    <a href="http://purl.org/dc/terms/isReplacedBy"><code>dct:isReplacedBy</code></a>,
+                    <a href="http://purl.org/dc/terms/references"><code>dct:references</code></a>,
+                    <a href="http://purl.org/dc/terms/isReferencedBy"><code>dct:isReferencedBy</code></a>,
+                    <a href="http://purl.org/dc/terms/requires"><code>dct:requires</code></a>,
+                    <a href="http://purl.org/dc/terms/isRequiredBy"><code>dct:isRequiredBy</code></a></td>
                 </tr>
                 </tbody>
             </table>
 
             <p>
                 Many existing and legacy catalogues do not distinguish between dataset components, representations, documentation, schemata and other resources that are lumped together as part of a dataset.
-                <a href="http://purl.org/dc/terms/relation">dct:relation</a> is a super-property of a number of more specific properties which express more precise relationships, so use of dct:relation is not inconsistent with a subsequent reclassification with more specific semantics, though the more specialized sub-properties <em title="SHOULD" class="rfc2119">SHOULD</em> be used to link a dataset to component and supplementary resources if possible.
+                <a href="http://purl.org/dc/terms/relation"><code>dct:relation</code></a> is a super-property of a number of more specific properties which express more precise relationships, so use of <code>dct:relation</code> is not inconsistent with a subsequent reclassification with more specific semantics, though the more specialized sub-properties <em title="SHOULD" class="rfc2119">SHOULD</em> be used to link a dataset to component and supplementary resources if possible.
             </p>
 
             <p class="issue" data-number="81">
                 The general need to describe relationships between datasets has been identified as a requirement to be satisfied in the revision of DCAT.
-                Guidance on the use of more specific relationship predicates is required, particularly in the context of the dcat:Dataset sub-class.
+                Guidance on the use of more specific relationship predicates is required, particularly in the context of the <code>dcat:Dataset</code> sub-class.
             </p>
 
             <p class="note">
@@ -1160,14 +1160,14 @@
                 <thead><tr><th>RDF Property:</th><th><a href="http://purl.org/dc/terms/conformsTo">dct:conformsTo</a></th></tr></thead>
                 <tbody>
                 <tr><td class="prop">Definition:</td><td>An established standard to which the described catalogued resource conforms.</td></tr>
-                <tr><td class="prop">Range:</td><td><a href="http://purl.org/dc/terms/Standard">dct:Standard</a> (A basis for comparison; a reference point against which other things can be evaluated.)</td></tr>
+                <tr><td class="prop">Range:</td><td><a href="http://purl.org/dc/terms/Standard"><code>dct:Standard</code></a> (A basis for comparison; a reference point against which other things can be evaluated.)</td></tr>
                 <tr><td class="prop">Usage note:</td><td>This property <em title="SHOULD" class="rfc2119">SHOULD</em> be used to indicate the model, schema, ontology, view or profile that the catalogued resource content conforms to. </td></tr>
                 </tbody>
             </table>
         </section>
 
         <p class="note">
-            <a href="http://purl.org/dc/terms/Standard">dct:Standard</a> is defined as "A basis for comparison; a reference point against which other things can be evaluated." The target resource is not restricted to formal standards issued by bodies like ISO and W3C. In this context, it is any resource that specifies one or more aspects of the catalogued resource content, for example schema, semantics, syntax, usage guidelines, file format, or specific serialization. The meaning of conformance is determined by provisions in the target standard.
+            <a href="http://purl.org/dc/terms/Standard"><code>dct:Standard</code></a> is defined as "A basis for comparison; a reference point against which other things can be evaluated." The target resource is not restricted to formal standards issued by bodies like ISO and W3C. In this context, it is any resource that specifies one or more aspects of the catalogued resource content, for example schema, semantics, syntax, usage guidelines, file format, or specific serialization. The meaning of conformance is determined by provisions in the target standard.
         </p>
 
 
@@ -1176,14 +1176,14 @@
             <h4>Property: keyword/tag</h4>
 
             <p class="note">
-                In DCAT 2014 [[VOCAB-DCAT-20140116]] the domain of dcat:keyword was dcat:Dataset, which limited use of this property in other contexts. The domain has been relaxed in this revision - see <a href="https://github.com/w3c/dxwg/issues/121">Issue #121</a>.
+                In DCAT 2014 [[VOCAB-DCAT-20140116]] the domain of <code>dcat:keyword</code> was <code>dcat:Dataset</code>, which limited use of this property in other contexts. The domain has been relaxed in this revision - see <a href="https://github.com/w3c/dxwg/issues/121">Issue #121</a>.
             </p>
 
             <table class="definition">
                 <thead><tr><th>RDF Property:</th><th><a href="http://www.w3.org/ns/dcat#keyword">dcat:keyword</a></th></tr></thead>
                 <tbody>
                 <tr><td class="prop">Definition:</td><td>A keyword or tag describing the resource.</td></tr>
-                <tr><td class="prop">Range:</td><td><a href="http://www.w3.org/2000/01/rdf-schema#Literal">rdfs:Literal</a></td></tr>
+                <tr><td class="prop">Range:</td><td><a href="http://www.w3.org/2000/01/rdf-schema#Literal"><code>rdfs:Literal</code></a></td></tr>
                 </tbody>
             </table>
         </section>
@@ -1192,18 +1192,18 @@
             <h4>Property: contact point</h4>
 
             <p class="note">
-                In DCAT 2014 [[VOCAB-DCAT-20140116]] the domain of dcat:contactPoint was dcat:Dataset, which limited use of this property in other contexts. The domain has been relaxed in this revision - see <a href="https://github.com/w3c/dxwg/issues/95">Issue #95</a>.
+                In DCAT 2014 [[VOCAB-DCAT-20140116]] the domain of <code>dcat:contactPoint</code> was <code>dcat:Dataset</code>, which limited use of this property in other contexts. The domain has been relaxed in this revision - see <a href="https://github.com/w3c/dxwg/issues/95">Issue #95</a>.
             </p>
 
             <p class="issue" data-number="109">
-                The axiomatization of dcat:contactPoint is being re-evaluated as part of the revision of DCAT.
+                The axiomatization of <code>dcat:contactPoint</code> is being re-evaluated as part of the revision of DCAT.
             </p>
 
             <table class="definition">
                 <thead><tr><th>RDF Property:</th><th><a href="http://www.w3.org/ns/dcat#contactPoint">dcat:contactPoint</a></th></tr></thead>
                 <tbody>
                 <tr><td class="prop">Definition:</td><td>Relevant contact information (provided using vCard [[VCARD-RDF]]) for the catalogued resource.</td></tr>
-                <tr><td class="prop">Range:</td><td><a href="http://www.w3.org/2006/vcard/ns#Kind">vcard:Kind</a></td></tr>
+                <tr><td class="prop">Range:</td><td><a href="http://www.w3.org/2006/vcard/ns#Kind"><code>vcard:Kind</code></a></td></tr>
                 </tbody>
             </table>
         </section>
@@ -1212,18 +1212,18 @@
             <h4>Property: landing page</h4>
 
             <p class="note">
-                In DCAT 2014 [[VOCAB-DCAT-20140116]] the domain of dcat:landingPage was dcat:Dataset, which limited use of this property in other contexts. The domain has been relaxed in this revision - see <a href="https://github.com/w3c/dxwg/issues/122">Issue #122</a>.
+                In DCAT 2014 [[VOCAB-DCAT-20140116]] the domain of <code>dcat:landingPage</code> was <code>dcat:Dataset</code>, which limited use of this property in other contexts. The domain has been relaxed in this revision - see <a href="https://github.com/w3c/dxwg/issues/122">Issue #122</a>.
             </p>
 
             <table class="definition">
                 <thead><tr><th>RDF Property:</th><th><a href="http://www.w3.org/ns/dcat#landingPage">dcat:landingPage</a></th></tr></thead>
                 <tbody>
                 <tr><td class="prop">Definition:</td><td>A Web page that can be navigated to in a Web browser to gain access to the catalog, a dataset, its distributions and/or additional information.</td></tr>
-                <tr><td class="prop">Sub property of:</td><td><a href="http://xmlns.com/foaf/0.1/page">foaf:page</a></td></tr>
-                <tr><td class="prop">Range:</td><td><a href="http://xmlns.com/foaf/0.1/Document">foaf:Document</a></td></tr>
+                <tr><td class="prop">Sub property of:</td><td><a href="http://xmlns.com/foaf/0.1/page"><code>foaf:page</code></a></td></tr>
+                <tr><td class="prop">Range:</td><td><a href="http://xmlns.com/foaf/0.1/Document"><code>foaf:Document</code></a></td></tr>
                 <tr><td class="prop">Usage note:</td><td>
                     If the distribution(s) are accessible only through a landing page
-                    (i.e. direct download URLs are not known), then the landing page link <em title="SHOULD" class="rfc2119">SHOULD</em> be duplicated as dcat:accessURL on a distribution. (see <a href="#example-landing-page"></a>)
+                    (i.e. direct download URLs are not known), then the landing page link <em title="SHOULD" class="rfc2119">SHOULD</em> be duplicated as <code>dcat:accessURL</code> on a distribution. (see <a href="#example-landing-page"></a>)
                 </td></tr>
                 </tbody>
             </table>
@@ -1253,7 +1253,7 @@
         <table class="definition">
             <thead><tr><th>RDF Class:</th><th><a href="http://www.w3.org/ns/dcat#CatalogRecord">dcat:CatalogRecord</a></th></tr></thead>
             <tbody>
-            <tr><td class="prop">Definition:</td><td>A record in a catalog, describing the registration of a single <a href="http://www.w3.org/ns/dcat#dcat:Resource">dcat:Resource</a>.</td></tr>
+            <tr><td class="prop">Definition:</td><td>A record in a catalog, describing the registration of a single <a href="http://www.w3.org/ns/dcat#dcat:Resource"><code>dcat:Resource</code></a>.</td></tr>
             <tr><td class="prop">Usage note</td><td>This class is optional and not all catalogs will use it. It exists for catalogs where a distinction is made between metadata about
                 a <em>dataset or service</em> and metadata about the <em>entry in the catalog about the dataset or service</em>. For example, the <i>publication date</i> property of the <i>dataset</i> reflects
                 the date when the information was originally made available by the publishing agency, while the publication date of the <i>catalog record</i> is the date when the dataset was added to the catalog.
@@ -1267,7 +1267,7 @@
 
         <p>If a catalog is represented as an RDF Dataset with named graphs (as defined in [[SPARQL11-QUERY]]),
             then it is appropriate to place the description of each dataset
-            (consisting of all RDF triples that mention the dcat:Dataset, dcat:CatalogRecord, and any of its dcat:Distributions)
+            (consisting of all RDF triples that mention the <code>dcat:Dataset</code>, <code>dcat:CatalogRecord</code>, and any of its <code>dcat:Distributions</code>)
             into a separate named graph. The name of that graph <em title="SHOULD" class="rfc2119">SHOULD</em> be the IRI of the catalog record.
         </p>
 
@@ -1277,7 +1277,7 @@
                 <thead><tr><th>RDF Property:</th><th><a href="http://purl.org/dc/terms/title">dct:title</a></th></tr></thead>
                 <tbody>
                 <tr><td class="prop">Definition:</td><td>A name given to the record.</td></tr>
-                <tr><td class="prop">Range:</td><td><a href="http://www.w3.org/2000/01/rdf-schema#Literal">rdfs:Literal</a></td></tr>
+                <tr><td class="prop">Range:</td><td><a href="http://www.w3.org/2000/01/rdf-schema#Literal"><code>rdfs:Literal</code></a></td></tr>
                 </tbody>
             </table>
         </section>
@@ -1288,7 +1288,7 @@
                 <thead><tr><th>RDF Property:</th><th><a href="http://purl.org/dc/terms/description">dct:description</a></th></tr></thead>
                 <tbody>
                 <tr><td class="prop">Definition:</td><td>A free-text account of the record.</td></tr>
-                <tr><td class="prop">Range:</td><td><a href="http://www.w3.org/2000/01/rdf-schema#Literal">rdfs:Literal</a></td></tr>
+                <tr><td class="prop">Range:</td><td><a href="http://www.w3.org/2000/01/rdf-schema#Literal"><code>rdfs:Literal</code></a></td></tr>
                 </tbody>
             </table>
         </section>
@@ -1299,11 +1299,11 @@
                 <thead><tr><th>RDF Property:</th><th><a href="http://purl.org/dc/terms/issued">dct:issued</a></th></tr></thead>
                 <tbody>
                 <tr><td class="prop">Definition:</td><td>The date of listing (i.e. formal recording) of the corresponding dataset or service in the catalog.</td></tr>
-                <tr><td class="prop">Range:</td><td><a href="http://www.w3.org/2000/01/rdf-schema#Literal">rdfs:Literal</a>
+                <tr><td class="prop">Range:</td><td><a href="http://www.w3.org/2000/01/rdf-schema#Literal"><code>rdfs:Literal</code></a>
                     encoded using the relevant ISO 8601 Date and Time compliant string [[!DATETIME]] and typed using the appropriate XML Schema datatype [[XMLSCHEMA11-2]]
                 </td></tr>
                 <tr><td class="prop">Usage note:</td><td>This indicates the date of listing the dataset in the catalog and not the publication date of the dataset itself.</td></tr>
-                <tr><td class="prop">See also:</td><td><a href="#Property:resource_release_date" title=""> resource release date</a></td></tr>
+                <tr><td class="prop">See also:</td><td><a href="#Property:resource_release_date" title="">resource release date</a></td></tr>
                 </tbody>
             </table>
         </section>
@@ -1314,11 +1314,11 @@
                 <thead><tr><th>RDF Property:</th><th><a href="http://purl.org/dc/terms/modified">dct:modified</a></th></tr></thead>
                 <tbody>
                 <tr><td class="prop">Definition:</td><td>Most recent date on which the catalog entry was changed, updated or modified.</td></tr>
-                <tr><td class="prop">Range:</td><td><a href="http://www.w3.org/2000/01/rdf-schema#Literal">rdfs:Literal</a>
+                <tr><td class="prop">Range:</td><td><a href="http://www.w3.org/2000/01/rdf-schema#Literal"><code>rdfs:Literal</code></a>
                     encoded using the relevant ISO 8601 Date and Time compliant string [[!DATETIME]] and typed using the appropriate XML Schema datatype [[XMLSCHEMA11-2]]
                 </td></tr>
                 <tr><td class="prop">Usage note:</td><td>This indicates the date of last change of a catalog entry, i.e. the catalog metadata description of the dataset, and not the date of the dataset itself.</td></tr>
-                <tr><td class="prop">See also:</td><td><a href="#Property:resource_update_date" title=""> resource modification date</a></td></tr>
+                <tr><td class="prop">See also:</td><td><a href="#Property:resource_update_date" title="">resource modification date</a></td></tr>
                 </tbody>
             </table>
         </section>
@@ -1329,8 +1329,8 @@
             <table class="definition">
                 <thead><tr><th>RDF Property:</th><th><a href="http://xmlns.com/foaf/0.1/primaryTopic">foaf:primaryTopic</a></th></tr></thead>
                 <tbody>
-                <tr><td class="prop">Definition:</td><td>The  <a href="http://www.w3.org/ns/dcat#dcat:Resource">dcat:Resource</a> (dataset or service) described in the record.</td></tr>
-                <tr><td class="prop">Usage note:</td><td><a href="http://xmlns.com/foaf/0.1/primaryTopic">foaf:primaryTopic</a> property is functional:
+                <tr><td class="prop">Definition:</td><td>The  <a href="http://www.w3.org/ns/dcat#dcat:Resource"><code>dcat:Resource</code></a> (dataset or service) described in the record.</td></tr>
+                <tr><td class="prop">Usage note:</td><td><a href="http://xmlns.com/foaf/0.1/primaryTopic"><code>foaf:primaryTopic</code></a> property is functional:
                     each catalog record can have at most one primary topic i.e. describes one dataset or service.</td></tr>
                 </tbody>
             </table>
@@ -1347,14 +1347,14 @@
                 <thead><tr><th>RDF Property:</th><th><a href="http://purl.org/dc/terms/conformsTo">dct:conformsTo</a></th></tr></thead>
                 <tbody>
                 <tr><td class="prop">Definition:</td><td>An established standard to which the described resource conforms.</td></tr>
-                <tr><td class="prop">Range:</td><td><a href="http://purl.org/dc/terms/Standard">dct:Standard</a> (A basis for comparison; a reference point against which other things can be evaluated.)</td></tr>
+                <tr><td class="prop">Range:</td><td><a href="http://purl.org/dc/terms/Standard"><code>dct:Standard</code></a> (A basis for comparison; a reference point against which other things can be evaluated.)</td></tr>
                 <tr><td class="prop">Usage note:</td><td>This property <em title="SHOULD" class="rfc2119">SHOULD</em> be used to indicate the model, schema, ontology, view or profile that the catalog record metadata conforms to. </td></tr>
                 </tbody>
             </table>
 
             <!-- this note is repeated from above, should we remove here or repeat for clarification in this context? -->
             <p class="note">
-                <a href="http://purl.org/dc/terms/Standard">dct:Standard</a> is defined as "A basis for comparison; a reference point against which other things can be evaluated." The target resource is not restricted to formal standards issued by bodies like ISO and W3C. In this context, it is any resource that specifies one or more aspects of the catalog record content, for example schema, semantics, syntax, usage guidelines, file format, or specific serialization. The meaning of conformance is determined by provisions in the target standard.
+                <a href="http://purl.org/dc/terms/Standard"><code>dct:Standard</code></a> is defined as "A basis for comparison; a reference point against which other things can be evaluated." The target resource is not restricted to formal standards issued by bodies like ISO and W3C. In this context, it is any resource that specifies one or more aspects of the catalog record content, for example schema, semantics, syntax, usage guidelines, file format, or specific serialization. The meaning of conformance is determined by provisions in the target standard.
             </p>
         </section>
 
@@ -1370,7 +1370,7 @@
             <a href="#Property:dataset_temporal">temporal coverage</a>,
             <a href="#Property:dataset_wasgeneratedby">was generated by</a>
         </p>
-        <p>The following properties are are inherited from the super-class <a href="http://www.w3.org/ns/dcat#Resource">dcat:Resource</a>:
+        <p>The following properties are are inherited from the super-class <a href="http://www.w3.org/ns/dcat#Resource"><code>dcat:Resource</code></a>:
             <a href="#Property:resource_conformsto">conformsTo</a>,
             <a href="#Property:resource_contact_point">contact point</a>,
             <a href="#Property:resource_creator">creator</a>,
@@ -1443,18 +1443,18 @@
             <thead><tr><th>RDF Class:</th><th><a href="http://www.w3.org/ns/dcat#Dataset">dcat:Dataset</a></th></tr></thead>
             <tbody>
             <tr><td class="prop">Definition:</td><td>A collection of data, published or curated by a single agent, and available for access or download in one or more formats.</td></tr>
-            <tr><td class="prop">Sub class of:</td><td><a href="http://www.w3.org/ns/dcat#Resource">dcat:Resource</a></td></tr>
+            <tr><td class="prop">Sub class of:</td><td><a href="http://www.w3.org/ns/dcat#Resource"><code>dcat:Resource</code></a></td></tr>
             <tr><td class="prop">Usage note:</td><td>This class represents the actual dataset as published by the dataset publisher. In cases where a distinction between the actual dataset and its entry in the catalog is necessary (because metadata such as modification date and maintainer might differ), the <i><a href="#Class:Catalog_Record">catalog record</a></i> class can be used for the latter.</td></tr>
             </tbody>
         </table>
 
         <div class="note">
             <p>
-                In DCAT 2014 [[VOCAB-DCAT-20140116]] <a href="#Class:Dataset">dcat:Dataset</a> was a sub-class of <a href="http://purl.org/dc/dcmitype/Dataset">dctype:Dataset</a>, which is a member of the <a href="http://dublincore.org/documents/dcmi-terms/#section-7">DCMI Types vocabulary</a> [[DCTERMS]].
-                The scope of <a href="#Class:Dataset">dcat:Dataset</a> also includes other members of the <a href="http://dublincore.org/documents/dcmi-terms/#section-7">DCMI Types vocabulary</a>, so the implicitly limited sub-class relationship from DCAT 2014 [[VOCAB-DCAT-20140116]] has been removed in this revised DCAT vocabulary - see <a href="https://github.com/w3c/dxwg/issues/98">Issue #98</a>.
+                In DCAT 2014 [[VOCAB-DCAT-20140116]] <a href="#Class:Dataset"><code>dcat:Dataset</code></a> was a sub-class of <a href="http://purl.org/dc/dcmitype/Dataset"><code>dctype:Dataset</code></a>, which is a member of the <a href="http://dublincore.org/documents/dcmi-terms/#section-7">DCMI Types vocabulary</a> [[DCTERMS]].
+                The scope of <a href="#Class:Dataset"><code>dcat:Dataset</code></a> also includes other members of the <a href="http://dublincore.org/documents/dcmi-terms/#section-7">DCMI Types vocabulary</a>, so the implicitly limited sub-class relationship from DCAT 2014 [[VOCAB-DCAT-20140116]] has been removed in this revised DCAT vocabulary - see <a href="https://github.com/w3c/dxwg/issues/98">Issue #98</a>.
             </p>
             <p>
-                Note that members of the <a href="http://dublincore.org/documents/dcmi-terms/#section-7">DCMI Types vocabulary</a> may appear as the value of the <a href="#Property:resource_type">dct:type</a> property, as shown in <a href="#classifying-dataset-types">Classifying dataset types</a>.
+                Note that members of the <a href="http://dublincore.org/documents/dcmi-terms/#section-7">DCMI Types vocabulary</a> may appear as the value of the <a href="#Property:resource_type"><code>dct:type</code></a> property, as shown in <a href="#classifying-dataset-types">Classifying dataset types</a>.
             </p>
         </div>
 
@@ -1466,16 +1466,16 @@
                 <thead><tr><th>RDF Property:</th><th><a href="http://www.w3.org/ns/dcat#distribution">dcat:distribution</a></th></tr></thead>
                 <tbody>
                 <tr><td class="prop">Definition:</td><td>An available distribution of the dataset.</td></tr>
-                <tr><td class="prop">Sub property of:</td><td><a href="http://purl.org/dc/terms/relation">dct:relation</a></td></tr>
-                <tr><td class="prop">Domain:</td><td><a href="http://www.w3.org/ns/dcat#Dataset">dcat:Dataset</a></td></tr>
-                <tr><td class="prop">Range:</td><td><a href="http://www.w3.org/ns/dcat#Distribution">dcat:Distribution</a></td></tr>
+                <tr><td class="prop">Sub property of:</td><td><a href="http://purl.org/dc/terms/relation"><code>dct:relation</code></a></td></tr>
+                <tr><td class="prop">Domain:</td><td><a href="http://www.w3.org/ns/dcat#Dataset"><code>dcat:Dataset</code></a></td></tr>
+                <tr><td class="prop">Range:</td><td><a href="http://www.w3.org/ns/dcat#Distribution"><code>dcat:Distribution</code></a></td></tr>
                 </tbody>
             </table>
         </section>
 
         <p class="issue">
             <a href="https://github.com/w3c/dxwg/issues/81">Issue #81</a> concerns the general need to describe relationships between datasets.
-            Guidance on the use of specializations of dct:relation is required in the context of dcat:Dataset.
+            Guidance on the use of specializations of <code>dct:relation</code> is required in the context of <code>dcat:Dataset</code>.
         </p>
 
         <section id="Property:dataset_frequency">
@@ -1484,7 +1484,7 @@
                 <thead><tr><th>RDF Property:</th><th><a href="http://purl.org/dc/terms/accrualPeriodicity">dct:accrualPeriodicity</a></th></tr></thead>
                 <tbody>
                 <tr><td class="prop">Definition:</td><td>The frequency at which dataset is published.</td></tr>
-                <tr><td class="prop">Range:</td><td><a href="http://purl.org/dc/terms/Frequency">dct:Frequency</a> (A rate at which something recurs)</td></tr>
+                <tr><td class="prop">Range:</td><td><a href="http://purl.org/dc/terms/Frequency"><code>dct:Frequency</code></a> (A rate at which something recurs)</td></tr>
                 </tbody>
             </table>
         </section>
@@ -1504,7 +1504,7 @@
                 <thead><tr><th>RDF Property:</th><th><a href="http://purl.org/dc/terms/spatial">dct:spatial</a></th></tr></thead>
                 <tbody>
                 <tr><td class="prop">Definition:</td><td>The geographical area covered by the dataset.</td></tr>
-                <tr><td class="prop">Range:</td><td><a href="http://purl.org/dc/terms/Location">dct:Location</a> (A spatial region or named place)</td></tr>
+                <tr><td class="prop">Range:</td><td><a href="http://purl.org/dc/terms/Location"><code>dct:Location</code></a> (A spatial region or named place)</td></tr>
                 </tbody>
             </table>
         </section>
@@ -1520,7 +1520,7 @@
                 <thead><tr><th>RDF Property:</th><th><a href="http://purl.org/dc/terms/temporal">dct:temporal</a></th></tr></thead>
                 <tbody>
                 <tr><td class="prop">Definition:</td><td>The temporal period that the dataset covers.</td></tr>
-                <tr><td class="prop">Range:</td><td><a href="http://purl.org/dc/terms/PeriodOfTime">dct:PeriodOfTime</a> (An interval of time that is named or defined by its start and end dates)</td></tr>
+                <tr><td class="prop">Range:</td><td><a href="http://purl.org/dc/terms/PeriodOfTime"><code>dct:PeriodOfTime</code></a> (An interval of time that is named or defined by its start and end dates)</td></tr>
                 </tbody>
             </table>
         </section>
@@ -1532,10 +1532,10 @@
                 <thead><tr><th>RDF Property:</th><th><a href="http://www.w3.org/ns/prov#wasGeneratedBy">prov:wasGeneratedBy</a></th></tr></thead>
                 <tbody>
                 <tr><td class="prop">Definition:</td><td>An activity that generated, or provides the business context for, the creation of the dataset.</td></tr>
-                <tr><td class="prop">Domain:</td><td><a href="http://www.w3.org/ns/prov#Entity">prov:Entity</a></td></tr>
-                <tr><td class="prop">Range:</td><td><a href="http://www.w3.org/ns/prov#Activity">prov:Activity</a> An activity is something that occurs over a period of time and acts upon or with entities; it may include consuming, processing, transforming, modifying, relocating, using, or generating entities.</td></tr>
-                <tr><td class="prop">Usage note:</td><td>The activity associated with generation of a dataset will typically be an initiative, project, mission, survey, on-going activity ("business as usual") etc. Multiple prov:wasGeneratedBy properties can be used to indicate the dataset production context at various levels of granularity. </td></tr>
-                <tr><td class="prop">Usage note:</td><td>Use <a href="http://www.w3.org/ns/prov#qualifiedGeneration">prov:qualifiedGeneration</a> to attach additional details about the relationship between the dataset and the activity, e.g. the exact time that the dataset was produced during the lifetime of a project</td></tr>
+                <tr><td class="prop">Domain:</td><td><a href="http://www.w3.org/ns/prov#Entity"><code>prov:Entity</code></a></td></tr>
+                <tr><td class="prop">Range:</td><td><a href="http://www.w3.org/ns/prov#Activity"><code>prov:Activity</code></a> An activity is something that occurs over a period of time and acts upon or with entities; it may include consuming, processing, transforming, modifying, relocating, using, or generating entities.</td></tr>
+                <tr><td class="prop">Usage note:</td><td>The activity associated with generation of a dataset will typically be an initiative, project, mission, survey, on-going activity ("business as usual") etc. Multiple <code>prov:wasGeneratedBy</code> properties can be used to indicate the dataset production context at various levels of granularity. </td></tr>
+                <tr><td class="prop">Usage note:</td><td>Use <a href="http://www.w3.org/ns/prov#qualifiedGeneration"><code>prov:qualifiedGeneration</code></a> to attach additional details about the relationship between the dataset and the activity, e.g. the exact time that the dataset was produced during the lifetime of a project</td></tr>
                 </tbody>
             </table>
 
@@ -1545,7 +1545,7 @@
 
             <p>
                 Details about how to describe the activity that generated a dataset, such as a project, initiative, on-going activity, mission or survey, are out of scope for this document.
-                <a href="http://www.w3.org/ns/prov#Activity">prov:Activity</a> provides for some basic properties such as begin and end time, associated agents etc.
+                <a href="http://www.w3.org/ns/prov#Activity"><code>prov:Activity</code></a> provides for some basic properties such as begin and end time, associated agents etc.
                 Further details may be provided through classes defined in applications.
                 A number of ontologies for describing projects are available, for example
                 VIVO for academic research projects [[VIVO-ISF]],
@@ -1575,7 +1575,7 @@
         </p>
 
         <p class="issue" data-number="54">
-            The packaging of files in a dcat:Distribution is being considered as part of the revision of DCAT.
+            The packaging of files in a <code>dcat:Distribution</code> is being considered as part of the revision of DCAT.
         </p>
 
         <p class="issue" data-number="59">
@@ -1590,27 +1590,27 @@
                 Examples of distributions include a CSV file, a netCDF file, or a data-cube</td></tr>
             <tr><td class="prop">Usage note:</td><td>This represents a general availability of a dataset. It implies no information
                 about the actual access method of the data, i.e. whether by direct download, API, or through a Web page.
-                The use of <a href="#Property:distribution_downloadurl">dcat:downloadURL</a> property indicates directly downloadable distributions.</td></tr>
+                The use of <a href="#Property:distribution_downloadurl"><code>dcat:downloadURL</code></a> property indicates directly downloadable distributions.</td></tr>
             <tr><td class="prop">See also:</td><td><a href="#Class:Data_Distribution_Service" title="">Data distribution service</a></td></tr>
             </tbody>
         </table>
 
         <div class="note">
             <p>
-                The scope of dcat:Distribution here is narrower than in DCAT-2014 [[VOCAB-DCAT-20140116]], where it also included APIs and feeds.
-                Data catalogues designed using DCAT-2014 therefore used instances of type dcat:Distribution to describe data distribution services.
-                <b>Applications consuming DCAT should be aware that catalogues designed using DCAT-2014 might use dcat:Distribution to represent both services and representations.</b>
+                The scope of <code>dcat:Distribution</code> here is narrower than in DCAT-2014 [[VOCAB-DCAT-20140116]], where it also included APIs and feeds.
+                Data catalogues designed using DCAT-2014 therefore used instances of type <code>dcat:Distribution</code> to describe data distribution services.
+                <b>Applications consuming DCAT should be aware that catalogues designed using DCAT-2014 might use <code>dcat:Distribution</code> to represent both services and representations.</b>
             </p>
             <p>
-                Under the revised scope, instances of type dcat:Distribution <em title="SHOULD" class="rfc2119">SHOULD</em> be limited to <i>representations</i> of datasets which might be transported as files, and <em title="SHOULD NOT" class="rfc2119">SHOULD NOT</em> be used for data <i>services</i> such as APIs or feeds. Data services including APIs and feeds <em title="SHOULD" class="rfc2119">SHOULD</em> be described using instances of type <a href="#Class:Data_Service">dcat:DataService</a> whose sub-class <a href="#Class:Data_Distribution_Service">dcat:DataDistributionService</a> <em title="MAY" class="rfc2119">MAY</em> serve <a href="#Class:Distribution">dcat:Distributions</a>.
+                Under the revised scope, instances of type <code>dcat:Distribution</code> <em title="SHOULD" class="rfc2119">SHOULD</em> be limited to <i>representations</i> of datasets which might be transported as files, and <em title="SHOULD NOT" class="rfc2119">SHOULD NOT</em> be used for data <i>services</i> such as APIs or feeds. Data services including APIs and feeds <em title="SHOULD" class="rfc2119">SHOULD</em> be described using instances of type <a href="#Class:Data_Service"><code>dcat:DataService</code></a> whose sub-class <a href="#Class:Data_Distribution_Service"><code>dcat:DataDistributionService</code></a> <em title="MAY" class="rfc2119">MAY</em> serve <a href="#Class:Distribution"><code>dcat:Distributions</code></a>.
             </p>
             <p>
-                Links between a dcat:Distribution and services or web addresses where it can be accessed are expressed using <a href="#Property:distribution_accessurl">dcat:accessURL</a>, <a href="#Property:distribution_accessservice">dcat:accessService</a>, <a href="#Property:distribution_downloadurl">dcat:downloadURL</a>, as shown in <a href="#fig1">Figure 1</a> and described in the definitions below.
+                Links between a <code>dcat:Distribution</code> and services or web addresses where it can be accessed are expressed using <a href="#Property:distribution_accessurl"><code>dcat:accessURL</code></a>, <a href="#Property:distribution_accessservice"><code>dcat:accessService</code></a>, <a href="#Property:distribution_downloadurl"><code>dcat:downloadURL</code></a>, as shown in <a href="#fig1">Figure 1</a> and described in the definitions below.
             </p>
         </div>
 
         <p class="note">
-            The definition text of dcat:Distribution has been revised to clarify that distributions are primarily <i>representations</i> of datasets.  As such, all distributions of a given dataset should be informationally equivalent.
+            The definition text of <code>dcat:Distribution</code> has been revised to clarify that distributions are primarily <i>representations</i> of datasets.  As such, all distributions of a given dataset should be informationally equivalent.
         </p>
 
         <p class="issue" data-number="411">
@@ -1623,7 +1623,7 @@
                 <thead><tr><th>RDF Property:</th><th><a href="http://purl.org/dc/terms/title">dct:title</a></th></tr></thead>
                 <tbody>
                 <tr><td class="prop">Definition:</td><td>A name given to the distribution.</td></tr>
-                <tr><td class="prop">Range:</td><td><a href="http://www.w3.org/2000/01/rdf-schema#Literal">rdfs:Literal</a></td></tr>
+                <tr><td class="prop">Range:</td><td><a href="http://www.w3.org/2000/01/rdf-schema#Literal"><code>rdfs:Literal</code></a></td></tr>
                 </tbody>
             </table>
         </section>
@@ -1634,7 +1634,7 @@
                 <thead><tr><th>RDF Property:</th><th><a href="http://purl.org/dc/terms/description">dct:description</a></th></tr></thead>
                 <tbody>
                 <tr><td class="prop">Definition:</td><td>free-text account of the distribution.</td></tr>
-                <tr><td class="prop">Range:</td><td><a href="http://www.w3.org/2000/01/rdf-schema#Literal">rdfs:Literal</a></td></tr>
+                <tr><td class="prop">Range:</td><td><a href="http://www.w3.org/2000/01/rdf-schema#Literal"><code>rdfs:Literal</code></a></td></tr>
                 </tbody>
             </table>
         </section>
@@ -1645,11 +1645,11 @@
                 <thead><tr><th>RDF Property:</th><th><a href="http://purl.org/dc/terms/issued">dct:issued</a></th></tr></thead>
                 <tbody>
                 <tr><td class="prop">Definition:</td><td>Date of formal issuance (e.g., publication) of the distribution.</td></tr>
-                <tr><td class="prop">Range:</td><td><a href="http://www.w3.org/2000/01/rdf-schema#Literal">rdfs:Literal</a>
+                <tr><td class="prop">Range:</td><td><a href="http://www.w3.org/2000/01/rdf-schema#Literal"><code>rdfs:Literal</code></a>
                     encoded using the relevant ISO 8601 Date and Time compliant string [[!DATETIME]] and typed using the appropriate XML Schema datatype [[XMLSCHEMA11-2]]
                 </td></tr>
                 <tr><td class="prop">Usage note:</td><td>This property <em title="SHOULD" class="rfc2119">SHOULD</em> be set using the first known date of issuance.</td></tr>
-                <tr><td class="prop">See also:</td><td><a href="#Property:resource_release_date" title=""> resource release date</a></td></tr>
+                <tr><td class="prop">See also:</td><td><a href="#Property:resource_release_date" title="">resource release date</a></td></tr>
                 </tbody>
             </table>
         </section>
@@ -1660,9 +1660,9 @@
                 <thead><tr><th>RDF Property:</th><th><a href="http://purl.org/dc/terms/modified">dct:modified</a></th></tr></thead>
                 <tbody>
                 <tr><td class="prop">Definition:</td><td>Most recent date on which the distribution was changed, updated or modified.</td></tr>
-                <tr><td class="prop">Range:</td><td><a href="http://www.w3.org/2000/01/rdf-schema#Literal">rdfs:Literal</a>
+                <tr><td class="prop">Range:</td><td><a href="http://www.w3.org/2000/01/rdf-schema#Literal"><code>rdfs:Literal</code></a>
                     encoded using the relevant ISO 8601 Date and Time compliant string [[!DATETIME]] and typed using the appropriate XML Schema datatype [[XMLSCHEMA11-2]]</td></tr>
-                <tr><td class="prop">See also:</td><td><a href="#Property:resource_update_date" title=""> resource modification date</a></td></tr>
+                <tr><td class="prop">See also:</td><td><a href="#Property:resource_update_date" title="">resource modification date</a></td></tr>
                 </tbody>
             </table>
         </section>
@@ -1674,10 +1674,10 @@
                 <thead><tr><th>RDF Property:</th><th><a href="http://purl.org/dc/terms/license">dct:license</a></th></tr></thead>
                 <tbody>
                 <tr><td class="prop">Definition:</td><td>A legal document under which the distribution is made available.</td></tr>
-                <tr><td class="prop">Range:</td><td><a href="http://purl.org/dc/terms/LicenseDocument">dct:LicenseDocument</a></td></tr>
+                <tr><td class="prop">Range:</td><td><a href="http://purl.org/dc/terms/LicenseDocument"><code>dct:LicenseDocument</code></a></td></tr>
                 <tr><td class="prop">Usage note:</td><td>Information about licenses and rights <em title="SHOULD" class="rfc2119">SHOULD</em> be provided on the level of Distribution. Information about licenses and rights <em title="MAY" class="rfc2119">MAY</em> be provided for a Dataset in addition to but not instead of the information provided for the Distributions of that Dataset. Providing license or rights information for a Dataset that is different from information provided for a Distribution of that Dataset <em title="SHOULD" class="rfc2119">SHOULD</em> be avoided as this can create legal conflicts. See also guidance at <a href="#license-rights">License and rights statements</a>.</td></tr>
 
-		<tr><td class="prop">See also:</td><td><a href="#Property:distribution_rights" title=""> distribution rights</a>,
+		<tr><td class="prop">See also:</td><td><a href="#Property:distribution_rights" title="">distribution rights</a>,
                     <a href="#Property:catalog_license" title="">catalog license</a></td></tr>
                 </tbody>
             </table>
@@ -1690,12 +1690,12 @@
                 <thead><tr><th>RDF Property:</th><th><a href="http://purl.org/dc/terms/rights">dct:rights</a></th></tr></thead>
                 <tbody>
                 <tr><td class="prop">Definition:</td><td>Information about rights held in and over the distribution.</td></tr>
-                <tr><td class="prop">Range:</td><td><a href="http://purl.org/dc/terms/RightsStatement">dct:RightsStatement</a></td></tr>
-                <tr><td class="prop">Usage note:</td><td>dct:license, which is a sub-property of dct:rights, can be used to link
-                    a distribution to a license document. However, dct:rights allows linking to a rights statement that
+                <tr><td class="prop">Range:</td><td><a href="http://purl.org/dc/terms/RightsStatement"><code>dct:RightsStatement</code></a></td></tr>
+                <tr><td class="prop">Usage note:</td><td><code>dct:license</code>, which is a sub-property of <code>dct:rights</code>, can be used to link
+                    a distribution to a license document. However, <code>dct:rights</code> allows linking to a rights statement that
                     can include licensing information as well as other information that supplements the license such as attribution.<br/>
                     Information about licenses and rights <em title="SHOULD" class="rfc2119">SHOULD</em> be provided on the level of Distribution. Information about licenses and rights MAY be provided for a Dataset in addition to but not instead of the information provided for the Distributions of that Dataset. Providing license or rights information for a Dataset that is different from information provided for a Distribution of that Dataset <em title="SHOULD" class="rfc2119">SHOULD</em> be avoided as this can create legal conflicts. See also guidance at <a href="#license-rights">License and rights statements</a>.</td></tr>
-                <tr><td class="prop">See also:</td><td><a href="#Property:distribution_license" title=""> distribution license</a>,
+                <tr><td class="prop">See also:</td><td><a href="#Property:distribution_license" title="">distribution license</a>,
                     <a href="#Property:catalog_rights" title="">catalog rights</a></td></tr>
                 </tbody>
             </table>
@@ -1706,25 +1706,25 @@
             <h4>Property: access address</h4>
 
             <p class="issue" data-number="145">
-                The granularity of dcat:accessURL is being re-considered to provide different usages for list and item endpoints as well as supporting the declaration of different profiles (for list results and data payload).
+                The granularity of <code>dcat:accessURL</code> is being re-considered to provide different usages for list and item endpoints as well as supporting the declaration of different profiles (for list results and data payload).
             </p>
 
             <table class="definition">
                 <thead><tr><th>RDF Property:</th><th><a href="http://www.w3.org/ns/dcat#accessURL">dcat:accessURL</a></th></tr></thead>
                 <tbody>
                 <tr><td class="prop">Definition:</td><td>A URL of the resource that gives access to a distribution of the dataset. E.g. landing page, feed, SPARQL endpoint.</td></tr>
-                <tr><td class="prop">Domain:</td><td><a href="http://www.w3.org/ns/dcat#Distribution">dcat:Distribution</a></td></tr>
-                <tr><td class="prop">Range:</td><td><a href="http://www.w3.org/2000/01/rdf-schema#Resource">rdfs:Resource</a></td></tr>
-                <tr><td class="prop">Usage note:</td><td><a href="#Property:distribution_accessurl">dcat:accessURL</a> <em title="SHOULD" class="rfc2119">SHOULD</em> be used for the address of a service or location that can provide access to this distribution, typically through a web form, query or API call.
-                    <br/><a href="#Property:distribution_downloadurl">dcat:downloadURL</a> is preferred for direct links to downloadable resources.
-                    <br/>If the distribution(s) are accessible only through a landing page (i.e. direct download URLs are not known), then the landingPage address associated with the dcat:Dataset <em title="SHOULD" class="rfc2119">SHOULD</em> be duplicated as accessURL on a distribution. (see <a href="#example-landing-page"></a>)
+                <tr><td class="prop">Domain:</td><td><a href="http://www.w3.org/ns/dcat#Distribution"><code>dcat:Distribution</code></a></td></tr>
+                <tr><td class="prop">Range:</td><td><a href="http://www.w3.org/2000/01/rdf-schema#Resource"><code>rdfs:Resource</code></a></td></tr>
+                <tr><td class="prop">Usage note:</td><td><a href="#Property:distribution_accessurl"><code>dcat:accessURL</code></a> <em title="SHOULD" class="rfc2119">SHOULD</em> be used for the address of a service or location that can provide access to this distribution, typically through a web form, query or API call.
+                    <br/><a href="#Property:distribution_downloadurl"><code>dcat:downloadURL</code></a> is preferred for direct links to downloadable resources.
+                    <br/>If the distribution(s) are accessible only through a landing page (i.e. direct download URLs are not known), then the landingPage address associated with the <code>dcat:Dataset</code> <em title="SHOULD" class="rfc2119">SHOULD</em> be duplicated as accessURL on a distribution. (see <a href="#example-landing-page"></a>)
                 </td></tr>
                 <tr><td class="prop">See also</td><td><a href="#Property:distribution_downloadurl">download address</a>, <a href="#Property:distribution_accessservice">access service</a></td></tr>
                 </tbody>
             </table>
 
             <p>
-                dcat:accessURL generally matches the property-chain dcat:accessService/dcat:endpointURL. In the RDF representation of DCAT this is axiomatized as an OWL property-chain axiom.
+                <code>dcat:accessURL</code> generally matches the property-chain <code>dcat:accessService</code>/<code>dcat:endpointURL</code>. In the RDF representation of DCAT this is axiomatized as an OWL property-chain axiom.
             </p>
         </section>
 
@@ -1739,9 +1739,9 @@
                 <thead><tr><th>RDF Property:</th><th><a href="http://www.w3.org/ns/dcat#accessService">dcat:accessService</a></th></tr></thead>
                 <tbody>
                 <tr><td class="prop">Definition:</td><td>A site or end-point that gives access to the distribution of the dataset</td></tr>
-                <tr><td class="prop">Sub-property of:</td><td><a href="http://www.w3.org/ns/dcat#accessURL">dcat:accessURL</a></td></tr>
-                <tr><td class="prop">Range:</td><td><a href="http://www.w3.org/ns/dcat#DataDistributionService">dcat:DataDistributionService</a></td></tr>
-                <tr><td class="prop">Usage note:</td><td><a href="#Property:distribution_accessservice">dcat:accessService</a> <em title="SHOULD" class="rfc2119">SHOULD</em> be used to link to a description of a <a href="#Class:Data_Distribution_Service">dcat:DataDistributionService</a> that can provide access to this distribution.</td></tr>
+                <tr><td class="prop">Sub-property of:</td><td><a href="http://www.w3.org/ns/dcat#accessURL"><code>dcat:accessURL</code></a></td></tr>
+                <tr><td class="prop">Range:</td><td><a href="http://www.w3.org/ns/dcat#DataDistributionService"><code>dcat:DataDistributionService</code></a></td></tr>
+                <tr><td class="prop">Usage note:</td><td><a href="#Property:distribution_accessservice"><code>dcat:accessService</code></a> <em title="SHOULD" class="rfc2119">SHOULD</em> be used to link to a description of a <a href="#Class:Data_Distribution_Service"><code>dcat:DataDistributionService</code></a> that can provide access to this distribution.</td></tr>
                 <tr><td class="prop">See also</td><td><a href="#Property:distribution_downloadurl">download address</a>, <a href="#Property:distribution_accessurl">access address</a></td></tr>
                 </tbody>
             </table>
@@ -1753,10 +1753,10 @@
             <table class="definition">
                 <thead><tr><th>RDF Property:</th><th><a href="http://www.w3.org/ns/dcat#downloadURL">dcat:downloadURL</a></th></tr></thead>
                 <tbody>
-                <tr><td class="prop">Definition:</td><td>The URL of the downloadable file in a given format. E.g. CSV file or RDF file. The format is indicated by the distribution's dct:format and/or dcat:mediaType</td></tr>
-                <tr><td class="prop">Domain:</td><td><a href="http://www.w3.org/ns/dcat#Distribution">dcat:Distribution</a></td></tr>
-                <tr><td class="prop">Range:</td><td><a href="http://www.w3.org/2000/01/rdf-schema#Resource">rdfs:Resource</a></td></tr>
-                <tr><td class="prop">Usage note:</td><td><a href="#Property:distribution_downloadurl">dcat:downloadURL</a> <em title="SHOULD" class="rfc2119">SHOULD</em> be used for the address at which this distribution is available directly, typically through a HTTP Get request.  </td></tr>
+                <tr><td class="prop">Definition:</td><td>The URL of the downloadable file in a given format. E.g. CSV file or RDF file. The format is indicated by the distribution's <code>dct:format</code> and/or <code>dcat:mediaType</code></td></tr>
+                <tr><td class="prop">Domain:</td><td><a href="http://www.w3.org/ns/dcat#Distribution"><code>dcat:Distribution</code></a></td></tr>
+                <tr><td class="prop">Range:</td><td><a href="http://www.w3.org/2000/01/rdf-schema#Resource"><code>rdfs:Resource</code></a></td></tr>
+                <tr><td class="prop">Usage note:</td><td><a href="#Property:distribution_downloadurl"><code>dcat:downloadURL</code></a> <em title="SHOULD" class="rfc2119">SHOULD</em> be used for the address at which this distribution is available directly, typically through a HTTP Get request.  </td></tr>
                 <tr><td class="prop">See also</td><td><a href="#Property:distribution_accessurl">access address</a>, <a href="#Property:distribution_accessservice">access service</a></td></tr>
                 </tbody>
             </table>
@@ -1766,15 +1766,15 @@
             <h4>Property: byteSize</h4>
 
             <p class="issue" data-number="125">
-                The axiomatization of dcat:byteSize is being re-evaluated as part of the revision of DCAT.
+                The axiomatization of <code>dcat:byteSize</code> is being re-evaluated as part of the revision of DCAT.
             </p>
 
             <table class="definition">
                 <thead><tr><th>RDF Property:</th><th><a href="http://www.w3.org/ns/dcat#size">dcat:byteSize</a></th></tr></thead>
                 <tbody>
                 <tr><td class="prop">Definition:</td><td>The size of a distribution in bytes.</td></tr>
-                <tr><td class="prop">Domain:</td><td><a href="http://www.w3.org/ns/dcat#Distribution">dcat:Distribution</a></td></tr>
-                <tr><td class="prop">Range:</td><td><a href="http://www.w3.org/2000/01/rdf-schema#Literal">rdfs:Literal</a> typed as <a href="http://www.w3.org/TR/xmlschema-2/#decimal">xsd:decimal</a>.</td></tr>
+                <tr><td class="prop">Domain:</td><td><a href="http://www.w3.org/ns/dcat#Distribution"><code>dcat:Distribution</code></a></td></tr>
+                <tr><td class="prop">Range:</td><td><a href="http://www.w3.org/2000/01/rdf-schema#Literal"><code>rdfs:Literal</code></a> typed as <a href="http://www.w3.org/TR/xmlschema-2/#decimal"><code>xsd:decimal</code></a>.</td></tr>
                 <tr><td class="prop">Usage note:</td><td>The size in bytes can be approximated when the precise size is not known.</td></tr>
                 </tbody>
             </table>
@@ -1791,14 +1791,14 @@
                 <thead><tr><th>RDF Property:</th><th><a href="http://purl.org/dc/terms/conformsTo">dct:conformsTo</a></th></tr></thead>
                 <tbody>
                 <tr><td class="prop">Definition:</td><td>An established standard to which the distribution conforms.</td></tr>
-                <tr><td class="prop">Range:</td><td><a href="http://purl.org/dc/terms/Standard">dct:Standard</a> (A basis for comparison; a reference point against which other things can be evaluated.)</td></tr>
+                <tr><td class="prop">Range:</td><td><a href="http://purl.org/dc/terms/Standard"><code>dct:Standard</code></a> (A basis for comparison; a reference point against which other things can be evaluated.)</td></tr>
                 <tr><td class="prop">Usage note:</td><td>This property <em title="SHOULD" class="rfc2119">SHOULD</em> be used to indicate the model, schema, ontology, view or profile that this representation of a dataset conforms to. This is (generally) a complementary concern to the media-type or format. </td></tr>
-                <tr><td class="prop">See also:</td><td><a href="#Property:distribution_format">format</a> , <a href="#Property:distribution_media_type">media type</a></td></tr>
+                <tr><td class="prop">See also:</td><td><a href="#Property:distribution_format">format</a>, <a href="#Property:distribution_media_type">media type</a></td></tr>
                 </tbody>
             </table>
 
             <p class="note">
-                <a href="http://purl.org/dc/terms/Standard">dct:Standard</a> is defined as "A basis for comparison; a reference point against which other things can be evaluated." It is not restricted to formal standards issued by bodies like ISO and W3C. In this context it will usually be used for a schema, ontology, data model or profile which specifies the structure of a dataset distribution. This is not necessarily tied to a single encoding or serialization.
+                <a href="http://purl.org/dc/terms/Standard"><code>dct:Standard</code></a> is defined as "A basis for comparison; a reference point against which other things can be evaluated." It is not restricted to formal standards issued by bodies like ISO and W3C. In this context it will usually be used for a schema, ontology, data model or profile which specifies the structure of a dataset distribution. This is not necessarily tied to a single encoding or serialization.
             </p>
         </section>
 
@@ -1806,17 +1806,17 @@
             <h4>Property: media type</h4>
 
             <p class="note">
-                The range of dcat:mediaType has been tightened from dct:MediaTypeOrExtent to dct:MediaType as part of the revision of DCAT.
+                The range of <code>dcat:mediaType</code> has been tightened from <code>dct:MediaTypeOrExtent</code> to <code>dct:MediaType</code> as part of the revision of DCAT.
             </p>
 
             <table class="definition">
                 <thead><tr><th>RDF Property:</th><th><a href="http://www.w3.org/ns/dcat#mediaType">dcat:mediaType</a></th></tr></thead>
                 <tbody>
                 <tr><td class="prop">Definition:</td><td>The media type of the distribution as defined by IANA [[!IANA-MEDIA-TYPES]].</td></tr>
-                <tr><td class="prop">Sub property of:</td><td><a href="http://purl.org/dc/terms/format">dct:format</a></td></tr>
-                <tr><td class="prop">Domain:</td><td><a href="http://www.w3.org/ns/dcat#Distribution">dcat:Distribution</a></td></tr>
-                <tr><td class="prop">Range:</td><td><a href="http://purl.org/dc/terms/MediaType">dct:MediaType</a></td></tr>
-                <tr><td class="prop">Usage note:</td><td>This property <em title="SHOULD" class="rfc2119">SHOULD</em> be used when the media type of the distribution is defined in IANA [[!IANA-MEDIA-TYPES]], otherwise dct:format <em title="MAY" class="rfc2119">MAY</em> be used with different values.</td></tr>
+                <tr><td class="prop">Sub property of:</td><td><a href="http://purl.org/dc/terms/format"><code>dct:format</code></a></td></tr>
+                <tr><td class="prop">Domain:</td><td><a href="http://www.w3.org/ns/dcat#Distribution"><code>dcat:Distribution</code></a></td></tr>
+                <tr><td class="prop">Range:</td><td><a href="http://purl.org/dc/terms/MediaType"><code>dct:MediaType</code></a></td></tr>
+                <tr><td class="prop">Usage note:</td><td>This property <em title="SHOULD" class="rfc2119">SHOULD</em> be used when the media type of the distribution is defined in IANA [[!IANA-MEDIA-TYPES]], otherwise <code>dct:format</code> <em title="MAY" class="rfc2119">MAY</em> be used with different values.</td></tr>
                 <tr><td class="prop">See also:</td><td><a href="#Property:distribution_format">format</a> , <a href="#Property:distribution_conformsto">conforms to</a></td></tr>
                 </tbody>
             </table>
@@ -1829,9 +1829,9 @@
                 <thead><tr><th>RDF Property:</th><th><a href="http://purl.org/dc/terms/format">dct:format</a></th></tr></thead>
                 <tbody>
                 <tr><td class="prop">Definition:</td><td>The file format of the distribution.</td></tr>
-                <tr><td class="prop">Range:</td><td><a href="http://purl.org/dc/terms/MediaTypeOrExtent">dct:MediaTypeOrExtent</a></td></tr>
-                <tr><td class="prop">Usage note:</td><td> <a href="#Property:distribution_media_type">dcat:mediaType</a> <em title="SHOULD" class="rfc2119">SHOULD</em> be used if the type of the distribution is defined by IANA [[!IANA-MEDIA-TYPES]].</td></tr>
-                <tr><td class="prop">See also:</td><td><a href="#Property:distribution_media_type">media type</a> , <a href="#Property:distribution_conformsto">conforms to</a></td></tr>
+                <tr><td class="prop">Range:</td><td><a href="http://purl.org/dc/terms/MediaTypeOrExtent"><code>dct:MediaTypeOrExtent</code></a></td></tr>
+                <tr><td class="prop">Usage note:</td><td> <a href="#Property:distribution_media_type"><code>dcat:mediaType</code></a> <em title="SHOULD" class="rfc2119">SHOULD</em> be used if the type of the distribution is defined by IANA [[!IANA-MEDIA-TYPES]].</td></tr>
+                <tr><td class="prop">See also:</td><td><a href="#Property:distribution_media_type">media type</a>, <a href="#Property:distribution_conformsto">conforms to</a></td></tr>
                 </tbody>
             </table>
         </section>
@@ -1841,7 +1841,7 @@
         <h3>Class: Data Service</h3>
 
         <p class="note">
-            The class <a href="#Class:Data_Service">dcat:DataService</a> has been added to the DCAT vocabulary in this revision.
+            The class <a href="#Class:Data_Service"><code>dcat:DataService</code></a> has been added to the DCAT vocabulary in this revision.
         </p>
 
         <p>The following properties are recommended for use on this class:
@@ -1850,7 +1850,7 @@
             <a href="#Property:dataservice_license">license</a>,
             <a href="#Property:dataservice_access_rights">accessRights</a>
         </p>
-        <p>The following properties are are inherited from the super-class <a href="http://www.w3.org/ns/dcat#Resource">dcat:Resource</a>:
+        <p>The following properties are are inherited from the super-class <a href="http://www.w3.org/ns/dcat#Resource"><code>dcat:Resource</code></a>:
             <a href="#Property:resource_conformsto">conformsTo</a>,
             <a href="#Property:resource_contact_point">contact point</a>,
             <a href="#Property:resource_creator">creator</a>,
@@ -1873,8 +1873,8 @@
             <thead><tr><th>RDF Class:</th><th><a href="http://www.w3.org/ns/dcat#DataService">dcat:DataService</a></th></tr></thead>
             <tbody>
             <tr><td class="prop">Definition:</td><td>A site or end-point for discovery, access or processing data or related resources.</td></tr>
-            <tr><td class="prop">Sub class of:</td><td><a href="http://www.w3.org/ns/dcat#Resource">dcat:Resource</a></td></tr>
-            <tr><td class="prop">Sub class of:</td><td><a href="http://purl.org/dc/dcmitype/Service">dctype:Service</a></td></tr>
+            <tr><td class="prop">Sub class of:</td><td><a href="http://www.w3.org/ns/dcat#Resource"><code>dcat:Resource</code></a></td></tr>
+            <tr><td class="prop">Sub class of:</td><td><a href="http://purl.org/dc/dcmitype/Service"><code>dctype:Service</code></a></td></tr>
             </tbody>
         </table>
 
@@ -1886,8 +1886,8 @@
                 <thead><tr><th>RDF Property:</th><th><a href="http://www.w3.org/ns/dcat#endpointURL">dcat:endpointURL</a></th></tr></thead>
                 <tbody>
                 <tr><td class="prop">Definition:</td><td>The IRI of the service end-point.</td></tr>
-                <tr><td class="prop">Domain:</td><td><a href="http://www.w3.org/ns/dcat#DataService">dcat:DataService</a> </td></tr>
-                <tr><td class="prop">Range:</td><td><a href="http://www.w3.org/TR/xmlschema11-2/#anyURI">xsd:anyURI</a> </td></tr>
+                <tr><td class="prop">Domain:</td><td><a href="http://www.w3.org/ns/dcat#DataService"><code>dcat:DataService</code></a> </td></tr>
+                <tr><td class="prop">Range:</td><td><a href="http://www.w3.org/TR/xmlschema11-2/#anyURI"><code>xsd:anyURI</code></a> </td></tr>
                 </tbody>
             </table>
         </section>
@@ -1898,8 +1898,8 @@
                 <thead><tr><th>RDF Property:</th><th><a href="http://www.w3.org/ns/dcat#endpointDescription">dcat:endpointDescription</a></th></tr></thead>
                 <tbody>
                 <tr><td class="prop">Definition:</td><td>A description of the service end-point, for example an OpenAPI (Swagger) description [[OpenAPI]], an OGC getCapabilities response, a SPARQL Service Description [[SPARQL11-SERVICE-DESCRIPTION]], an [[OpenSearch]] or [[WSDL]] document, a Hydra API description [[HYDRA]].  </td></tr>
-                <tr><td class="prop">Domain:</td><td><a href="http://www.w3.org/ns/dcat#DataService">dcat:DataService</a> </td></tr>
-                <tr><td class="prop">Range:</td><td><a href="http://www.w3.org/2000/01/rdf-schema#Resource">rdfs:Resource</a> </td></tr>
+                <tr><td class="prop">Domain:</td><td><a href="http://www.w3.org/ns/dcat#DataService"><code>dcat:DataService</code></a> </td></tr>
+                <tr><td class="prop">Range:</td><td><a href="http://www.w3.org/2000/01/rdf-schema#Resource"><code>rdfs:Resource</code></a> </td></tr>
                 </tbody>
             </table>
         </section>
@@ -1910,8 +1910,8 @@
                 <thead><tr><th>RDF Property:</th><th><a href="http://purl.org/dc/terms/license">dct:license</a></th></tr></thead>
                 <tbody>
                 <tr><td class="prop">Definition:</td><td>A legal document under which the service is made available.</td></tr>
-                <tr><td class="prop">Range:</td><td><a href="http://purl.org/dc/terms/LicenseDocument">dct:LicenseDocument</a></td></tr>
-                <tr><td class="prop">See also:</td><td><a href="#Property:distribution_rights" title=""> distribution rights</a>,
+                <tr><td class="prop">Range:</td><td><a href="http://purl.org/dc/terms/LicenseDocument"><code>dct:LicenseDocument</code></a></td></tr>
+                <tr><td class="prop">See also:</td><td><a href="#Property:distribution_rights" title="">distribution rights</a>,
                     <a href="#Property:catalog_license" title="">catalog license</a></td></tr>
                 </tbody>
             </table>
@@ -1923,7 +1923,7 @@
                 <thead><tr><th>RDF Property:</th><th><a href="http://purl.org/dc/terms/accessRights">dct:accessRights</a></th></tr></thead>
                 <tbody>
                 <tr><td class="prop">Definition:</td><td>Access Rights <em title="MAY" class="rfc2119">MAY</em> include information regarding access or restrictions based on privacy, security, or other policies. </td></tr>
-                <tr><td class="prop">Range:</td><td><a href="http://purl.org/dc/terms/RightsStatement">dct:RightsStatement</a></td></tr>
+                <tr><td class="prop">Range:</td><td><a href="http://purl.org/dc/terms/RightsStatement"><code>dct:RightsStatement</code></a></td></tr>
                 </tbody>
             </table>
         </section>
@@ -1934,19 +1934,19 @@
         <h3>Class: Data Distribution Service</h3>
 
         <p class="note">
-            The class <a href="#Class:Data_Distribution_Service">dcat:DataDistributionService</a> has been added to the DCAT vocabulary in this revision.
+            The class <a href="#Class:Data_Distribution_Service"><code>dcat:DataDistributionService</code></a> has been added to the DCAT vocabulary in this revision.
         </p>
 
         <p>The following properties are recommended for use on this class:
             <a href="#Property:datadistributionservice_servesdataset">servesDataset</a>,
         </p>
-        <p>The following properties are inherited from the super-class <a href="http://www.w3.org/ns/dcat#DataService">dcat:DataService</a>:
+        <p>The following properties are inherited from the super-class <a href="http://www.w3.org/ns/dcat#DataService"><code>dcat:DataService</code></a>:
             <a href="#Property:dataservice_endpointdescription">endpointDescription</a>,
             <a href="#Property:dataservice_endpointurl">endpointURL</a>,
             <a href="#Property:dataservice_license">license</a>,
             <a href="#Property:dataservice_access_rights">accessRights</a>
         </p>
-        <p>The following properties are are inherited from the super-class <a href="http://www.w3.org/ns/dcat#Resource">dcat:Resource</a>:
+        <p>The following properties are are inherited from the super-class <a href="http://www.w3.org/ns/dcat#Resource"><code>dcat:Resource</code></a>:
             <a href="#Property:resource_conformsto">conformsTo</a>,
             <a href="#Property:resource_contact_point">contact point</a>,
             <a href="#Property:resource_creator">creator</a>,
@@ -1969,7 +1969,7 @@
             <thead><tr><th>RDF Class:</th><th><a href="http://www.w3.org/ns/dcat#DataDistributionService">dcat:DataDistributionService</a></th></tr></thead>
             <tbody>
             <tr><td class="prop">Definition:</td><td>A site or end-point that provides access to datasets through distributions of the datasets</td></tr>
-            <tr><td class="prop">Sub class of:</td><td><a href="http://www.w3.org/ns/dcat#DataService">dcat:DataService</a></td></tr>
+            <tr><td class="prop">Sub class of:</td><td><a href="http://www.w3.org/ns/dcat#DataService"><code>dcat:DataService</code></a></td></tr>
             </tbody>
         </table>
 
@@ -1979,7 +1979,7 @@
                 <thead><tr><th>RDF Property:</th><th><a href="http://www.w3.org/ns/dcat#servesdataset">dcat:servesDataset</a></th></tr></thead>
                 <tbody>
                 <tr><td class="prop">Definition:</td><td>A collection of data that this DataDistributionService can distribute</td></tr>
-                <tr><td class="prop">Range:</td><td><a href="http://www.w3.org/ns/dcat#Dataset">dcat:Dataset</a></td></tr>
+                <tr><td class="prop">Range:</td><td><a href="http://www.w3.org/ns/dcat#Dataset"><code>dcat:Dataset</code></a></td></tr>
                 </tbody>
             </table>
         </section>
@@ -1989,13 +1989,13 @@
 
     <section id="Class:Discovery_Service">
         <h3>Class: Discovery Service</h3>
-        <p>The following properties are inherited from the super-class <a href="http://www.w3.org/ns/dcat#DataService">dcat:DataService</a>:
+        <p>The following properties are inherited from the super-class <a href="http://www.w3.org/ns/dcat#DataService"><code>dcat:DataService</code></a>:
             <a href="#Property:dataservice_endpointdescription">endpointDescription</a>,
             <a href="#Property:dataservice_endpointurl">endpointURL</a>,
             <a href="#Property:dataservice_license">license</a>,
             <a href="#Property:dataservice_access_rights">accessRights</a>
         </p>
-        <p>The following properties are are inherited from the super-class <a href="http://www.w3.org/ns/dcat#Resource">dcat:Resource</a>:
+        <p>The following properties are are inherited from the super-class <a href="http://www.w3.org/ns/dcat#Resource"><code>dcat:Resource</code></a>:
             <a href="#Property:resource_conformsto">conformsTo</a>,
             <a href="#Property:resource_contact_point">contact point</a>,
             <a href="#Property:resource_creator">creator</a>,
@@ -2018,14 +2018,14 @@
             <thead><tr><th>RDF Class:</th><th><a href="http://www.w3.org/ns/dcat#DiscoveryService">dcat:DiscoveryService</a></th></tr></thead>
             <tbody>
             <tr><td class="prop">Definition:</td><td>A site or end-point that supports data discovery, usually by providing access to catalogs</td></tr>
-            <tr><td class="prop">Sub class of:</td><td><a href="http://www.w3.org/ns/dcat#DataDistributionService">dcat:DataDistributionService</a></td></tr>
+            <tr><td class="prop">Sub class of:</td><td><a href="http://www.w3.org/ns/dcat#DataDistributionService"><code>dcat:DataDistributionService</code></a></td></tr>
             <tr><td class="prop">Usage note:</td><td> </td></tr>
             <tr><td class="prop">See also:</td><td> </td></tr>
             </tbody>
         </table>
 
         <p class="note">
-            The class <a href="#Class:Discovery_Service">dcat:DiscoveryService</a> has been added to the DCAT vocabulary in this revision.
+            The class <a href="#Class:Discovery_Service"><code>dcat:DiscoveryService</code></a> has been added to the DCAT vocabulary in this revision.
         </p>
 
     </section> <!-- end class DiscoveryService -->
@@ -2049,8 +2049,8 @@
             <thead><tr><th>RDF Class:</th><th><a href="http://www.w3.org/2004/02/skos/core#Concept">skos:Concept</a></th></tr></thead>
             <tbody>
             <tr><td class="prop">Definition:</td><td>A category or a theme used to describe datasets in the catalog.</td></tr>
-            <tr><td class="prop">Usage note:</td><td>It is recommended to use either skos:inScheme or skos:topConceptOf on every skos:Concept
-                used to classify datasets to link it to the concept scheme it belongs to. This concept scheme is typically associated with the catalog using dcat:themeTaxonomy</td></tr>
+            <tr><td class="prop">Usage note:</td><td>It is recommended to use either <code>skos:inScheme</code> or <code>skos:topConceptOf</code> on every <code>skos:Concept</code>
+                used to classify datasets to link it to the concept scheme it belongs to. This concept scheme is typically associated with the catalog using <code>dcat:themeTaxonomy</code></td></tr>
             <tr><td class="prop">See also:</td><td><a href="#Property:catalog_themes">catalog themes</a>, <a href="#Property:resource_theme">dataset theme</a></td></tr>
             </tbody>
         </table>
@@ -2060,7 +2060,7 @@
         <h3>Class: Organization/Person</h3>
 
         <table class="definition">
-            <thead><tr><th>RDF Classes:</th><th><a href="http://xmlns.com/foaf/0.1/Person">foaf:Person</a> for people and <a href="http://xmlns.com/foaf/0.1/Organization">foaf:Organization</a> for government agencies or other entities.</th></tr></thead>
+            <thead><tr><th>RDF Classes:</th><th><a href="http://xmlns.com/foaf/0.1/Person"><code>foaf:Person</code></a> for people and <a href="http://xmlns.com/foaf/0.1/Organization"><code>foaf:Organization</code></a> for government agencies or other entities.</th></tr></thead>
             <tbody>
             <tr><td class="prop">Usage note:</td><td>[[!FOAF]] provides sufficient properties to describe these entities.</td></tr>
             </tbody>
@@ -2073,15 +2073,15 @@
           <thead><tr><th>RDF Property:</th><th><a href="http://www.w3.org/ns/dcat#hadRole">dcat:hadRole</a></th></tr></thead>
           <tbody>
           <tr><td class="prop">Definition:</td><td>The function of an entity or agent with respect to another entity or resource.</td></tr>
-          <tr><td class="prop">Domain:</td><td><a href="http://www.w3.org/ns/prov#Influence">prov:Influence</a></td></tr>
-          <tr><td class="prop">Range:</td><td><a href="http://www.w3.org/ns/prov#Role">prov:Role</a></td></tr>
+          <tr><td class="prop">Domain:</td><td><a href="http://www.w3.org/ns/prov#Influence"><code>prov:Influence</code></a></td></tr>
+          <tr><td class="prop">Range:</td><td><a href="http://www.w3.org/ns/prov#Role"><code>prov:Role</code></a></td></tr>
           <tr><td class="prop">Usage note:</td><td>"May be used in a qualified-attribution to specify the role of an Agent with respect to an Entity. It is recommended that the value be taken from a controlled vocabulary of agent roles, such as <a href="http://registry.it.csiro.au/def/isotc211/CI_RoleCode">ISO 19115 CI_RoleCode</a>.</td></tr>
           <tr><td class="prop">Usage note:</td><td>May be used in a qualified-relation to specify the role of an Entity with respect to another Entity. It is recommended that the value be taken from a controlled vocabulary of entity roles.</td></tr>
           </tbody>
         </table>
 
         <p>
-          This DCAT property complements <a href="http://www.w3.org/ns/prov#hadRole">prov:hadRole</a> which provides the function of an entity or agent with respect to an activity.
+          This DCAT property complements <a href="http://www.w3.org/ns/prov#hadRole"><code>prov:hadRole</code></a> which provides the function of an entity or agent with respect to an activity.
         </p>
 
         <p class="note">
@@ -2096,7 +2096,7 @@
     <h2>Dereferenceable identifiers</h2>
 
     <p>DCAT should rely on persistent HTTP URIs, which are an effective way of making identifiers actionable.</p>
-    <p>The property <a href="#Property:resource_identifier">dct:identifier</a>  explicitly indicates HTTP URIs as well as legacy identifiers. In the following examples,  <a href="#Property:resource_identifier">dct:identifier</a>  identifies a dataset, but it can similarly be used with any kind of resources.</p>
+    <p>The property <a href="#Property:resource_identifier"><code>dct:identifier</code></a>  explicitly indicates HTTP URIs as well as legacy identifiers. In the following examples,  <a href="#Property:resource_identifier"><code>dct:identifier</code></a>  identifies a dataset, but it can similarly be used with any kind of resources.</p>
 
     <div class="example">
     <pre class="nohighlight turtle" aria-busy="false" aria-live="polite">
@@ -2111,8 +2111,8 @@
 &lt;https://example.org/proxyid&gt; a dcat:Dataset;
 	dct:identifier  "id"^^xsd:string
     .</pre></div>
-    <p> The property <a href="https://www.w3.org/TR/vocab-adms/#adms-identifier">adms:identifier</a> can express other locally minted identifiers or external identifiers, like Datacite, DOI, ELI etc., as long as they are globally unique and stable.</p>
-    <p>The following example uses <a href="https://www.w3.org/ns/adms#schemaAgency">adms:schemaAgency</a> and <a href="http://dublincore.org/2012/06/14/dcterms#creator">dct:creator</a> to represent the authority that defines the identifier scheme (e.g., DOI foundation in the example), adms:schemaAgency is used when the authority has no URI associated.
+    <p> The property <a href="https://www.w3.org/TR/vocab-adms/#adms-identifier"><code>adms:identifier</code></a> can express other locally minted identifiers or external identifiers, like Datacite, DOI, ELI etc., as long as they are globally unique and stable.</p>
+    <p>The following example uses <a href="https://www.w3.org/ns/adms#schemaAgency"><code>adms:schemaAgency</code></a> and <a href="http://dublincore.org/2012/06/14/dcterms#creator"><code>dct:creator</code></a> to represent the authority that defines the identifier scheme (e.g., DOI foundation in the example), <code>adms:schemaAgency</code> is used when the authority has no URI associated.
     </p>
 
     <div class="example">
@@ -2138,7 +2138,7 @@ ex:InternationalDOIFundation a dct:Agent;
 
     <p> The example does not represent the authority responsible for assigning and maintaining identifiers using that scheme (e.g., zenodo) as naming the registrant goes against the philosophy of DOI where the sub-spaces are abstracted from the organisation that registers them, with the advantage that DOIs don't change when the organisation changes or the responsibility for that sub-space is handed over to someone else.</p>
 
-    <p>When the HTTP dereferenceable ID returns RDF/OWL description for the dataset, the use owl:sameAs might be consider. For example, </p>
+    <p>When the HTTP dereferenceable ID returns RDF/OWL description for the dataset, the use <code>owl:sameAs</code> might be consider. For example, </p>
     <div class="example">
     <pre class="nohighlight turtle" aria-busy="false" aria-live="polite">
 &lt;https://example.org/id&gt; a dcat:Dataset;
@@ -2199,7 +2199,7 @@ ex:InternationalDOIFundation a dct:Agent;
 
     It can relate  DCAT datasets and distributions with different types of quality information including
     <ul>
-        <li> <a href="https://www.w3.org/TR/vocab-dqv/#dqv:QualityAnnotation"> dqv:QualityAnnotation</a>, which represents feedback and quality certificates given about the dataset or its distribution. </li>
+        <li><a href="https://www.w3.org/TR/vocab-dqv/#dqv:QualityAnnotation">dqv:QualityAnnotation</a>, which represents feedback and quality certificates given about the dataset or its distribution. </li>
         <li> <a href="https://www.w3.org/TR/vocab-dqv/#dqv:QualityPolicy">dqv:QualityPolicy</a>, which represents a policy or agreement that is chiefly governed by data quality concerns.</li>
         <li><a href="https://www.w3.org/TR/vocab-dqv/#dqv:QualityMeasurement">dqv:QualityMeasurement</a>, which represents a metric value providing quantitative or qualitative information about the dataset or distribution.</li>
     </ul>
@@ -2508,12 +2508,12 @@ a:TestingActivity a prov:Activity;
 <section id="qualified-attribution">
   <h2>Attribution roles</h2>
   <p>
-    The standard Dublin Core properties <a href="http://purl.org/dc/terms/contributor">dct:contributor</a>, <a href="http://purl.org/dc/terms/creator">dct:creator</a> and <a href="http://purl.org/dc/terms/publisher">dct:publisher</a>, and the generic <a href="https://www.w3.org/TR/prov-o/#wasAttributedTo">prov:wasAttributedTo</a> from [[PROV-O]], support basic associations of responsible agents with a catalogued resource.
+    The standard Dublin Core properties <a href="http://purl.org/dc/terms/contributor"><code>dct:contributor</code></a>, <a href="http://purl.org/dc/terms/creator"><code>dct:creator</code></a> and <a href="http://purl.org/dc/terms/publisher"><code>dct:publisher</code></a>, and the generic <a href="https://www.w3.org/TR/prov-o/#wasAttributedTo"><code>prov:wasAttributedTo</code></a> from [[PROV-O]], support basic associations of responsible agents with a catalogued resource.
     However, there are many other roles of importance in relation to datasets and services - e.g. funder, distributor, custodian, editor.
     Some of these roles are enumerated in the CI_RoleCode values from [[ISO-19115-1]], in the [[DataCite]] metadata schema, and included within the <a href="https://id.loc.gov/vocabulary/relators">MARC relators</a>.
   <p>
   </p>
-    A general method for assigning an agent to a resource with a specified relationship is provided by using the qualified form <a href="https://www.w3.org/TR/prov-o/#qualifiedAttribution">prov:qualifiedAttribution</a> from [[PROV-O]].
+    A general method for assigning an agent to a resource with a specified relationship is provided by using the qualified form <a href="https://www.w3.org/TR/prov-o/#qualifiedAttribution"><code>prov:qualifiedAttribution</code></a> from [[PROV-O]].
     The following provides an illustration:
   </p>
 <div class="example">
@@ -2539,8 +2539,8 @@ ex:DS987
 </p>
 
 <p class="note">
-  Note: The domain of <a href="http://www.w3.org/ns/prov#hadRole">prov:hadRole</a> property is <a href="http://www.w3.org/ns/prov#Association">prov:Association</a> [[PROV-O]] i.e. PROV-O roles relate to activities, not entities.
-  Therefore, a new property <a href="http://www.w3.org/ns/dcat#hadRole">dcat:hadRole</a> is used to attach a specific role to the association-class <a href="http://www.w3.org/ns/prov#Attribution">prov:Attribution</a>.
+  Note: The domain of <a href="http://www.w3.org/ns/prov#hadRole"><code>prov:hadRole</code></a> property is <a href="http://www.w3.org/ns/prov#Association"><code>prov:Association</code></a> [[PROV-O]] i.e. PROV-O roles relate to activities, not entities.
+  Therefore, a new property <a href="http://www.w3.org/ns/dcat#hadRole"><code>dcat:hadRole</code></a> is used to attach a specific role to the association-class <a href="http://www.w3.org/ns/prov#Attribution"><code>prov:Attribution</code></a>.
 </p>
 </section>
 
@@ -2556,7 +2556,7 @@ ex:DS987
         <a href="https://github.com/w3c/dxwg/issues/66">Issue #66</a>,
         <a href="https://github.com/w3c/dxwg/issues/63">Issue #63</a>.
         It has been suggested that many of the requirements can be satisfied by using capabilities from the [[PROV-O]] ontology,
-        in particular by treating <code><a href="#Class:Resource">dcat:Resource</a></code> and/or <code><a href="#Class:Catalog_Record">dcat:CatalogRecord</a></code> a sub-class of <a href="http://www.w3.org/ns/prov#Entity">prov:Entity</a>.
+        in particular by treating <code><a href="#Class:Resource">dcat:Resource</a></code> and/or <code><a href="#Class:Catalog_Record">dcat:CatalogRecord</a></code> a sub-class of <a href="http://www.w3.org/ns/prov#Entity"><code>prov:Entity</code></a>.
         A preliminary <a href="https://raw.githubusercontent.com/w3c/dxwg/gh-pages/dcat/rdf/dcat-prov.ttl">alignment of DCAT with PROV-O is available</a>.
     </p>
 
@@ -2591,12 +2591,12 @@ ex:DS987
 	<p>
 		The following approach is recommended:
 		<ol>
-			<li>use <a href="http://dublincore.org/documents/dcmi-terms/#terms-license">dct:license</a> to refer to well-known licenses such as <a href="https://creativecommons.org/share-your-work/licensing-types-examples/">those defined by Creative Commons</a></br>
-			The object of dct:license, a <a href="http://dublincore.org/documents/dcmi-terms/#terms-LicenseDocument">dct:LicenseDocument</a>, is "A legal document giving official permission to do something with a Resource."</li>
-			<li>use <a href="http://dublincore.org/documents/dcmi-terms/#terms-rights">dct:rights</a> to refer to rights statements that are not licenses, such as copyright statements</br>
-			The object of dct:rights, a <a href="http://dublincore.org/documents/dcmi-terms/#terms-RightsStatement">dct:RightsStatement</a>, is "A statement about the intellectual property rights (IPR) held in or over a Resource, a legal document giving official permission to do something with a resource, or a statement about access rights."
-			This is more general than a <a href="http://dublincore.org/documents/dcmi-terms/#terms-LicenseDocument">dct:LicenseDocument</a> and therefore should be used if it the statement contains more general information about rights.</li>
-			<li>use <a href="https://www.w3.org/TR/odrl-vocab/#term-hasPolicy">odrl:hasPolicy</a> for linking to <a href="https://www.w3.org/TR/odrl-vocab/#term-Policy">ODRL policies</a></br>
+			<li>use <a href="http://dublincore.org/documents/dcmi-terms/#terms-license"><code>dct:license</code></a> to refer to well-known licenses such as <a href="https://creativecommons.org/share-your-work/licensing-types-examples/">those defined by Creative Commons</a></br>
+			The object of <code>dct:license</code>, a <a href="http://dublincore.org/documents/dcmi-terms/#terms-LicenseDocument"><code>dct:LicenseDocument</code></a>, is "A legal document giving official permission to do something with a Resource."</li>
+			<li>use <a href="http://dublincore.org/documents/dcmi-terms/#terms-rights"><code>dct:rights</code></a> to refer to rights statements that are not licenses, such as copyright statements</br>
+			The object of <code>dct:rights</code>, a <a href="http://dublincore.org/documents/dcmi-terms/#terms-RightsStatement"><code>dct:RightsStatement</code></a>, is "A statement about the intellectual property rights (IPR) held in or over a Resource, a legal document giving official permission to do something with a resource, or a statement about access rights."
+			This is more general than a <a href="http://dublincore.org/documents/dcmi-terms/#terms-LicenseDocument"><code>dct:LicenseDocument</code></a> and therefore should be used if it the statement contains more general information about rights.</li>
+			<li>use <a href="https://www.w3.org/TR/odrl-vocab/#term-hasPolicy"><code>odrl:hasPolicy</code></a> for linking to <a href="https://www.w3.org/TR/odrl-vocab/#term-Policy">ODRL policies</a></br>
 			The Open Digital Rights Language (ODRL) is a policy expression language that provides a flexible and interoperable information model, vocabulary, and encoding mechanisms for representing statements about usage (i.e. permissions, prohibitions, and obligations) of content and services.</li>
 		</ol>
 	</p>
@@ -2615,32 +2615,32 @@ ex:DS987
 	</p>
 
 	<p>
-		To address these scenarios, the recommendation is to use property dct:rights, and its sub-properties dct:license and dct:accessRights. More precisely:
+		To address these scenarios, the recommendation is to use property <code>dct:rights</code>, and its sub-properties <code>dct:license</code> and <code>dct:accessRights</code>. More precisely:
   </p>
 		<ol>
 			<li>
-			  <p>use <a href="http://dublincore.org/documents/dcmi-terms/#terms-license">dct:license</a> to refer to licenses;</p>
+			  <p>use <a href="http://dublincore.org/documents/dcmi-terms/#terms-license"><code>dct:license</code></a> to refer to licenses;</p>
 <!--
-			<p>The object of dct:license, a <a href="http://dublincore.org/documents/dcmi-terms/#terms-LicenseDocument">dct:LicenseDocument</a>, is "A legal document giving official permission to do something with a Resource."</p>
+			<p>The object of <code>dct:license</code>, a <a href="http://dublincore.org/documents/dcmi-terms/#terms-LicenseDocument"><code>dct:LicenseDocument</code></a>, is "A legal document giving official permission to do something with a Resource."</p>
 -->
         <p class="note">
           For interoperability, it is recommended to use canonical URIs of well-known licenses such as <a href="https://creativecommons.org/share-your-work/licensing-types-examples/">those defined by Creative Commons</a>.
         </p>
 			</li>
 			<li>
-			  <p>use <a href="http://dublincore.org/documents/dcmi-terms/#terms-accessRights">dct:accessRights</a>  to express statements concerning only access rights (e.g., whether data can be accessed by anyone or just by authorized parties);</p>
+			  <p>use <a href="http://dublincore.org/documents/dcmi-terms/#terms-accessRights"><code>dct:accessRights</code></a>  to express statements concerning only access rights (e.g., whether data can be accessed by anyone or just by authorized parties);</p>
 <!--
-        <p>The object of dct:accessRights is a dct:RightsStatement providing "Information about who can access the resource or an indication of its security status."</p>
+        <p>The object of <code>dct:accessRights</code> is a <code>dct:RightsStatement</code> providing "Information about who can access the resource or an indication of its security status."</p>
 -->
         <p class="note">
           Access rights can also be expressed as code lists / taxonomies. Examples include the access rights code list  [[MDR-AR]] used in [[DCAT-AP]] and the <a href="http://purl.org/eprint/accessRights/">Eprints Access Rights Vocabulary Encoding Scheme</a>.
         </p>
       </li>
 			<li>
-			  <p>use <a href="http://dublincore.org/documents/dcmi-terms/#terms-rights">dct:rights</a> for all the other types of rights statements - those which are not covered by dct:license and dct:accessRights, such as copyright statementss.</p>
+			  <p>use <a href="http://dublincore.org/documents/dcmi-terms/#terms-rights"><code>dct:rights</code></a> for all the other types of rights statements - those which are not covered by <code>dct:license</code> and <code>dct:accessRights</code>, such as copyright statements.</p>
 <!--
-			  <p>The object of dct:rights, a <a href="http://dublincore.org/documents/dcmi-terms/#terms-RightsStatement">dct:RightsStatement</a>, is "A statement about the intellectual property rights (IPR) held in or over a Resource, a legal document giving official permission to do something with a resource, or a statement about access rights."
-			This is more general than a <a href="http://dublincore.org/documents/dcmi-terms/#terms-LicenseDocument">dct:LicenseDocument</a> and therefore should be used if it the statement contains more general information about rights.</p>
+			  <p>The object of <code>dct:rights</code>, a <a href="http://dublincore.org/documents/dcmi-terms/#terms-RightsStatement"><code>dct:RightsStatement</code></a>, is "A statement about the intellectual property rights (IPR) held in or over a Resource, a legal document giving official permission to do something with a resource, or a statement about access rights."
+			This is more general than a <a href="http://dublincore.org/documents/dcmi-terms/#terms-LicenseDocument"><code>dct:LicenseDocument</code></a> and therefore should be used if it the statement contains more general information about rights.</p>
 -->
 			  <p class="note">
 			    A more sophisticated approach to express rights, based on and extending [[DCTERMS]], is provided by the Open Data Rights Statement Vocabulary (ODRS) [[ODRS]], which defines properties for specifying, among others, copyright statements and copyright notices.
@@ -2648,7 +2648,7 @@ ex:DS987
 			</li>
 		</ol>
 
-	<p>Finally, in the particular case when rights are expressed via <a href="https://www.w3.org/TR/odrl-vocab/#term-Policy">ODRL policies</a>, it is recommended to use use the <a href="https://www.w3.org/TR/odrl-vocab/#term-hasPolicy">odrl:hasPolicy</a> property as the link from the description of the catalogued resource or distribution to the ODRL policy, in addition to the relevant <code>dct</code> property.</p>
+	<p>Finally, in the particular case when rights are expressed via <a href="https://www.w3.org/TR/odrl-vocab/#term-Policy">ODRL policies</a>, it is recommended to use use the <a href="https://www.w3.org/TR/odrl-vocab/#term-hasPolicy"><code>odrl:hasPolicy</code></a> property as the link from the description of the catalogued resource or distribution to the ODRL policy, in addition to the relevant <code>dct</code> property.</p>
   <p class="note">The Open Digital Rights Language (ODRL) [[ODRL-VOCAB]] is a policy expression language that provides a flexible and interoperable information model, vocabulary, and encoding mechanisms for representing statements about usage (i.e. permissions, prohibitions, and obligations) of content and services.</p>
 
   <p>Recommendations on the use of these properties on the different types of resources defined in DCAT are provided in the relevant class descriptions.</p>
@@ -3210,8 +3210,8 @@ ex:DS987
                 <thead><tr><th>RDF Property:</th><th><a href="http://www.w3.org/ns/dcat#datasets">dcat:datasets</a></th></tr></thead>
                 <tbody>
                 <tr><td class="prop">Definition:</td><td>Connects a catalog to the LDP container of its datasets.</td></tr>
-                <tr><td class="prop">Domain:</td><td><a href="http://www.w3.org/ns/dcat#Catalog">dcat:Catalog</a></td></tr>
-                <tr><td class="prop">Range:</td><td><a href="http://www.w3.org/ns/ldp#DirectContainer">ldp:DirectContainer</a></td></tr>
+                <tr><td class="prop">Domain:</td><td><a href="http://www.w3.org/ns/dcat#Catalog"><code>dcat:Catalog</code></a></td></tr>
+                <tr><td class="prop">Range:</td><td><a href="http://www.w3.org/ns/ldp#DirectContainer"><code>ldp:DirectContainer</code></a></td></tr>
                 </tbody>
             </table>
         </section>
@@ -3223,8 +3223,8 @@ ex:DS987
                 <thead><tr><th>RDF Property:</th><th><a href="http://www.w3.org/ns/dcat#records">dcat:records</a></th></tr></thead>
                 <tbody>
                 <tr><td class="prop">Definition:</td><td>Connects a catalog to the LDP container of its catalog records.</td></tr>
-                <tr><td class="prop">Domain:</td><td><a href="http://www.w3.org/ns/dcat#Catalog">dcat:Catalog</a></td></tr>
-                <tr><td class="prop">Range:</td><td><a href="http://www.w3.org/ns/ldp#DirectContainer">ldp:DirectContainer</a></td></tr>
+                <tr><td class="prop">Domain:</td><td><a href="http://www.w3.org/ns/dcat#Catalog"><code>dcat:Catalog</code></a></td></tr>
+                <tr><td class="prop">Range:</td><td><a href="http://www.w3.org/ns/ldp#DirectContainer"><code>ldp:DirectContainer</code></a></td></tr>
                 </tbody>
             </table>
         </section>
@@ -3236,8 +3236,8 @@ ex:DS987
                 <thead><tr><th>RDF Property:</th><th><a href="http://www.w3.org/ns/dcat#services">dcat:services</a></th></tr></thead>
                 <tbody>
                 <tr><td class="prop">Definition:</td><td>Connects a catalog to the LDP container of its data services.</td></tr>
-                <tr><td class="prop">Domain:</td><td><a href="http://www.w3.org/ns/dcat#Catalog">dcat:Catalog</a></td></tr>
-                <tr><td class="prop">Range:</td><td><a href="http://www.w3.org/ns/ldp#DirectContainer">ldp:DirectContainer</a></td></tr>
+                <tr><td class="prop">Domain:</td><td><a href="http://www.w3.org/ns/dcat#Catalog"><code>dcat:Catalog</code></a></td></tr>
+                <tr><td class="prop">Range:</td><td><a href="http://www.w3.org/ns/ldp#DirectContainer"><code>ldp:DirectContainer</code></a></td></tr>
                 </tbody>
             </table>
         </section>
@@ -3249,8 +3249,8 @@ ex:DS987
                 <thead><tr><th>RDF Property:</th><th><a href="http://www.w3.org/ns/dcat#distributions">dcat:distributions</a></th></tr></thead>
                 <tbody>
                 <tr><td class="prop">Definition:</td><td>Connects a dataset to the LDP container of its distributions.</td></tr>
-                <tr><td class="prop">Domain:</td><td><a href="http://www.w3.org/ns/dcat#Dataset">dcat:Dataset</a></td></tr>
-                <tr><td class="prop">Range:</td><td><a href="http://www.w3.org/ns/ldp#DirectContainer">ldp:DirectContainer</a></td></tr>
+                <tr><td class="prop">Domain:</td><td><a href="http://www.w3.org/ns/dcat#Dataset"><code>dcat:Dataset</code></a></td></tr>
+                <tr><td class="prop">Range:</td><td><a href="http://www.w3.org/ns/ldp#DirectContainer"><code>ldp:DirectContainer</code></a></td></tr>
                 </tbody>
             </table>
         </section>
@@ -3363,7 +3363,7 @@ ex:DS987
           In many legacy catalogues and repositories (e.g. CKAN), ‘datasets’ are ‘just a bag of files’. There is no distinction made between part/whole, distribution (representation), and other kinds of relationship (e.g. documentation, schema, supporting documents) from the dataset to each of the files.
       </p>
       <p>
-          If the nature of the relationships between a dataset and component resources in a catalogue, repository, or elsewhere are not known, <b>dct:relation</b> can be used:
+          If the nature of the relationships between a dataset and component resources in a catalogue, repository, or elsewhere are not known, <code>dct:relation</code> can be used:
       </p>
       <div class="example">
 <pre class="nohighlight turtle" aria-busy="false" aria-live="polite">
@@ -3382,7 +3382,7 @@ dct:relation :isc2017.ttl ;
 .
 </pre></div>
       <p>
-          If it is clear that any of these related resources is a proper <i>representation</i> of the dataset, dcat:distribution should be used.
+          If it is clear that any of these related resources is a proper <i>representation</i> of the dataset, <code>dcat:distribution</code> should be used.
       </p>
       <div class="example">
 <pre class="nohighlight turtle" aria-busy="false" aria-live="polite">
@@ -3457,19 +3457,19 @@ rdfs:seeAlso &lt;https://doi.org/10.1111/j.1365-2966.2006.10100.x&gt; ;
           This example is available from the <a href="https://github.com/w3c/dxwg/tree/gh-pages/dcat/examples">DXWG code repository</a> at <a href="https://raw.githubusercontent.com/w3c/dxwg/gh-pages/dcat/examples/csiro-dap-examples.ttl">csiro-dap-examples.ttl</a>
       </p>
       <p>
-          Several properties capture provenance information, including within the citation and title, but the primary link to a formal description of the project is through <a href="#Property:dataset_wasgeneratedby">prov:wasGeneratedBy</a>.
-          A terse description of the project is shown as a <a href="http://www.w3.org/ns/prov#Activity">prov:Activity</a>, though this would not necessarily be part of the same catalog.
+          Several properties capture provenance information, including within the citation and title, but the primary link to a formal description of the project is through <a href="#Property:dataset_wasgeneratedby"><code>prov:wasGeneratedBy</code></a>.
+          A terse description of the project is shown as a <a href="http://www.w3.org/ns/prov#Activity"><code>prov:Activity</code></a>, though this would not necessarily be part of the same catalog.
           Note that as the project is ongoing, the activity has no end date.
       </p>
       <p>
-          Further provenance information might be provided using the other <i>starting point properties</i> from PROV, in particular <a href="http://www.w3.org/TR/prov-o/#wasAttributedTo">prov:wasAttributedTo</a> (to link to an agent associated with the dataset production) and <a href="http://www.w3.org/TR/prov-o/#wasDerivedFrom">prov:wasDerivedFrom</a> (to link to a predecessor dataset). Both of these complement Dublin Core properties already used in DCAT, as follows:
+          Further provenance information might be provided using the other <i>starting point properties</i> from PROV, in particular <a href="http://www.w3.org/TR/prov-o/#wasAttributedTo"><code>prov:wasAttributedTo</code></a> (to link to an agent associated with the dataset production) and <a href="http://www.w3.org/TR/prov-o/#wasDerivedFrom"><code>prov:wasDerivedFrom</code></a> (to link to a predecessor dataset). Both of these complement Dublin Core properties already used in DCAT, as follows:
       </p>
       <ul>
           <li>
-              <b>prov:wasAttributedTo</b> provides a general link to all kinds of associated agents, such as project sponsors, managers, dataset owners, etc which are not correctly characterized using <b>dct:creator</b>, <b>dct:contributor</b> or <b>dct:publisher</b>.
+              <code>prov:wasAttributedTo</code> provides a general link to all kinds of associated agents, such as project sponsors, managers, dataset owners, etc which are not correctly characterized using <code>dct:creator</code>, <code>dct:contributor</code> or <code>dct:publisher</code>.
           </li>
           <li>
-              <b>prov:wasDerivedFrom</b> supports a more specific relationship to an input or predecessor dataset compared with <b>dct:source</b>, which is not necessarily a previous dataset.
+              <code>prov:wasDerivedFrom</code> supports a more specific relationship to an input or predecessor dataset compared with <code>dct:source</code>, which is not necessarily a previous dataset.
           </li>
       </ul>
       <p>
@@ -3482,11 +3482,11 @@ rdfs:seeAlso &lt;https://doi.org/10.1111/j.1365-2966.2006.10100.x&gt; ;
       <h3>Data services</h3>
       <p>
           Data services may be described using DCAT.
-          The values of the classifiers <b>dct:type</b>, <b>dct:conformsTo</b>, and <b>dcat:endpointDescription</b> provide progressively more detail about a service, whose actual endpoint is given by the <b>dcat:endpointURL</b>.
+          The values of the classifiers <code>dct:type</code>, <code>dct:conformsTo</code>, and <code>dcat:endpointDescription</code> provide progressively more detail about a service, whose actual endpoint is given by the <code>dcat:endpointURL</code>.
       </p>
       <p>
           The first example describes a data catalog hosted by the European Environment Agency.
-          This is classified as a <a href="#Class:Discovery_Service">dcat:DiscoveryService</a> and also has the <code>dct:type</code> set to <a href="http://inspire.ec.europa.eu/metadata-codelist/SpatialDataServiceType/discovery">discovery</a> from the <a href="http://inspire.ec.europa.eu/metadata-codelist/SpatialDataServiceType/">INSPIRE classification of spatial data service types</a>.
+          This is classified as a <a href="#Class:Discovery_Service"><code>dcat:DiscoveryService</code></a> and also has the <code>dct:type</code> set to <a href="http://inspire.ec.europa.eu/metadata-codelist/SpatialDataServiceType/discovery">discovery</a> from the <a href="http://inspire.ec.europa.eu/metadata-codelist/SpatialDataServiceType/">INSPIRE classification of spatial data service types</a>.
       </p>
       <p>
           This example is available from the <a href="https://github.com/w3c/dxwg/tree/gh-pages/dcat/examples">DXWG code repository</a> at <a href="https://raw.githubusercontent.com/w3c/dxwg/gh-pages/dcat/examples/eea-csw.ttl">eea-csw.ttl</a>
@@ -3516,8 +3516,8 @@ dcat:endpointURL &lt;http://sdi.eea.europa.eu/catalogue/srv/eng/csw&gt; ;
 .
 </pre></div>
       <p>
-          The next example shows a dataset hosted by Geoscience Australia, which is available from three distinct services, as indicated by the value of the <a href="#Property:datadistributionservice_servesdataset">dcat:servesDataset</a> property of each of the service descriptions.
-          These are classified as a <a href="#Class:Data_Distribution_Service">dcat:DataDistributionService</a> and also have the <code>dct:type</code> set to <a href="http://inspire.ec.europa.eu/metadata-codelist/SpatialDataServiceType/download">download</a> and <a href="http://inspire.ec.europa.eu/metadata-codelist/SpatialDataServiceType/view">view</a> from the <a href="http://inspire.ec.europa.eu/metadata-codelist/SpatialDataServiceType/">INSPIRE classification of spatial data service types</a>.
+          The next example shows a dataset hosted by Geoscience Australia, which is available from three distinct services, as indicated by the value of the <a href="#Property:datadistributionservice_servesdataset"><code>dcat:servesDataset</code></a> property of each of the service descriptions.
+          These are classified as a <a href="#Class:Data_Distribution_Service"><code>dcat:DataDistributionService</code></a> and also have the <code>dct:type</code> set to <a href="http://inspire.ec.europa.eu/metadata-codelist/SpatialDataServiceType/download">download</a> and <a href="http://inspire.ec.europa.eu/metadata-codelist/SpatialDataServiceType/view">view</a> from the <a href="http://inspire.ec.europa.eu/metadata-codelist/SpatialDataServiceType/">INSPIRE classification of spatial data service types</a>.
       </p>
       <p>
           This example is available from the <a href="https://github.com/w3c/dxwg/tree/gh-pages/dcat/examples">DXWG code repository</a> at <a href="https://raw.githubusercontent.com/w3c/dxwg/gh-pages/dcat/examples/ga-courts.ttl">ga-courts.ttl</a>
@@ -3609,37 +3609,37 @@ dcat:servesDataset ga-courts:jc ;
             </li>
 
             <li>
-                <a href="#Property:hadRole">Property: had role</a>: The property dcat:hadRole is added to support the use of prov:qualifiedAttribution to associate an agent with a DCAT resource, where the role of the agent with relation to the resource is specified, and is something other than the standard Dublin Core roles: creator, publisher or contributor - see <a href="https://github.com/w3c/dxwg/issues/79">Issue #79</a>
+                <a href="#Property:hadRole">Property: had role</a>: The property <code>dcat:hadRole</code> is added to support the use of <code>prov:qualifiedAttribution</code> to associate an agent with a DCAT resource, where the role of the agent with relation to the resource is specified, and is something other than the standard Dublin Core roles: creator, publisher or contributor - see <a href="https://github.com/w3c/dxwg/issues/79">Issue #79</a>
             </li>
 
             <li>
-               The section <a href="#license-rights">License and rights statements</a> was added to describe patterns for linking dcat:Datasets and dcat:Distributions to the relevant license and rights expressions.
+               The section <a href="#license-rights">License and rights statements</a> was added to describe patterns for linking <code>dcat:Datasets</code> and <code>dcat:Distribution</code>s to the relevant license and rights expressions.
             </li>
 
             <li>
-                <a href="#Property:dataset_creator">Property: dataset creator</a>: The property dct:creator is recommended for use in the context of a dataset to allow the entity responsible for generating the dataset to be recorded - see <a href="https://github.com/w3c/dxwg/issues/61">Issue #61</a>
-            </li>
-
-
-            <li>
-                <a href="#Property:dataset_wasgeneratedby">Property: was generated by</a>: The property prov:wasGeneratedBy is recommended for use in the context of a dataset to allow the provenance or business context to be recorded - see <a href="https://github.com/w3c/dxwg/issues/71">Issue #71</a>
-            </li>
-
-            <li>
-                <a href="#Property:resource_relation">Property: resource relation</a>: The property dct:relation is recommended for use in the context of a catalogued resource to capture general relationships, including the case where the package of resources associated with a catalogued item includes a mixture of representations, parts, documentation and other elements which are not strictly 'distributions' of a dataset - see <a href="https://github.com/w3c/dxwg/issues/253">Issue #253</a>.
+                <a href="#Property:dataset_creator">Property: dataset creator</a>: The property <code>dct:creator</code> is recommended for use in the context of a dataset to allow the entity responsible for generating the dataset to be recorded - see <a href="https://github.com/w3c/dxwg/issues/61">Issue #61</a>
             </li>
 
 
             <li>
-                <a href="#Property:distribution_media_type">Property:media_type</a>: The range of dcat:mediaType has been tightened from dct:MediaTypeOrExtent to dct:MediaType - see <a href="https://github.com/w3c/dxwg/issues/127">Issue #127</a>.
+                <a href="#Property:dataset_wasgeneratedby">Property: was generated by</a>: The property <code>prov:wasGeneratedBy</code> is recommended for use in the context of a dataset to allow the provenance or business context to be recorded - see <a href="https://github.com/w3c/dxwg/issues/71">Issue #71</a>
             </li>
 
             <li>
-                <a href="#Property:distribution_conformsto">Property: conforms to</a>: The property dct:conformsTo is recommended for use in the context of a dcat:Distribution to allow the model or schema used for the representation to be indicated as well as the serialization (which is indicated using dct:format and dcat:mediaType) - see <a href="https://github.com/w3c/dxwg/issues/55">Issue #55</a>.
+                <a href="#Property:resource_relation">Property: resource relation</a>: The property <code>dct:relation</code> is recommended for use in the context of a catalogued resource to capture general relationships, including the case where the package of resources associated with a catalogued item includes a mixture of representations, parts, documentation and other elements which are not strictly 'distributions' of a dataset - see <a href="https://github.com/w3c/dxwg/issues/253">Issue #253</a>.
+            </li>
+
+
+            <li>
+                <a href="#Property:distribution_media_type">Property: media type</a>: The range of <code>dcat:mediaType</code> has been tightened from <code>dct:MediaTypeOrExtent</code> to <code>dct:MediaType</code> - see <a href="https://github.com/w3c/dxwg/issues/127">Issue #127</a>.
             </li>
 
             <li>
-                Errors in examples of <a href="#Property:distribution_media_type">dcat:mediaType</a> usage fixed - see <a href="https://github.com/w3c/dxwg/issues/170">Issue #170</a>.
+                <a href="#Property:distribution_conformsto">Property: conforms to</a>: The property <code>dct:conformsTo</code> is recommended for use in the context of a <code>dcat:Distribution</code> to allow the model or schema used for the representation to be indicated as well as the serialization (which is indicated using <code>dct:format</code> and <code>dcat:mediaType</code>) - see <a href="https://github.com/w3c/dxwg/issues/55">Issue #55</a>.
+            </li>
+
+            <li>
+                Errors in examples of <a href="#Property:distribution_media_type"><code>dcat:mediaType</code></a> usage fixed - see <a href="https://github.com/w3c/dxwg/issues/170">Issue #170</a>.
             </li>
 
             <li>
@@ -3647,33 +3647,33 @@ dcat:servesDataset ga-courts:jc ;
             </li>
 
             <li>
-                <a href="#Class:Resource">Class: Catalogued resource</a>: In DCAT 2014 [[VOCAB-DCAT-20140116]] the scope of a <a href="#Class:Catalog">dcat:Catalog</a> was limited to Datasets. This has been generalized, and properties common to all catalogued resources are now associated with a super-class <code><a href="#Class:Resource">dcat:Resource</a></code> - see <a href="https://github.com/w3c/dxwg/issues/172">Issue #172</a> and <a href="https://github.com/w3c/dxwg/issues/116">Issue #116</a>. The wiki page on <a href="https://github.com/w3c/dxwg/wiki/Cataloguing-data-services">Cataloguing data services</a> describes some proposals related to this requirement.
+                <a href="#Class:Resource">Class: Catalogued resource</a>: In DCAT 2014 [[VOCAB-DCAT-20140116]] the scope of a <a href="#Class:Catalog"><code>dcat:Catalog</code></a> was limited to Datasets. This has been generalized, and properties common to all catalogued resources are now associated with a super-class <code><a href="#Class:Resource"><code>dcat:Resource</code></a></code> - see <a href="https://github.com/w3c/dxwg/issues/172">Issue #172</a> and <a href="https://github.com/w3c/dxwg/issues/116">Issue #116</a>. The wiki page on <a href="https://github.com/w3c/dxwg/wiki/Cataloguing-data-services">Cataloguing data services</a> describes some proposals related to this requirement.
             </li>
 
             <li>
-                <a href="#Class:Data_Service">Class: Data service</a>: In DCAT 2014 [[VOCAB-DCAT-20140116]] the scope of a <a href="#Class:Catalog">dcat:Catalog</a> was limited to Datasets. The new class dcat:DataService has been added to support cataloguing various kinds of data services - see <a href="https://github.com/w3c/dxwg/issues/172">Issue #172</a>.
+                <a href="#Class:Data_Service">Class: Data service</a>: In DCAT 2014 [[VOCAB-DCAT-20140116]] the scope of a <a href="#Class:Catalog"><code>dcat:Catalog</code></a> was limited to Datasets. The new class <code>dcat:DataService</code> has been added to support cataloguing various kinds of data services - see <a href="https://github.com/w3c/dxwg/issues/172">Issue #172</a>.
             </li>
 
             <li>
-                <a href="#Class:Data_Distribution_Service">Class: Data distribution service</a>: In DCAT 2014 [[VOCAB-DCAT-20140116]] the scope of a <a href="#Class:Catalog">dcat:Catalog</a> was limited to Datasets. The new class dcat:DataDistributionService has been added to support cataloguing data distribution services - see <a href="https://github.com/w3c/dxwg/issues/172">Issue #172</a> and <a href="https://github.com/w3c/dxwg/issues/56">Issue #56</a>.
+                <a href="#Class:Data_Distribution_Service">Class: Data distribution service</a>: In DCAT 2014 [[VOCAB-DCAT-20140116]] the scope of a <a href="#Class:Catalog"><code>dcat:Catalog</code></a> was limited to Datasets. The new class <code>dcat:DataDistributionService</code> has been added to support cataloguing data distribution services - see <a href="https://github.com/w3c/dxwg/issues/172">Issue #172</a> and <a href="https://github.com/w3c/dxwg/issues/56">Issue #56</a>.
             </li>
 
             <li>
-                <a href="#Class:Discovery_Service">Class: Discovery service</a>: In DCAT 2014 [[VOCAB-DCAT-20140116]] the scope of a <a href="#Class:Catalog">dcat:Catalog</a> was limited to Datasets. The new class dcat:DiscoveryService has been added to support cataloguing data discovery services - see <a href="https://github.com/w3c/dxwg/issues/172">Issue #172</a>.
+                <a href="#Class:Discovery_Service">Class: Discovery service</a>: In DCAT 2014 [[VOCAB-DCAT-20140116]] the scope of a <a href="#Class:Catalog"><code>dcat:Catalog</code></a> was limited to Datasets. The new class <code>dcat:DiscoveryService</code> has been added to support cataloguing data discovery services - see <a href="https://github.com/w3c/dxwg/issues/172">Issue #172</a>.
             </li>
 
             <li><a href="#Class:Dataset">Class: Dataset</a>:
-                In DCAT 2014 [[VOCAB-DCAT-20140116]] <a href="#Class:Dataset">dcat:Dataset</a> was a sub-class of <a href="http://purl.org/dc/dcmitype/Dataset">dctype:Dataset</a>, which is a term of the <a href="http://dublincore.org/documents/dcmi-terms/#section-7">DCMI Types vocabulary</a> [[DCTERMS]]. This relationship has been removed in the revised DCAT vocabulary - see <a href="https://github.com/w3c/dxwg/issues/98">Issue #98</a>.
+                In DCAT 2014 [[VOCAB-DCAT-20140116]] <a href="#Class:Dataset"><code>dcat:Dataset</code></a> was a sub-class of <a href="http://purl.org/dc/dcmitype/Dataset"><code>dctype:Dataset</code></a>, which is a term of the <a href="http://dublincore.org/documents/dcmi-terms/#section-7">DCMI Types vocabulary</a> [[DCTERMS]]. This relationship has been removed in the revised DCAT vocabulary - see <a href="https://github.com/w3c/dxwg/issues/98">Issue #98</a>.
             </li>
 
             <li>
                 <a href="#Class:Distribution">Class: Distribution</a>
-                : In DCAT 2014 [[VOCAB-DCAT-20140116]] the definition of a <a href="#Class:Distribution">dcat:Distribution</a> allowed a number of alternative interpretations. The definition has been rephrased to clarify that distributions are primarily <i>representations</i> of datasets. See <a href="https://github.com/w3c/dxwg/issues/172">Issue #52</a> and related use cases.
+                : In DCAT 2014 [[VOCAB-DCAT-20140116]] the definition of a <a href="#Class:Distribution"><code>dcat:Distribution</code></a> allowed a number of alternative interpretations. The definition has been rephrased to clarify that distributions are primarily <i>representations</i> of datasets. See <a href="https://github.com/w3c/dxwg/issues/172">Issue #52</a> and related use cases.
             </li>
 
 
             <li><a href="#Property:resource_theme">Property: theme/category</a>:
-                In DCAT 2014 [[VOCAB-DCAT-20140116]] the domain of dcat:theme was dcat:Dataset,
+                In DCAT 2014 [[VOCAB-DCAT-20140116]] the domain of <code>dcat:theme</code> was <code>dcat:Dataset</code>,
                 which limited use of this property in other contexts. The domain has been relaxed in this revision -
                 see <a href="https://github.com/w3c/dxwg/issues/123">Issue #123</a>.
             </li>
@@ -3683,37 +3683,37 @@ dcat:servesDataset ga-courts:jc ;
             </li>
 
             <li><a href="#Property:resource_keyword">Property: keyword/tag</a>:
-                In DCAT 2014 [[VOCAB-DCAT-20140116]] the domain of dcat:keyword was dcat:Dataset,
+                In DCAT 2014 [[VOCAB-DCAT-20140116]] the domain of <code>dcat:keyword</code> was <code>dcat:Dataset</code>,
                 which limited use of this property in other contexts. The domain has been relaxed in this revision -
                 see <a href="https://github.com/w3c/dxwg/issues/121">Issue #121</a>.
             </li>
 
             <li><a href="#Property:resource_contact_point">Property: contact point</a>:
-                In DCAT 2014 [[VOCAB-DCAT-20140116]] the domain of dcat:contactPoint was dcat:Dataset,
+                In DCAT 2014 [[VOCAB-DCAT-20140116]] the domain of <code>dcat:contactPoint</code> was <code>dcat:Dataset</code>,
                 which limited use of this property in other contexts. The domain has been relaxed in this revision -
                 see <a href="https://github.com/w3c/dxwg/issues/95">Issue #95</a>.
             </li>
 
             <li><a href="#Property:resource_landing_page">Property: landing page</a>:
-                In DCAT 2014 [[VOCAB-DCAT-20140116]] the domain of dcat:landingPage was dcat:Dataset,
+                In DCAT 2014 [[VOCAB-DCAT-20140116]] the domain of <code>dcat:landingPage</code> was <code>dcat:Dataset</code>,
                 which limited use of this property in other contexts. The domain has been relaxed in this revision -
                 see <a href="https://github.com/w3c/dxwg/issues/122">Issue #122</a>.
             </li>
 
-            <li><a href="http://vocab.org/vann/#usageNote">Property: vann:usageNote</a>:
-                DCAT 2014 [[VOCAB-DCAT-20140116]] included documentation captured as text using <a href="http://vocab.org/vann/#usageNote">vann:usageNote</a> elements,
-                which is a sub-property of rdfs:seeAlso - an owl:ObjectProperty that cannot have a Literal value.
-                This revision of DCAT has fixed these issues and replaced the use of vann:usageNote with <a href="https://www.w3.org/TR/skos-primer/#secdocumentation">skos:scopeNote</a> -
+            <li><a href="http://vocab.org/vann/#usageNote">Property: <code>vann:usageNote</code></a>:
+                DCAT 2014 [[VOCAB-DCAT-20140116]] included documentation captured as text using <a href="http://vocab.org/vann/#usageNote"><code>vann:usageNote</code></a> elements,
+                which is a sub-property of <code>rdfs:seeAlso</code> - an <code>owl:ObjectProperty</code> that cannot have a Literal value.
+                This revision of DCAT has fixed these issues and replaced the use of <code>vann:usageNote</code> with <a href="https://www.w3.org/TR/skos-primer/#secdocumentation"><code>skos:scopeNote</code></a> -
                 see <a href="https://github.com/w3c/dxwg/issues/233">Issue #233</a>.
             </li>
 
             <li><a href="#Property:record_conformsto">Property: conforms to </a>:
-                DCAT 2014 [[VOCAB-DCAT-20140116]] had no way of representing the conformance of a record metadata with a metadata standard. This revision has added the property dct:conformsTo for dcat:CatalogRecord to cover this requirement.
+                DCAT 2014 [[VOCAB-DCAT-20140116]] had no way of representing the conformance of a record metadata with a metadata standard. This revision has added the property <code>dct:conformsTo</code> for <code>dcat:CatalogRecord</code> to cover this requirement.
                 - see <a href="https://github.com/w3c/dxwg/issues/502">Issue #502</a>.
             </li>
             <li>
-                A new  section, <a href="#license-rights">License and rights statements</a>, is added to provide guidance and recommendations for the use of <a href="http://dublincore.org/documents/dcmi-terms/#terms-license">dct:license</a>, <a href="http://dublincore.org/documents/dcmi-terms/#terms-accessRights">dct:accessRights</a>,
-		and <a href="http://dublincore.org/documents/dcmi-terms/#terms-rights">dct:rights</a> in the context of dcat catalogs and distributions.
+                A new  section, <a href="#license-rights">License and rights statements</a>, is added to provide guidance and recommendations for the use of <a href="http://dublincore.org/documents/dcmi-terms/#terms-license"><code>dct:license</code></a>, <a href="http://dublincore.org/documents/dcmi-terms/#terms-accessRights"><code>dct:accessRights</code></a>,
+		and <a href="http://dublincore.org/documents/dcmi-terms/#terms-rights"><code>dct:rights</code></a> in the context of dcat catalogs and distributions.
 		See <a href="https://github.com/w3c/dxwg/issues/114">Issue #114</a> for the background discussion.
             </li>
 


### PR DESCRIPTION
- Fixed typo ("statementss") as per @kcoyle 's email: http://lists.w3.org/Archives/Public/public-dxwg-wg/2019Jan/0195.html
- Added CODE HTML tags to qualified names of classes and properties used in the running text