### PR TITLE
DCAT Issue 353 - Remove normative statement from non-normative section

### DIFF
--- a/dcat/index.html
+++ b/dcat/index.html
@@ -123,8 +123,8 @@ $(document).ready( function() {
     </p>
 
     <p>
-        Other, complementary vocabularies <em title="MAY" class="rfc2119">MAY</em> be used together with DCAT to provide more detailed format-specific information.
-      For example, properties from the VoID vocabulary [[VOID]] can be used to express various statistics about a DCAT-described dataset if that dataset is in RDF format.
+      Complementary vocabularies can be used together with DCAT to provide more detailed format-specific information.
+      For example, properties from the VoID vocabulary [[?VOID]] can be used to express various statistics about a DCAT-described dataset if that dataset is in RDF format.
     </p>
 
     <p>
@@ -632,11 +632,27 @@ $(document).ready( function() {
 
     </section>
 
+    <section id="external-vocab">
+      <h3>Elements from other vocabularies</h3>
+
+      <p>
+        DCAT requires use of elements from a number of other vocabularies.
+        Furthermore, DCAT may be augmented by elements from external vocabularies, following the usual RDFS [[RDF-SCHEMA]] and OWL2 [[OWL2-OVERVIEW]] rules and patterns.
+      </p>
+
+    <section id="complements">
+      <h4>Complementary vocabularies</h4>
+      <p>
+          Elements from a number of complementary vocabularies <em title="MAY" class="rfc2119">MAY</em> be used together with DCAT to provide more detailed information.
+        For example: properties from the VoID vocabulary [[VOID]] allow the description of various statistics about a DCAT-described dataset if that dataset is in RDF format; properties from the Provenance ontology [[PROV-O]] can be used to provide more information about the workflow that generated a dataset or service and related activities and agents.
+      </p>
+
+    </section>
     <section id="dependencies">
-        <h3>Dependencies</h3>
+        <h4>Definitions of external elements</h4>
 
         <p>
-            The definitions (including domain and range) of terms outside the DCAT namespace are provided here only for convenience and <em title="MUST NOT" class="rfc2119">MUST NOT</em> be considered normative. The authoritative definitions of these terms are in the corresponding specifications: [[!DC11]], [[!DCTERMS]], [[!FOAF]], [[!RDF-SCHEMA]], [[!SKOS-REFERENCE]], [[!XMLSCHEMA11-2]] and [[!VCARD-RDF]].
+            The definitions (including domain and range) of terms outside the DCAT namespace are provided here only for convenience and <em title="MUST NOT" class="rfc2119">MUST NOT</em> be considered normative. The authoritative definitions of these terms are in the corresponding specifications: [[!DC11]], [[!DCTERMS]], [[!FOAF]], [[!PROV-O]], [[!RDF-SCHEMA]], [[!SKOS-REFERENCE]], [[!XMLSCHEMA11-2]] and [[!VCARD-RDF]].
         </p>
     </section>
 


### PR DESCRIPTION
Addressing #353 - 
Removed MAY from non-normative section; add text to normative section on same topic to balance