### PR TITLE
DCAT issue 655 - Align endpointURL definition with the other aaaURL properties

### DIFF
--- a/dcat/index.html
+++ b/dcat/index.html
@@ -1994,9 +1994,9 @@ $(document).ready( function() {
             <table class="definition">
                 <thead><tr><th>RDF Property:</th><th><a href="http://www.w3.org/ns/dcat#endpointURL">dcat:endpointURL</a></th></tr></thead>
                 <tbody>
-                <tr><td class="prop">Definition:</td><td>The IRI of the service end-point.</td></tr>
+                <tr><td class="prop">Definition:</td><td>The location of the service end-point (an IRI).</td></tr>
                 <tr><td class="prop">Domain:</td><td><a href="#Class:Data_Service"><code>dcat:DataService</code></a> </td></tr>
-                <tr><td class="prop">Range:</td><td><a href="http://www.w3.org/TR/xmlschema11-2/#anyURI"><code>xsd:anyURI</code></a> </td></tr>
+                <tr><td class="prop">Range:</td><td><a href="http://www.w3.org/2000/01/rdf-schema#Resource">rdfs:Resource</a> </td></tr>
                 </tbody>
             </table>
         </section>

--- a/dcat/index.html
+++ b/dcat/index.html
@@ -1996,7 +1996,7 @@ $(document).ready( function() {
                 <tbody>
                 <tr><td class="prop">Definition:</td><td>The location of the service end-point (an IRI).</td></tr>
                 <tr><td class="prop">Domain:</td><td><a href="#Class:Data_Service"><code>dcat:DataService</code></a> </td></tr>
-                <tr><td class="prop">Range:</td><td><a href="http://www.w3.org/2000/01/rdf-schema#Resource">rdfs:Resource</a> </td></tr>
+                <tr><td class="prop">Range:</td><td><a href="http://www.w3.org/2000/01/rdf-schema#Resource"><code>rdfs:Resource</code></a> </td></tr>
                 </tbody>
             </table>
         </section>
@@ -2008,7 +2008,7 @@ $(document).ready( function() {
                 <tbody>
                 <tr><td class="prop">Definition:</td><td>A description of the service end-point, including its operations, parameters etc.</td></tr>
                 <tr><td class="prop">Domain:</td><td><a href="#Class:Data_Service">dcat:DataService</a> </td></tr>
-                <tr><td class="prop">Range:</td><td><a href="http://www.w3.org/2000/01/rdf-schema#Resource">rdfs:Resource</a> </td></tr>
+                <tr><td class="prop">Range:</td><td><a href="http://www.w3.org/2000/01/rdf-schema#Resource"><code>rdfs:Resource</code></a> </td></tr>
                 <tr><td class="prop">Usage note:</td><td>The endpoint description gives specific details of the actual endpoint instance, while <a href="#Property:resource_conformsto">dct:conformsTo</a> is used to indicate the general standard or specification that the endpoint implements.</td></tr>
                 <tr><td class="prop">Usage note:</td><td>An endpoint description may be expressed in a machine-readable form, such as an OpenAPI (Swagger) description [[?OpenAPI]], an OGC getCapabilities response [[?WFS]], [[?ISO-19142]], [[?WMS]], [[?ISO-19128]], a SPARQL Service Description [[?SPARQL11-SERVICE-DESCRIPTION]], an [[?OpenSearch]] or [[?WSDL20]] document, a Hydra API description [[?HYDRA]], else in text or some other informal mode if a formal representation is not possible.</td></tr>
                 </tbody>

--- a/dcat/rdf/dcat.ttl
+++ b/dcat/rdf/dcat.ttl
@@ -633,6 +633,7 @@ dcat:endpointURL
   rdf:type owl:ObjectProperty ;
   rdfs:comment "The URI of the service end-point" ;
   rdfs:domain dcat:DataService ;
+  rdfs:range rdfs:Resource ;
   rdfs:label "service end-point" ;
   skos:changeNote "New property in this revision of DCAT" ;
   skos:editorialNote "Status: Property accepted by DCAT revision team, but details of definition and constraints not yet resolved." ;


### PR DESCRIPTION
To resolve #655