### PR TITLE
Changing some note's into ednote's

### DIFF
--- a/dcat/index.html
+++ b/dcat/index.html
@@ -49,10 +49,10 @@ $(document).ready( function() {
     <p>
         Since the <a href="https://www.w3.org/TR/2018/WD-vocab-dcat-2-20180508/">First Public Working Draft</a>, the main changes to the DCAT vocabulary have been:</p>
     <ul>
-        <li>addition of a <code><a href="#Class:Resource">dcat:Resource</a></code> class for representing any resource than can be included in the catalog, this is
-            now the super-class of <code><a href="#Class:Dataset">dcat:Dataset</a></code></li>
-        <li>addition of <code><a href="#Class:Data_Service">dcat:DataService</a></code>, as a sub-class of <code><a href="#Class:Resource">dcat:Resource</a></code>, to support cataloguing service end-points providing access to resources</li>
-        <li>addition of <code><a href="#Class:Data_Distribution_Service">dcat:DataDistributionService</a></code>, as a sub-class of <code><a href="#Class:Data_Service">dcat:DataService</a></code>,
+        <li>addition of a <a href="#Class:Resource"><code>dcat:Resource</code></a> class for representing any resource than can be included in the catalog, this is
+            now the super-class of <a href="#Class:Dataset"><code>dcat:Dataset</code><</a></li>
+        <li>addition of <a href="#Class:Data_Service"><code>dcat:DataService</code></a>, as a sub-class of <a href="#Class:Resource"><code>dcat:Resource</code></a>, to support cataloguing service end-points providing access to resources</li>
+        <li>addition of <a href="#Class:Data_Distribution_Service"><code>dcat:DataDistributionService</code></a>, as a sub-class of <a href="#Class:Data_Service"><code>dcat:DataService</code></a>,
             representing service end-points providing access to datasets through their distributions, respectively </li>
         <li>addition of ways to representing <a href="#bag-of-files">loosely structured catalogs</a>, where there is no distinction between a dataset and its distributions</li>
         <li>more details for the ways of representing <a href="#examples-dataset-provenance">dataset provenance</a> and <a href="#quality-information">dataset quality</a></li>
@@ -214,39 +214,39 @@ $(document).ready( function() {
       DCAT is based around eight main classes:</p>
     <ul>
         <li>
-          <code><a href="#Class:Catalog">dcat:Catalog</a></code> represents a catalog, which is a dataset in which each individual item is a metadata record describing some resource; the scope of <code>dcat:catalog</code> is collections of metadata about <b>datasets</b> or <b>data services</b>.
+          <a href="#Class:Catalog"><code>dcat:Catalog</code></a> represents a catalog, which is a dataset in which each individual item is a metadata record describing some resource; the scope of <code>dcat:catalog</code> is collections of metadata about <b>datasets</b> or <b>data services</b>.
         </li>
         <li>
-          <code><a href="#Class:Resource">dcat:Resource</a></code> represents an individual item in a catalog.
-          This class is not intended to be used directly, but is the parent class of <code><a href="#Class:Dataset">dcat:Dataset</a></code>, <code><a href="#Class:Data_Service">dcat:DataService</a></code> and <code><a href="#Class:Catalog">dcat:Catalog</a></code>.
-          Member items in a catalog should be members of one of the sub-classes, or of a sub-class of these, or of a sub-class of <code><a href="#Class:Resource">dcat:Resource</a></code> defined in a DCAT application profile or other DCAT application.
-          <code><a href="#Class:Resource">dcat:Resource</a></code> is effectively an extension point for defining a catalog of any kind of resource.
+          <a href="#Class:Resource"><code>dcat:Resource</code></a> represents an individual item in a catalog.
+          This class is not intended to be used directly, but is the parent class of <a href="#Class:Dataset"><code>dcat:Dataset</code></a>, <a href="#Class:Data_Service"><code>dcat:DataService</code></a> and <a href="#Class:Catalog">dcat:Catalog</a>.
+          Member items in a catalog should be members of one of the sub-classes, or of a sub-class of these, or of a sub-class of <a href="#Class:Resource"><code>dcat:Resource</code></a> defined in a DCAT application profile or other DCAT application.
+          <a href="#Class:Resource"><code>dcat:Resource</code></a> is effectively an extension point for defining a catalog of any kind of resource.
         </li>
         <li>
-          <code><a href="#Class:Dataset">dcat:Dataset</a></code> represents a dataset in a catalog.
+          <a href="#Class:Dataset"><code>dcat:Dataset</code></a> represents a dataset in a catalog.
           A dataset is a collection of data, published or curated by a single agent.
           Data comes in many forms, including numbers, words, pixels, imagery, sound and other multi-media, and potentially other types, any of which might be collected into a dataset.
         </li>
         <li>
-          <code><a href="#Class:Distribution">dcat:Distribution</a></code> represents an accessible form or representation of a dataset, for example a downloadable file.
+          <a href="#Class:Distribution"><code>dcat:Distribution</code></a> represents an accessible form or representation of a dataset, for example a downloadable file.
         </li>
         <li>
-          <code><a href="#Class:Data_Service">dcat:DataService</a></code> represents a data service in a catalog.
+          <a href="#Class:Data_Service"><code>dcat:DataService</code></a> represents a data service in a catalog.
           A data service is a collection of operations, accessible through an interface (API) that provide access to one or more datasets or data processing functions.
         </li>
         <li>
-          <code><a href="#Class:Data_Distribution_Service">dcat:DataDistributionService</a></code> represents a kind of data service that provides access to distributions of one or more datasets or extracts of datasets.
+          <a href="#Class:Data_Distribution_Service"><code>dcat:DataDistributionService</code></a> represents a kind of data service that provides access to distributions of one or more datasets or extracts of datasets.
         </li>
         <!--
           <li>
-            <code><a href="#Class:DataTransformationService">dcat:DataTransformationService</a></code> represents a service that can transform a dataset, e.g. spatial coordinate transformation; interpolation or resampling of a dataset.
+            <a href="#Class:DataTransformationService"><code>dcat:DataTransformationService</code></a> represents a service that can transform a dataset, e.g. spatial coordinate transformation; interpolation or resampling of a dataset.
           </li>
         <li>
-          <code><a href="#Class:Discovery_Service">dcat:DiscoveryService</a></code> represents a description of a kind of data distribution service that provides access to one or more catalogs to support discovery functions.
+          <a href="#Class:Discovery_Service"><code>dcat:DiscoveryService</code></a> represents a description of a kind of data distribution service that provides access to one or more catalogs to support discovery functions.
         </li>
       -->
         <li>
-          <code><a href="#Class:Catalog_Record">dcat:CatalogRecord</a></code> represents a metadata item in the catalog, primarily concerning the registration information, such as who added the item and when.
+          <a href="#Class:Catalog_Record"><code>dcat:CatalogRecord</code></a> represents a metadata item in the catalog, primarily concerning the registration information, such as who added the item and when.
         </li>
     </ul>
 
@@ -284,8 +284,8 @@ $(document).ready( function() {
       Descriptions of datasets and data services can be included in a <b>catalog</b>.
       A catalog is a kind of dataset whose member items are descriptions of datasets and data services.
       Other types of thing might also be catalogued, but the scope of DCAT is currently limited to datasets and data services.
-      To extend the scope of a catalog beyond datasets and data services it is recommended to define additional sub-classes of <code><a href="#Class:Resource">dcat:Resource</a></code> in a DCAT application profile or other DCAT application.
-      To extend the scope of service descriptions beyond data distribution services it is recommended to define additional sub-classes of <code><a href="#Class:Data_Service">dcat:DataService</a></code> in a DCAT application profile or other DCAT application.
+      To extend the scope of a catalog beyond datasets and data services it is recommended to define additional sub-classes of <a href="#Class:Resource"><code>dcat:Resource</code></a> in a DCAT application profile or other DCAT application.
+      To extend the scope of service descriptions beyond data distribution services it is recommended to define additional sub-classes of <a href="#Class:Data_Service"><code>dcat:DataService</code></a> in a DCAT application profile or other DCAT application.
     </p>
 
     <div class="note">
@@ -299,11 +299,11 @@ $(document).ready( function() {
       </p>
       <p>
         Catalogs of other kinds of things might be designed following the DCAT pattern, e.g. dealing with facilities, instruments, samples and specimens, other physical artefacts, events or activities.
-        These are currently out of scope for DCAT, but might be defined through further sub-classes of <code><a href="#Class:Resource">dcat:Resource</a></code>, which could be specified in a DCAT application profile or other DCAT application.
+        These are currently out of scope for DCAT, but might be defined through further sub-classes of <a href="#Class:Resource"><code>dcat:Resource</code></a>, which could be specified in a DCAT application profile or other DCAT application.
       </p>
     </div>
 
-    <p>A <b>CatalogRecord</b> describes an entry in the catalog. Notice that while <code><a href="#Class:Resource">dcat:Resource</a></code> represents the dataset or service itself, <code><a href="#Class:Catalog_Record">dcat:CatalogRecord</a></code> is the record that describes the registration of an item in the catalog. The use of explicit <code><a href="#Class:Catalog_Record">dcat:CatalogRecord</a></code> is considered optional. It is used to capture provenance information about entries in a catalog explicitly. If this is not necessary then <code><a href="#Class:Catalog_Record">dcat:CatalogRecord</a></code> can be safely ignored.</p>
+    <p>A <b>CatalogRecord</b> describes an entry in the catalog. Notice that while <a href="#Class:Resource"><code>dcat:Resource</code></a> represents the dataset or service itself, <a href="#Class:Catalog_Record"><code>dcat:CatalogRecord</code></a> is the record that describes the registration of an item in the catalog. The use of explicit <a href="#Class:Catalog_Record"><code>dcat:CatalogRecord</code></a> is considered optional. It is used to capture provenance information about entries in a catalog explicitly. If this is not necessary then <a href="#Class:Catalog_Record"><code>dcat:CatalogRecord</code></a> can be safely ignored.</p>
   </section>
   <section id="dcat-rdf">
     <h3>RDF considerations</h3>
@@ -586,7 +586,7 @@ $(document).ready( function() {
     <section id="RDF-representation">
         <h3>RDF representation</h3>
 
-        <p class="note">
+        <p class="ednote">
             The DCAT RDF representation is modularized into several files or graphs to help users access a version of DCAT with only the alignments that they need.
             This mechanism can also be used to capture different levels of axiomatization, though the status of such proposals has not been finalized.
             See <a href="https://github.com/w3c/dxwg/issues/134">Issue #134</a> and the issues enumerated below.
@@ -877,7 +877,7 @@ $(document).ready( function() {
             This class carries properties common to all catalogued resources, including datasets and data services.
 
             It is strongly recommended to use a more specific sub-class when available.</td></tr>
-            <tr><td class="prop">Usage note:</td><td><code><a href="#Class:Resource"><code>dcat:Resource</code></a></code> is an extension point that enables the definition of any kind of catalog. Additional subclasses may be defined in a DCAT application profile or other DCAT application for catalogs of other kinds of resources</td></tr>
+            <tr><td class="prop">Usage note:</td><td><a href="#Class:Resource"><code>dcat:Resource</code></a> is an extension point that enables the definition of any kind of catalog. Additional subclasses may be defined in a DCAT application profile or other DCAT application for catalogs of other kinds of resources</td></tr>
             <tr><td class="prop">See also:</td><td><a href="#Class:Catalog_Record" title="">Catalog record</a></td></tr>
             </tbody>
         </table>
@@ -914,7 +914,7 @@ $(document).ready( function() {
         </section>
 
         <p class="note">
-            <a href="http://purl.org/dc/terms/Standard"><code>dct:Standard</code></a> is defined as "A basis for comparison; a reference point against which other things can be evaluated." The target resource is not restricted to formal standards issued by bodies like ISO and W3C. In this context, it is any resource that specifies one or more aspects of the catalogued resource content, for example schema, semantics, syntax, usage guidelines, file format, or specific serialization. The meaning of conformance is determined by provisions in the target standard.
+            <a href="http://purl.org/dc/terms/Standard"><code>dct:Standard</code></a> is defined as "A basis for comparison; a reference point against which other things can be evaluated." The target resource is not restricted to formal standards issued by bodies like <abbr title="International Organization for Standardization">ISO</abbr> and W3C. In this context, it is any resource that specifies one or more aspects of the catalogued resource content, for example schema, semantics, syntax, usage guidelines, file format, or specific serialization. The meaning of conformance is determined by provisions in the target standard.
         </p>
 
         <section id="Property:resource_contact_point">
@@ -938,7 +938,7 @@ $(document).ready( function() {
 
             <p class="note">
                 New property added in this revision of DCAT, specifically added when considering the data citation requirement and
-                added to the <code><a href="#Class:Resource"><code>dcat:Resource</code></a></code> class, as the Dataset superclass.
+                added to the <a href="#Class:Resource"><code>dcat:Resource</code></a> class, as the Dataset superclass.
             </p>
 
             <p class="issue" data-number="80">
@@ -2223,7 +2223,7 @@ end class DiscoveryService -->
               <thead><tr><th>RDF Property:</th><th><a href="http://www.w3.org/ns/dcat#hadRole">dcat:hadRole</a></th></tr></thead>
               <tbody>
               <tr><td class="prop">Definition:</td><td>The function of an entity or agent with respect to another entity or resource.</td></tr>
-              <tr><td class="prop">Domain:</td><td><code><a href="http://www.w3.org/ns/prov#Attribution"><code>prov:Attribution</code></a> or <a href="#Class:Relationship"><code>dcat:Relationship</code></a></code></td></tr>
+              <tr><td class="prop">Domain:</td><td><a href="http://www.w3.org/ns/prov#Attribution"><code>prov:Attribution</code></a> or <a href="#Class:Relationship"><code>dcat:Relationship</code></a></td></tr>
               <tr><td class="prop">Range:</td><td><a href="http://www.w3.org/ns/prov#Role"><code>dcat:Role</code></a></td></tr>
               <tr><td class="prop">Usage note:</td><td>May be used in a qualified-attribution to specify the role of an Agent with respect to an Entity. It is recommended that the value be taken from a controlled vocabulary of agent roles, such as <a href="http://registry.it.csiro.au/def/isotc211/CI_RoleCode">ISO 19115 CI_RoleCode</a>.</td></tr>
               <tr><td class="prop">Usage note:</td><td>May be used in a qualified-relation to specify the role of an Entity with respect to another Entity. It is recommended that the value be taken from a controlled vocabulary of entity roles.</td></tr>
@@ -2795,7 +2795,7 @@ ex:Test543L
 </pre>
 
 <p class="note">
-  Note: The property <a href="#Property:resource_qualifiedRelation">dcat:qualifiedRelation</a> and association-class <a href="#Class:Relationship">dcat:Relationship</a> follow the pattern established in W3C [[!PROV-O]] and described in the section <a href="https://www.w3.org/TR/prov-o/#description-qualified-terms">Qualified Terms</a>.
+  The property <a href="#Property:resource_qualifiedRelation">dcat:qualifiedRelation</a> and association-class <a href="#Class:Relationship">dcat:Relationship</a> follow the pattern established in W3C [[!PROV-O]] and described in the section <a href="https://www.w3.org/TR/prov-o/#description-qualified-terms">Qualified Terms</a>.
   However, PROV-O is activity-centric, and does not support Entity-Entity relations except for the single case of 'was derived from', thus necessitating the new elements shown here to support the general case.
 </p>
 </section>
@@ -2806,7 +2806,7 @@ ex:Test543L
 <section id="prov-patterns">
 
     <h2>Provenance patterns</h2>
-    <p class="note">
+    <p class="ednote">
         In this chapter it is planned to describe patterns for the use of the [[!PROV-O]] vocabulary to support the various provenance-related requirements.
 	A number of requirements identify the need to provide better support for Dataset and Record provenance - see
         <a href="https://github.com/w3c/dxwg/issues/77">Issue #78</a>,
@@ -2820,7 +2820,7 @@ ex:Test543L
 
 
     Many of the requirements can be satisfied by using capabilities from the [[?PROV-O]] ontology,
-    in particular by treating <code><a href="#Class:Resource">dcat:Resource</a></code> and/or <code><a href="#Class:Catalog_Record">dcat:CatalogRecord</a></code> a sub-class of <a href="http://www.w3.org/ns/prov#Entity"><code>prov:Entity</code></a>.
+    in particular by treating <a href="#Class:Resource"><code>dcat:Resource</code></a> and/or <a href="#Class:Catalog_Record"><code>dcat:CatalogRecord</code></a> a sub-class of <a href="http://www.w3.org/ns/prov#Entity"><code>prov:Entity</code></a>.
     See <a href="https://github.com/w3c/dxwg/issues/128">Issue #128</a> for the relevant discussion. A preliminary <a href="https://raw.githubusercontent.com/w3c/dxwg/gh-pages/dcat/rdf/dcat-prov.ttl">alignment of DCAT with PROV-O is available</a>.
     See the wiki page on <a href="https://github.com/w3c/dxwg/wiki/Provenance-patterns">Provenance Patterns</a> for more discussion.
 
@@ -3815,7 +3815,7 @@ dcat:servesDataset ga-courts:jc ;
   <section id="more-examples-needed">
       <h3>More examples needed</h3>
 
-      <p class="note">
+      <p class="ednote">
           This section will contain more examples on the use of DCAT.
       </p>
 
@@ -3884,7 +3884,7 @@ dcat:servesDataset ga-courts:jc ;
             </li>
 
             <li>
-                <a href="#Class:Resource">Class: Catalogued resource</a>: In DCAT 2014 [[?VOCAB-DCAT-20140116]] the scope of a <a href="#Class:Catalog"><code>dcat:Catalog</code></a> was limited to Datasets. This has been generalized, and properties common to all catalogued resources are now associated with a super-class <code><a href="#Class:Resource"><code>dcat:Resource</code></a></code> - see <a href="https://github.com/w3c/dxwg/issues/172">Issue #172</a> and <a href="https://github.com/w3c/dxwg/issues/116">Issue #116</a>. The wiki page on <a href="https://github.com/w3c/dxwg/wiki/Cataloguing-data-services">Cataloguing data services</a> describes some proposals related to this requirement.
+                <a href="#Class:Resource">Class: Catalogued resource</a>: In DCAT 2014 [[?VOCAB-DCAT-20140116]] the scope of a <a href="#Class:Catalog"><code>dcat:Catalog</code></a> was limited to Datasets. This has been generalized, and properties common to all catalogued resources are now associated with a super-class <a href="#Class:Resource"><code>dcat:Resource</code></a> - see <a href="https://github.com/w3c/dxwg/issues/172">Issue #172</a> and <a href="https://github.com/w3c/dxwg/issues/116">Issue #116</a>. The wiki page on <a href="https://github.com/w3c/dxwg/wiki/Cataloguing-data-services">Cataloguing data services</a> describes some proposals related to this requirement.
             </li>
 
             <li>

--- a/dcat/index.html
+++ b/dcat/index.html
@@ -50,7 +50,7 @@ $(document).ready( function() {
         Since the <a href="https://www.w3.org/TR/2018/WD-vocab-dcat-2-20180508/">First Public Working Draft</a>, the main changes to the DCAT vocabulary have been:</p>
     <ul>
         <li>addition of a <a href="#Class:Resource"><code>dcat:Resource</code></a> class for representing any resource than can be included in the catalog, this is
-            now the super-class of <a href="#Class:Dataset"><code>dcat:Dataset</code><</a></li>
+            now the super-class of <a href="#Class:Dataset"><code>dcat:Dataset</code></a></li>
         <li>addition of <a href="#Class:Data_Service"><code>dcat:DataService</code></a>, as a sub-class of <a href="#Class:Resource"><code>dcat:Resource</code></a>, to support cataloguing service end-points providing access to resources</li>
         <li>addition of <a href="#Class:Data_Distribution_Service"><code>dcat:DataDistributionService</code></a>, as a sub-class of <a href="#Class:Data_Service"><code>dcat:DataService</code></a>,
             representing service end-points providing access to datasets through their distributions, respectively </li>


### PR DESCRIPTION
Following from https://github.com/w3c/dxwg/issues/226

I made `ednote`'s 3 original `note`'s which, to my understanding, are supposed to be revised / dropped in later version of the spec.

I also made some additional minor editorial changes.

Preview here: https://rawgit.com/w3c/dxwg/andrea-perego-dcat-ednote-rev/dcat/index.html

