### PR TITLE
Added sections for acknowledgements and changes

### DIFF
--- a/conneg-by-ap/index.html
+++ b/conneg-by-ap/index.html
@@ -979,20 +979,20 @@ GET /a/resource?_profile=list&amp;_mediatype=text/html HTTP/1.1
 <section id="changes" class="informative">
 	<h2>Changes</h2>
 	<p>Changes since the <a href="https://www.w3.org/TR/2018/WD-dx-prof-conneg-20181218/">18 December 2018 Working Draft</a> are:</p>
-	<li>
-		<ul>Added text about existing standards for transporting profile information in http headers
+	<ul>
+		<li>Added text about existing standards for transporting profile information in http headers
 			to <a href="#relatedwork">related work</a>.
-			(<a href="https://github.com/w3c/dxwg/issues/45">Issue 45</a>)</ul>
-		<ul>Removed advice on use of HTTP OPTIONS.
-			(<a href="https://github.com/w3c/dxwg/issues/510">Issue 510</a>)</ul>
-		<ul>Added text about ARK identifiers to <a href="#relatedwork">related work</a>.
-			(<a href="https://github.com/w3c/dxwg/issues/514">Issue 514</a>)</ul>
-		<ul>Clarified difference between the <code>profile</code> parameter in <code>Accept</code> header fields
+			(<a href="https://github.com/w3c/dxwg/issues/45">Issue 45</a>)</li>
+		<li>Removed advice on use of HTTP OPTIONS.
+			(<a href="https://github.com/w3c/dxwg/issues/510">Issue 510</a>)</li>
+		<li>Added text about ARK identifiers to <a href="#relatedwork">related work</a>.
+			(<a href="https://github.com/w3c/dxwg/issues/514">Issue 514</a>)</li>
+		<li>Clarified difference between the <code>profile</code> parameter in <code>Accept</code> header fields
 			and the <code>Accept-Profile</code> header field.
-			(<a href="https://github.com/w3c/dxwg/issues/662">Issue 662</a>)</ul>
-		<ul>Updated the <a href="#security_and_privacy">Security and Privacy</a> section.
-			(<a href="https://github.com/w3c/dxwg/issues/782">Issue 782</a>)</ul>
-	</li>
+			(<a href="https://github.com/w3c/dxwg/issues/662">Issue 662</a>)</li>
+		<li>Updated the <a href="#security_and_privacy">Security and Privacy</a> section.
+			(<a href="https://github.com/w3c/dxwg/issues/782">Issue 782</a>)</li>
+	</ul>
 </section>
   <section id="security_and_privacy" class="informative">
     <h2>Security and Privacy</h2>

--- a/conneg-by-ap/index.html
+++ b/conneg-by-ap/index.html
@@ -969,7 +969,9 @@ GET /a/resource?_profile=list&amp;_mediatype=text/html HTTP/1.1
 <section id="acknowledgements" class="informative">
 	<h2>Acknowledgements</h2>
 	<p>Comments and suggestions from
-		Annette Greiner
+		Annette Greiner,
+		Erik Wilde,
+		Gregg Kellogg
 		and Kam Hay Fung
 		improved this specification
 	</p>
@@ -979,7 +981,7 @@ GET /a/resource?_profile=list&amp;_mediatype=text/html HTTP/1.1
 	<p>Changes since the <a href="https://www.w3.org/TR/2018/WD-dx-prof-conneg-20181218/">18 December 2018 Working Draft</a> are:</p>
 	<li>
 		<ul>Added text about existing standards for transporting profile information in http headers
-			to <a href="#relatedork">related work</a>.
+			to <a href="#relatedwork">related work</a>.
 			(<a href="https://github.com/w3c/dxwg/issues/45">Issue 45</a>)</ul>
 		<ul>Removed advice on use of HTTP OPTIONS.
 			(<a href="https://github.com/w3c/dxwg/issues/510">Issue 510</a>)</ul>

--- a/conneg-by-ap/index.html
+++ b/conneg-by-ap/index.html
@@ -966,6 +966,32 @@ GET /a/resource?_profile=list&amp;_mediatype=text/html HTTP/1.1
     </ul>
     <div class="issue" data-number="467"></div>
   </section>
+<section id="acknowledgements" class="informative">
+	<h2>Acknowledgements</h2>
+	<p>Comments and suggestions from
+		Annette Greiner
+		and Kam Hay Fung
+		improved this specification
+	</p>
+</section>
+<section id="changes" class="informative">
+	<h2>Changes</h2>
+	<p>Changes since the <a href="https://www.w3.org/TR/2018/WD-dx-prof-conneg-20181218/">18 December 2018 Working Draft</a> are:</p>
+	<li>
+		<ul>Added text about existing standards for transporting profile information in http headers
+			to <a href="#relatedork">related work</a>.
+			(<a href="https://github.com/w3c/dxwg/issues/45">Issue 45</a>)</ul>
+		<ul>Removed advice on use of HTTP OPTIONS.
+			(<a href="https://github.com/w3c/dxwg/issues/510">Issue 510</a>)</ul>
+		<ul>Added text about ARK identifiers to <a href="#relatedwork">related work</a>.
+			(<a href="https://github.com/w3c/dxwg/issues/514">Issue 514</a>)</ul>
+		<ul>Clarified difference between the <code>profile</code> parameter in <code>Accept</code> header fields
+			and the <code>Accept-Profile</code> header field.
+			(<a href="https://github.com/w3c/dxwg/issues/662">Issue 662</a>)</ul>
+		<ul>Updated the <a href="#security_and_privacy">Security and Privacy</a> section.
+			(<a href="https://github.com/w3c/dxwg/issues/782">Issue 782</a>)</ul>
+	</li>
+</section>
   <section id="security_and_privacy" class="informative">
     <h2>Security and Privacy</h2>
     <p>


### PR DESCRIPTION
Addressing [the note](https://lists.w3.org/Archives/Public/public-dxwg-wg/2019Mar/0277.html) from @kcoyle that we need to keep track of changes.
Also adds a "acknowledgements" section
Preview: https://raw.githack.com/w3c/dxwg/larsgsvensson-changes-1/conneg-by-ap/index.html#changes