### PR TITLE
Remove explicit Provenance sections

### DIFF
--- a/dcat/index.html
+++ b/dcat/index.html
@@ -75,7 +75,7 @@ $(document).ready( function() {
 
     <h3 id="please_send_comments">Please send comments</h3>
     The Working Group invites publishers to describe their catalogs and datasets with the revised version of DCAT described in this document and to report their implementations following <a href="https://github.com/w3c/dxwg/wiki/DCAT-implementation-evidence">the instruction  to reporting DCAT revised implementations</a>. The information gathered through this means will be augmented by further analysis of implementation available on the Web. The Working Group expects to adduce the combined set of evidence when requesting that the Director advance this document to Proposed Recommendation.
-    
+
 
 </section>
 
@@ -1192,6 +1192,10 @@ $(document).ready( function() {
             </p>
 
             <p class="note">
+              Since this property is a sub-property of <a href="http://www.w3.org/ns/prov#qualifiedInfluence">prov:qualifiedInfluence</a>, use of this property on an individual entails that the context resource is a member of the class <a href="http://www.w3.org/ns/prov#Entity">prov:Entity</a> [[RDF-SCHEMA]] .
+            </p>
+
+            <p class="note">
               Property added in this revision of DCAT.
             </p>
         </section>
@@ -1252,6 +1256,10 @@ $(document).ready( function() {
 
             <p>
               This DCAT property follows the common <a href="#qualified-forms">qualified relation pattern</a> .
+            </p>
+
+            <p class="note">
+              Use of this property on an individual entails that the context resource is a member of the class <a href="http://www.w3.org/ns/prov#Entity">prov:Entity</a> [[RDF-SCHEMA]] .
             </p>
 
             <p class="note">
@@ -1668,6 +1676,10 @@ $(document).ready( function() {
                 <tr><td class="prop">Usage note:</td><td>Use <a href="http://www.w3.org/ns/prov#qualifiedGeneration"><code>prov:qualifiedGeneration</code></a> to attach additional details about the relationship between the dataset and the activity, e.g. the exact time that the dataset was produced during the lifetime of a project</td></tr>
                 </tbody>
             </table>
+
+            <p class="note">
+              Use of this property on an individual entails that the context resource is a member of the class <a href="http://www.w3.org/ns/prov#Entity">prov:Entity</a> [[RDF-SCHEMA]] .
+            </p>
 
             <p class="note">
                 New property in this context in this revision of DCAT.
@@ -2858,6 +2870,11 @@ a:testingActivity a prov:Activity;
   <p>
     Note that, while the focus of these qualified forms is to allow for additional <i>roles</i> on a relationship, other aspect of the relationships, such as the applicable time interval, are easily attached when a specific node is used to describe the relationship like this (e.g. see the <a href="https://www.w3.org/TR/prov-o/#qualified-terms-figure">chart of Influence relations</a> in [[?PROV-O]] for some examples).
   </p>
+  <p class="note">
+    Because of the global domain constraints on <a href="https://www.w3.org/TR/prov-o/#qualifiedAttribution">prov:qualifiedAttribution</a> and the super-property of <a href="#Property:resource_qualifiedRelation">dcat:qualifiedRelation</a>, use of the qualified forms entail that the context resources is a member of the class <a href="http://www.w3.org/ns/prov#Entity">prov:Entity</a> [[RDF-SCHEMA]] .
+  </p>
+
+
 <section id="qualified-attribution">
   <h3>Relationships between datasets and agents</h3>
   <p>
@@ -2941,7 +2958,7 @@ ex:Test543L
 
 </section>
 
-
+<!-- Remove separate chapter on Provenance Patterns - highly incomplete
 <section id="prov-patterns">
 
     <h2>Provenance patterns</h2>
@@ -2964,6 +2981,7 @@ ex:Test543L
     See the wiki page on <a href="https://github.com/w3c/dxwg/wiki/Provenance-patterns">Provenance Patterns</a> for more discussion.
 
 </section>
+-->
 
 <section id="license-rights">
 
@@ -3127,11 +3145,11 @@ ex:Test543L
 <section id="security_and_privacy">
     <h2>Security and Privacy</h2>
     <p>
-    The DCAT vocabulary supports the attribution of data and metadata to various participants such as resource <a href="#Property:resource_creator">creators</a>, <a href="#Property:resource_publisher">publishers</a> and other parties or agents via <a href="#qualified-forms">qualified relations</a>, 
-	    and as such defines terms that may be related to personal information.  In addition, it also supports the association of <a href="#Property:resource_rights">rights</a> and <a href="#Property:resource_license">licenses</a> with cataloged Resources and Distributions. 
-	    These rights and licences could potentially include or reference sensitive information such as user and asset identifiers as <a href="https://www.w3.org/TR/odrl-vocab/#privacy-consideration">described</a> in [[!ODRL-VOCAB]].   Implementations that produce, maintain, publish or 
+    The DCAT vocabulary supports the attribution of data and metadata to various participants such as resource <a href="#Property:resource_creator">creators</a>, <a href="#Property:resource_publisher">publishers</a> and other parties or agents via <a href="#qualified-forms">qualified relations</a>,
+	    and as such defines terms that may be related to personal information.  In addition, it also supports the association of <a href="#Property:resource_rights">rights</a> and <a href="#Property:resource_license">licenses</a> with cataloged Resources and Distributions.
+	    These rights and licences could potentially include or reference sensitive information such as user and asset identifiers as <a href="https://www.w3.org/TR/odrl-vocab/#privacy-consideration">described</a> in [[!ODRL-VOCAB]].   Implementations that produce, maintain, publish or
 	    consume such vocabulary terms must take steps to ensure security and privacy considerations are addressed at the application level.
-    </p>  	
+    </p>
 </section>
 
 <section id="other-w3c-recommendations">
@@ -3532,13 +3550,14 @@ ex:Test543L
 
     </section>
 
-
+<!-- this will not happen in DCAT 2
     <section id="dcat-prov-o" class="informative">
         <h3>PROV-O</h3>
             An alignment of DCAT with PROV-O [[?PROV-O]] is being prepared, and has been discussed in <a href="https://github.com/w3c/dxwg/issues/128">Issue #128</a>.
 	    A <a href="https://raw.githubusercontent.com/w3c/dxwg/gh-pages/dcat/rdf/dcat-prov.ttl">provisional version</a> is available.
 
     </section>
+-->
 
 </section>
 
@@ -3838,7 +3857,7 @@ rdfs:seeAlso &lt;https://doi.org/10.1111/j.1365-2966.2006.10100.x&gt; ;
           </li>
       </ul>
       <p>
-          For a more detailed discussion of the use of PROV for dataset provenance, including recommendations on the use of <i>qualified properties</i>, see the chapter on <a href="#prov-patterns">Provenance Patterns</a> below.
+          Further patterns for the use of <i>qualified properties</i> for resource attribution and interrelationships are described in the chapter on <a href="#qualified-forms">Qualified relations</a> below.
       </p>
 
   </section>


### PR DESCRIPTION
Remove stub chapter on Provenance patterns
Remove annex on DCAT/prov-o alignment
Attempt to clean text of cross-references to these

But also add notes pointing out where RDFS entailments would make DCAT resources also PROV Entities