### PR TITLE
Editorial changes

### DIFF
--- a/dcat/config.js
+++ b/dcat/config.js
@@ -66,10 +66,7 @@ var respecConfig = {
     lint: "false",
     github: "https://github.com/w3c/dxwg/",
     localBiblio: {
-        "SCHEMA-ORG" : {
-            href : "http://schema.org/",
-            title : "Schema.org"
-        },
+/*        
         "DATS": {
             href : "http://wg3-metadataspecifications.readthedocs.io/",
             title : "Data Tag Suite",
@@ -77,6 +74,7 @@ var respecConfig = {
             publisher : "NIH Big Data 2 Knowledge bioCADDIE project.",
             date : "2016"
         },
+*/        
         "DATS": {
             "href": "https://github.com/datatagsuite/",
             "title": "Data Tag Suite",
@@ -238,6 +236,10 @@ var respecConfig = {
             title: "Negotiating Profiles in HTTP",
             date: "24 October 2017",
             status: "IETF Internet Draft"
+        },
+        "SCHEMA-ORG" : {
+            href : "http://schema.org/",
+            title : "Schema.org"
         },
         "VIVO-ISF" : {
             href:"http://github.com/vivo-isf/vivo-isf",

--- a/dcat/config.js
+++ b/dcat/config.js
@@ -77,32 +77,6 @@ var respecConfig = {
             publisher : "NIH Big Data 2 Knowledge bioCADDIE project.",
             date : "2016"
         },
-        "ZaveriEtAl" : {
-            title : "Quality assessment for Linked Data: A Survey",
-            authors : [ "Amrapali Zaveri", "Anisa Rula", "Andrea Maurino",
-                "Ricardo Pietrobon", "Jens  Lehmann", "Sören Auer" ],
-            status : "Semantic Web, vol. 7, no. 1, pp. 63-93",
-            publisher : "IOS Press",
-            href : "https://doi.org/10.3233/SW-150175",
-            date : "2015"
-        },
-        "ISOIEC25012" : {
-            title : "ISO/IEC 25012 - Data Quality model",
-            href : "http://iso25000.com/index.php/en/iso-25000-standards/iso-25012"
-        },
-        "ISO-26324" : {
-            "authors":["ISO/TC 46/SC 9"],
-            "href":"https://www.iso.org/standard/43506.html",
-            "title":"Information and documentation -- Digital object identifier system",
-            "publisher":"ISO",
-            "status":"International Standard",
-            "date":"2012"
-        },
-        "DDI" : {
-            href : "http://www.ddialliance.org/explore-documentation",
-            title : "Data Documentation Initiative",
-            publisher : "DDI Alliance"
-        },
         "DATS": {
             "href": "https://github.com/datatagsuite/",
             "title": "Data Tag Suite",
@@ -114,10 +88,45 @@ var respecConfig = {
             href:"http://dbpedia.org/ontology/",
             title:"DBPedia ontology"
         },
+        "DCAT-AP-SE": {
+            title: "DCAT-AP-SE: Swedish recommendation for DCAT-AP1.1",
+            href: "https://lankadedata.se/spec/DCAT-AP-SE",
+            authors: ["Matthias Palmér"],
+            etAl: false
+        },
+        "DCAT-BE": {
+            title: "Linking data portals across Belgium.",
+            href: "http://dcat.be/"
+        },
+        "DCAT-AP-IT": {
+            title: "Profilo nazionale dei metadati DCAT-AP_IT v1.0",
+            href: "https://www.dati.gov.it/content/profilo-nazionale-dei-metadati-dcat-ap-it-v10"
+        },
+        "DCAT-AP-NO": {
+            title: "Standard for beskrivelse av datasett og datakataloger (DCAT-AP-NO)",
+            href: "http://difi.github.io/dcat-ap-no/"
+        },
+        "DCAT-AP.de": {
+            title: "DCAT-AP.de als formaler Metadatenstandard für offene Verwaltungsdaten bestätigt",
+            href: "https://www.govdata.de/standardisierung"
+        },
+        "DDI" : {
+            href : "http://www.ddialliance.org/explore-documentation",
+            title : "Data Documentation Initiative",
+            publisher : "DDI Alliance"
+        },
         "DOAP" : {
             href:"https://github.com/ewilderj/doap/wiki",
             title:"Description of a Project",
             authors: ["Edd Wilder-James"]
+        },
+        "FAIR" : {
+            title : "The FAIR Guiding Principles for scientific data management and stewardship",
+            authors : [ "Mark D. Wilkinson" ],
+            etAl : true,
+            status : "Scientific Data, vol. 3, Article nr. 160018",
+            publisher : "Nature",
+            href : "https://doi.org/10.1038/sdata.2016.18"
         },
         "FRAPO" : {
             href:"http://www.sparontologies.net/ontologies/frapo",
@@ -125,19 +134,41 @@ var respecConfig = {
             authors: ["David Shotton"],
             date: "04 September 2017"
         },
-        "OBO" : {
-            href:"http://www.obofoundry.org/",
-            title:"The OBO Foundry"
+        "GeoDCAT-AP-IT": {
+            title: "GeoDCAT-AP in Italy, the national guidelines published",
+            href: "https://joinup.ec.europa.eu/news/geodcat-apit"
         },
-        "PDO" : {
-            href:"http://vocab.deri.ie/pdo",
-            title:"Project Documents Ontology",
-            authors: ["Pradeep Varma"],
-            date: "09 July 2010"
+        "HYDRA": {
+            authors: [
+                "Markus Lanthaler"
+            ],
+            href:"https://www.hydra-cg.com/spec/latest/core/",
+            title:"Hydra Core Vocabulary",
+            date:"15 March 2018",
+            publisher:"Hydra W3C Community Group",
+            status:"Unofficial Draft"
         },
-        "VIVO-ISF" : {
-            href:"http://github.com/vivo-isf/vivo-isf",
-            title:"VIVO-ISF Data Standard"
+        "INSPIRE-DoC": {
+            "href":"http://inspire.ec.europa.eu/metadata-codelist/DegreeOfConformity/",
+            "title":"INSPIRE Registry: Degrees of conformity",
+            "publisher":"European Commission"
+        },
+        "INSPIRE-SDST": {
+            "href":"http://inspire.ec.europa.eu/metadata-codelist/SpatialDataServiceType/",
+            "title":"INSPIRE Registry: Spatial data service types",
+            "publisher":"European Commission"
+        },        
+        "ISO-IEC-25012" : {
+            title : "ISO/IEC 25012 - Data Quality model",
+            href : "http://iso25000.com/index.php/en/iso-25000-standards/iso-25012"
+        },
+        "ISO-26324" : {
+            "authors":["ISO/TC 46/SC 9"],
+            "href":"https://www.iso.org/standard/43506.html",
+            "title":"Information and documentation -- Digital object identifier system",
+            "publisher":"ISO",
+            "status":"International Standard",
+            "date":"2012"
         },
         "LinkedDataPatterns" : {
             title : "Linked Data Patterns: A pattern catalogue for modelling, publishing, and consuming Linked Data",
@@ -145,27 +176,23 @@ var respecConfig = {
             date: "31 May 2012",
             href : "http://patterns.dataincubator.org/book/"
         },
-        "PROF-CONNEG": {
-            href: "https://w3c.github.io/dxwg/conneg-by-ap/",
-            title: "Content Negotiation by Profile",
-            date: "03 October 2018",
-            status: "W3C Editor's Draft"
+        "MDR-AR":{
+            "href":"https://publications.europa.eu/en/web/eu-vocabularies/at-dataset/-/resource/dataset/access-right",
+            "title":"Named Authority List: Access rights",
+            "publisher":"Publications Office of the European Union"
         },
-        "PROF-GUIDE": {
-            href: "https://w3c.github.io/dxwg/profiles/",
-            title: "Profile Guidance",
-            date: "03 October 2018",
-            status: "W3C Editor's Draft"
+        "OBO" : {
+            href:"http://www.obofoundry.org/",
+            title:"The OBO Foundry"
         },
-        "PROF-IETF": {
+        "ODRS": {
             authors: [
-                "L. Svensson",
-                "R. Verborgh"
+                "Leigh Dodds"
             ],
-            href: "https://profilenegotiation.github.io/I-D-Accept--Schema/I-D-accept-schema",
-            title: "Negotiating Profiles in HTTP",
-            date: "24 October 2017",
-            status: "IETF Internet Draft"
+            href:"http://schema.theodi.org/odrs",
+            title:"Open Data Rights Statement Vocabulary",
+            date:"29 July 2013",
+            publisher:"ODI"
         },
         "OpenAPI": {
             href: "https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.2.md",
@@ -182,63 +209,49 @@ var respecConfig = {
             date:"17 April 2018",
             publisher:"OpenSearch"
         },
-        "HYDRA": {
+        "PDO" : {
+            href:"http://vocab.deri.ie/pdo",
+            title:"Project Documents Ontology",
+            authors: ["Pradeep Varma"],
+            date: "09 July 2010"
+        },
+/*        
+        "PROF-CONNEG": {
+            href: "https://w3c.github.io/dxwg/conneg-by-ap/",
+            title: "Content Negotiation by Profile",
+            date: "03 October 2018",
+            status: "W3C Editor's Draft"
+        },
+*/        
+        "PROF-GUIDE": {
+            href: "https://w3c.github.io/dxwg/profiles/",
+            title: "Profile Guidance",
+            date: "03 October 2018",
+            status: "W3C Editor's Draft"
+        },
+        "PROF-IETF": {
             authors: [
-                "Markus Lanthaler"
+                "L. Svensson",
+                "R. Verborgh"
             ],
-            href:"https://www.hydra-cg.com/spec/latest/core/",
-            title:"Hydra Core Vocabulary",
-            date:"15 March 2018",
-            publisher:"Hydra W3C Community Group",
-            status:"Unofficial Draft"
+            href: "https://profilenegotiation.github.io/I-D-Accept--Schema/I-D-accept-schema",
+            title: "Negotiating Profiles in HTTP",
+            date: "24 October 2017",
+            status: "IETF Internet Draft"
         },
-        "ODRS": {
-            authors: [
-                "Leigh Dodds"
-            ],
-            href:"http://schema.theodi.org/odrs",
-            title:"Open Data Rights Statement Vocabulary",
-            date:"29 July 2013",
-            publisher:"ODI"
+        "VIVO-ISF" : {
+            href:"http://github.com/vivo-isf/vivo-isf",
+            title:"VIVO-ISF Data Standard"
         },
-        "MDR-AR":{
-            "href":"https://publications.europa.eu/en/web/eu-vocabularies/at-dataset/-/resource/dataset/access-right",
-            "title":"Named Authority List: Access rights",
-            "publisher":"Publications Office of the European Union"
-        },
-        "FAIR" : {
-            title : "The FAIR Guiding Principles for scientific data management and stewardship",
-            authors : [ "Mark D. Wilkinson" ],
+        "ZaveriEtAl" : {
+            title : "Quality assessment for Linked Data: A Survey",
+            authors : [ "Amrapali Zaveri"],
             etAl : true,
-            status : "Scientific Data, vol. 3, Article nr. 160018",
-            publisher : "Nature",
-            href : "https://doi.org/10.1038/sdata.2016.18"
+            status : "Semantic Web, vol. 7, no. 1, pp. 63-93",
+            publisher : "IOS Press",
+            href : "https://doi.org/10.3233/SW-150175",
+            date : "2015"
         },
-        "DCAT-AP-SE": {
-            title: "DCAT-AP-SE: Swedish recommendation for DCAT-AP1.1",
-            href: "https://lankadedata.se/spec/DCAT-AP-SE",
-            authors: ["Matthias Palmér"],
-            etAl: false
-        },
-        "DCAT-BE": {
-            title: "Linking data portals across Belgium.",
-            href: "http://dcat.be/"
-        },
-        "DCAT-AP-IT": {
-            title: "Profilo nazionale dei metadati DCAT-AP_IT v1.0",
-            href: "https://www.dati.gov.it/content/profilo-nazionale-dei-metadati-dcat-ap-it-v10"
-        },
-        "GeoDCAT-AP-IT": {
-            title: "GeoDCAT-AP in Italy, the national guidelines published",
-            href: "https://joinup.ec.europa.eu/news/geodcat-apit"
-        },
-        "DCAT-AP-NO": {
-            title: "Standard for beskrivelse av datasett og datakataloger (DCAT-AP-NO)",
-            href: "http://difi.github.io/dcat-ap-no/"
-        },
-        "DCAT-AP.de": {
-            title: "DCAT-AP.de als formaler Metadatenstandard für offene Verwaltungsdaten bestätigt",
-            href: "https://www.govdata.de/standardisierung"
-        }
+        
     }
 };

--- a/dcat/index.html
+++ b/dcat/index.html
@@ -2593,7 +2593,7 @@ ex:InternationalDOIFundation a foaf:Organization ;
     <p>Each type of quality information can pertain to one or more quality dimensions, namely, quality characteristics relevant
     to the consumer. The practice to see the quality as a multi-dimensional space is consolidated in the field of quality
     management to split the quality management into addressable chunks. DQV does not define a normative list of quality
-    dimensions. It offers the quality dimensions proposed in ISO/IEC 25012 [[?ISOIEC25012]] and Zaveri et al. [[?ZaveriEtAl]]
+    dimensions. It offers the quality dimensions proposed in ISO/IEC 25012 [[?ISO-IEC-25012]] and [[?ZaveriEtAl]]
     as two possible starting points. It also provides an <a href="https://www.w3.org/2016/05/ldqd">RDF representation</a>
     for the quality dimensions and categories defined in the latter. Ultimately, implementers will need to choose themselves
     the collection of quality dimensions that best fits their needs.
@@ -2747,7 +2747,7 @@ a:conformanceTest a prov:Plan ;
     # Here one can specify additional information on the test, which in the example is derived by the W3C Data on the Web Best Practices
     prov:wasDerivedFrom &lt;https://www.w3.org/TR/dwbp/&gt; .
     </pre></aside>
-            <p>Also, [[?VOCAB-DQV]] can be deployed to  measure the compliance to a specific standard. In the following example, the <code>:levelOfComplianceToDWBP</code> is a quality metrics which measures the compliance of a dataset to [[?DWBP]] in terms of the percentage of passed compliance tests. The example assumes <code>iso</code> as a namespace prefix representing the quality dimensions and categories defined in the ISO/IEC 25012 [[?ISOIEC25012]].</p>
+            <p>Also, [[?VOCAB-DQV]] can be deployed to  measure the compliance to a specific standard. In the following example, the <code>:levelOfComplianceToDWBP</code> is a quality metrics which measures the compliance of a dataset to [[?DWBP]] in terms of the percentage of passed compliance tests. The example assumes <code>iso</code> as a namespace prefix representing the quality dimensions and categories defined in the ISO/IEC 25012 [[?ISO-IEC-25012]].</p>
             <aside class="example" id="ex-conformance-degree-percentage">
   <pre class="nohighlight turtle">
 :levelOfComplianceToDWBP a dqv:Metric ;

--- a/dcat/index.html
+++ b/dcat/index.html
@@ -1222,7 +1222,7 @@ $(document).ready( function() {
             </p>
 
             <p class="note">
-              Since this property is a sub-property of <a href="http://www.w3.org/ns/prov#qualifiedInfluence"><code>prov:qualifiedInfluence</code></a>, use of this property on an individual entails that the context resource is a member of the class <a href="http://www.w3.org/ns/prov#Entity"><code>prov:Entity</code></a> [[RDF-SCHEMA]] .
+              Since this property is a sub-property of <a href="http://www.w3.org/ns/prov#qualifiedInfluence"><code>prov:qualifiedInfluence</code></a>, use of this property on an individual entails that the context resource is a member of the class <a href="http://www.w3.org/ns/prov#Entity"><code>prov:Entity</code></a> [[PROV-O]] .
             </p>
 
             <p class="note">

--- a/dcat/index.html
+++ b/dcat/index.html
@@ -2151,7 +2151,7 @@ $(document).ready( function() {
             <tr><td class="prop">Sub class of:</td><td><a href="#Class:Resource"><code>dcat:Resource</code></a></td></tr>
             <tr><td class="prop">Sub class of:</td><td><a href="http://purl.org/dc/dcmitype/Service"><code>dctype:Service</code></a></td></tr>
             <tr><td class="prop">Usage note:</td><td>If a  <a href="#Class:Data_Service"><code>dcat:DataService</code></a> is bound to one or more specified Datasets, they are indicated by the <a href="Property:dataservice_serves_dataset"><code>dcat:servesDataset</code></a> property.</td></tr>
-            <tr><td class="prop">Usage note:</td><td>The kind of service can be indicated using the <a href="http://purl.org/dc/terms/type"><code>dct:type</code></a> property. Its value may be taken from a controlled vocabulary such as the <a href="https://inspire.ec.europa.eu/metadata-codelist/SpatialDataServiceType/">INSPIRE spatial data service type vocabulary</a>.</td></tr>
+            <tr><td class="prop">Usage note:</td><td>The kind of service can be indicated using the <a href="http://purl.org/dc/terms/type"><code>dct:type</code></a> property. Its value may be taken from a controlled vocabulary such as the INSPIRE spatial data service type code list [[?INSPIRE-SDST]].</td></tr>
             </tbody>
         </table>
 
@@ -2712,7 +2712,7 @@ a:dataset a dcat:Dataset;
         <section id="quality-conformance-degree">
             <h3>Degree of conformance</h3>
             <p>Some legal context requires to specify the degree of conformance. For example, INSPIRE metadata adopts a
-	    specific <a href="http://inspire.ec.europa.eu/metadata-codelist/DegreeOfConformity">controlled vocabulary</a>
+	    specific controlled vocabulary [[?INSPIRE-DoC]]
 	    to express non-conformance and non-evaluation beside the full compliance. Similar controlled vocabularies can
 	    be defined in other contexts.</p>
 	    <p>The following example specifies some newly minted concepts representing the degree of conformance (i.e., conformant, not conformant) and  declares the
@@ -3922,7 +3922,7 @@ rdfs:seeAlso &lt;https://doi.org/10.1111/j.1365-2966.2006.10100.x&gt; ;
       </p>
       <p>
           The first example describes a data catalog hosted by the European Environment Agency (EEA).
-          This is classified as a <a href="#Class:Data_Service"><code>dcat:DataService</code></a> and has the <code>dct:type</code> set to <a href="http://inspire.ec.europa.eu/metadata-codelist/SpatialDataServiceType/discovery">discovery</a> from the <a href="http://inspire.ec.europa.eu/metadata-codelist/SpatialDataServiceType/">INSPIRE classification of spatial data service types</a>.
+          This is classified as a <a href="#Class:Data_Service"><code>dcat:DataService</code></a> and has the <code>dct:type</code> set to &quot;<a href="http://inspire.ec.europa.eu/metadata-codelist/SpatialDataServiceType/discovery">discovery</a>&quot; from the INSPIRE classification of spatial data service types [[?INSPIRE-SDST]].
       </p>
       <p>
           This example is available from the <a href="https://github.com/w3c/dxwg/tree/gh-pages/dcat/examples">DXWG code repository</a> at <a href="https://w3c.github.io/dxwg/dcat/examples/eea-csw.ttl"><code>eea-csw.ttl</code></a>
@@ -3959,7 +3959,7 @@ a:EEA-CSW-Endpoint
 </pre>
       <p>
           The next example shows a dataset hosted by Geoscience Australia, which is available from three distinct services, as indicated by the value of the <a href="#Property:dataservice_serves_dataset"><code>dcat:servesDataset</code></a> property of each of the service descriptions.
-          These are classified as a <a href="#Class:Data_Service"><code>dcat:DataService</code></a> and also have the <code>dct:type</code> set to <a href="http://inspire.ec.europa.eu/metadata-codelist/SpatialDataServiceType/download">download</a> and <a href="http://inspire.ec.europa.eu/metadata-codelist/SpatialDataServiceType/view">view</a> from the <a href="http://inspire.ec.europa.eu/metadata-codelist/SpatialDataServiceType/">INSPIRE classification of spatial data service types</a>.
+          These are classified as a <a href="#Class:Data_Service"><code>dcat:DataService</code></a> and also have the <code>dct:type</code> set to &quot;<a href="http://inspire.ec.europa.eu/metadata-codelist/SpatialDataServiceType/download">download</a>&quot; and &quot;<a href="http://inspire.ec.europa.eu/metadata-codelist/SpatialDataServiceType/view">view</a>&quot; from the INSPIRE classification of spatial data service types [[?INSPIRE-SDST]].
       </p>
       <p>
           This example is available from the <a href="https://github.com/w3c/dxwg/tree/gh-pages/dcat/examples">DXWG code repository</a> at <a href="https://w3c.github.io/dxwg/dcat/examples/ga-courts.ttl"><code>ga-courts.ttl</code></a>

--- a/dcat/index.html
+++ b/dcat/index.html
@@ -70,7 +70,7 @@ $(document).ready( function() {
     </p>
     <h3 id="dcat_history">DCAT history</h3>
     <p>The original DCAT vocabulary was developed and <a href="http://vocab.deri.ie/dcat">hosted</a> at the Digital Enterprise Research Institute (DERI), then refined by the <a href="http://www.w3.org/egov/">eGov Interest Group</a>, and finally standardized in 2014 [[?VOCAB-DCAT-20140116]] by the <a href="http://www.w3.org/2011/gld/">Government Linked Data (GLD)</a> Working Group.</p>
-    <p>This revised version of DCAT was developed by the <a href="https://www.w3.org/2017/dxwg/">Dataset Exchange Working Group</a> in response to a new set of Use Cases and Requirements [[?DCAT-UCR]] gathered from peoples' experience with the DCAT vocabulary from the time of the original version, and new applications that were not considered in the first version. A summary of the changes from  [[?VOCAB-DCAT-20140116]] <a href="#changes">is provided</a>. </p>
+    <p>This revised version of DCAT was developed by the <a href="https://www.w3.org/2017/dxwg/">Dataset Exchange Working Group</a> in response to a new set of Use Cases and Requirements [[?DCAT-UCR]] gathered from peoples' experience with the DCAT vocabulary from the time of the original version, and new applications that were not considered in the first version. A summary of the changes from [[?VOCAB-DCAT-20140116]] is provided in <a href="#changes"></a>. </p>
 
     <h3 id="external_terms">External terms</h3>
     <p>DCAT incorporates terms from pre-existing vocabularies where stable terms with appropriate meanings could be found, such as <a href="http://xmlns.com/foaf/0.1/homepage"><code>foaf:homepage</code></a> and <a href="http://purl.org/dc/terms/title"><code>dct:title</code></a>.

--- a/dcat/index.html
+++ b/dcat/index.html
@@ -633,7 +633,7 @@ $(document).ready( function() {
         </p-->
 
         <p>The (revised) DCAT vocabulary is <a href="https://github.com/w3c/dxwg/tree/gh-pages/dcat/rdf/">available in RDF</a>.
-            The primary artefact <a href="https://w3c.github.io/dxwg/dcat/rdf/dcat.ttl">dcat.ttl</a> is a serialization of the core DCAT vocabulary.
+            The primary artefact <a href="https://w3c.github.io/dxwg/dcat/rdf/dcat.ttl"><code>dcat.ttl</code></a> is a serialization of the core DCAT vocabulary.
             Alongside it are a set of other RDF files that provide additional information, including:</p>
         <ol>
             <li>
@@ -3756,7 +3756,7 @@ ex:Test543L
 </pre>
 
       <p>
-          This example is available from the <a href="https://github.com/w3c/dxwg/tree/gh-pages/dcat/examples">DXWG code repository</a> at <a href="https://w3c.github.io/dxwg/dcat/examples/csiro-dap-examples.ttl">csiro-dap-examples.ttl</a>
+          This example is available from the <a href="https://github.com/w3c/dxwg/tree/gh-pages/dcat/examples">DXWG code repository</a> at <a href="https://w3c.github.io/dxwg/dcat/examples/csiro-dap-examples.ttl"><code>csiro-dap-examples.ttl</code></a>.
       </p>
 
       <p>
@@ -3862,7 +3862,7 @@ dap:d33937
 .
       </pre>
       <p>
-          This example is available from the <a href="https://github.com/w3c/dxwg/tree/gh-pages/dcat/examples">DXWG code repository</a> at <a href="https://w3c.github.io/dxwg/dcat/examples/csiro-stratchart.ttl">csiro-stratchart.ttl</a>
+          This example is available from the <a href="https://github.com/w3c/dxwg/tree/gh-pages/dcat/examples">DXWG code repository</a> at <a href="https://w3c.github.io/dxwg/dcat/examples/csiro-stratchart.ttl"><code>csiro-stratchart.ttl</code></a>.
       </p>
 
   </section>
@@ -3895,7 +3895,7 @@ rdfs:seeAlso &lt;https://doi.org/10.1111/j.1365-2966.2006.10100.x&gt; ;
 .
 </pre>
       <p>
-          This example is available from the <a href="https://github.com/w3c/dxwg/tree/gh-pages/dcat/examples">DXWG code repository</a> at <a href="https://w3c.github.io/dxwg/dcat/examples/csiro-dap-examples.ttl">csiro-dap-examples.ttl</a>
+          This example is available from the <a href="https://github.com/w3c/dxwg/tree/gh-pages/dcat/examples">DXWG code repository</a> at <a href="https://w3c.github.io/dxwg/dcat/examples/csiro-dap-examples.ttl"><code>csiro-dap-examples.ttl</code></a>.
       </p>
       <p>
           Several properties capture provenance information, including within the citation and title, but the primary link to a formal description of the project is through <a href="#Property:dataset_wasgeneratedby"><code>prov:wasGeneratedBy</code></a>.
@@ -3967,7 +3967,7 @@ a:EEA-CSW-Endpoint
           These are classified as a <a href="#Class:Data_Service"><code>dcat:DataService</code></a> and also have the <code>dct:type</code> set to <a href="http://inspire.ec.europa.eu/metadata-codelist/SpatialDataServiceType/download">download</a> and <a href="http://inspire.ec.europa.eu/metadata-codelist/SpatialDataServiceType/view">view</a> from the <a href="http://inspire.ec.europa.eu/metadata-codelist/SpatialDataServiceType/">INSPIRE classification of spatial data service types</a>.
       </p>
       <p>
-          This example is available from the <a href="https://github.com/w3c/dxwg/tree/gh-pages/dcat/examples">DXWG code repository</a> at <a href="https://w3c.github.io/dxwg/dcat/examples/ga-courts.ttl">ga-courts.ttl</a>
+          This example is available from the <a href="https://github.com/w3c/dxwg/tree/gh-pages/dcat/examples">DXWG code repository</a> at <a href="https://w3c.github.io/dxwg/dcat/examples/ga-courts.ttl"><code>ga-courts.ttl</code></a>
       </p>
 
 <pre id="ex-service-gsa" class="example nohighlight turtle">

--- a/dcat/index.html
+++ b/dcat/index.html
@@ -1285,7 +1285,7 @@ $(document).ready( function() {
               <tr><td class="prop">Range:</td><td><a href="https://www.w3.org/TR/prov-o/#Attribution">prov:Attribution</a></td></tr>
               <tr><td class="prop">Usage note:</td><td>Used to link to an Agent where the nature of the relationship is known but does not match one of the standard [[?DCTERMS]] properties (<a href="http://purl.org/dc/terms/creator"></code>dct:creator</code></a>, <a href="http://purl.org/dc/terms/creator"></code>dct:publisher</code></a>).
               Use <code>dcat:hadRole</code> on the <a href="http://www.w3.org/ns/prov#Attribution"></code>prov:Attribution</code></a> to capture the responsibility of the Agent with respect to the Resource.
-              See <a class="sectionRef" href="#qualified-attribution></a> for usage examples.</td></tr>
+              See <a class="sectionRef" href="#qualified-attribution"></a> for usage examples.</td></tr>
               </tbody>
             </table>
 

--- a/dcat/index.html
+++ b/dcat/index.html
@@ -78,7 +78,7 @@ $(document).ready( function() {
     <p>This revised version of DCAT was developed by the <a href="https://www.w3.org/2017/dxwg/">Dataset Exchange Working Group</a> in response to a new set of Use Cases and Requirements [[?DCAT-UCR]] gathered from peoples' experience with the DCAT vocabulary from the time of the original version, and new applications that were not considered in the first version. A summary of the changes from  [[?VOCAB-DCAT-20140116]] can be found at <a href="#changes">Change History</a></p>
 
     <h3 id="external_terms">External terms</h3>
-    <p>DCAT incorporates terms from pre-existing vocabularies where stable terms with appropriate meanings could be found, such as <a href="http://xmlns.com/foaf/0.1/homepage">foaf:homepage</a> and <a href="http://purl.org/dc/terms/title">dct:title</a>.
+    <p>DCAT incorporates terms from pre-existing vocabularies where stable terms with appropriate meanings could be found, such as <a href="http://xmlns.com/foaf/0.1/homepage"><code>foaf:homepage</code></a> and <a href="http://purl.org/dc/terms/title"><code>dct:title</code></a>.
       Informal summary definitions of the externally-defined terms are included here for convenience, while authoritative definitions are available in the normative references.
       Changes to definitions in the references, if any, supersede the summaries given in this specification.
       Note that conformance to DCAT (Section 4) concerns usage of only the terms in the DCAT namespace itself, so possible changes to the external definitions will not affect the conformance of DCAT implementations.</p>
@@ -147,7 +147,7 @@ $(document).ready( function() {
 <section id="motivation" class="informative"><h2>Motivation for change</h2>
     <p>The original Recommendation [[?VOCAB-DCAT-20140116]] published in January 2014 provided the basic framework for describing datasets. It made an important distinction between a <i>dataset</i> as an abstract idea and a <i>distribution</i> as a manifestation of the dataset. Although DCAT has been widely adopted, it has become clear that the original specification lacked a number of essential features that were added either through the mechanism of an application profile, such as the European Commission's DCAT-AP [[?DCAT-AP]], or the development of larger vocabularies that to a greater or lesser extent built upon the base standard, such as the Healthcare and Life Sciences Community Profile [[?HCLS-Dataset]], the Data Tag Suite [[?DATS]] and more. This revision of DCAT has been developed to address the specific shortcomings that have come to light through the experiences of different communities, the aim being to improve interoperability between the outputs of these larger vocabularies.
     For example, in this new DCAT version we provide classes, properties and guidance to address <a href="#Dereferenceable-identifiers">identifiers</a>, <a href="#quality-information">dataset quality information</a>, and <a href="#data-citation">data citation</a> issues.</p>
-    <p>This draft includes re-writing of the specification throughout. Significant changes from the 2014 Recommendation are marked within the text using "Note" sections, as well as being described in the <a href="#changes">Change History</a>.</p>
+    <p>This draft includes re-writing of the specification throughout. Significant changes from the 2014 Recommendation are marked within the text using "Note" sections, as well as being described in <a class="sectionRef" href="#changes"></a>.</p>
 
 </section>
 
@@ -229,7 +229,7 @@ $(document).ready( function() {
         </li>
         <li>
           <a href="#Class:Resource"><code>dcat:Resource</code></a> represents an individual item in a catalog.
-          This class is not intended to be used directly, but is the parent class of <a href="#Class:Dataset"><code>dcat:Dataset</code></a>, <a href="#Class:Data_Service"><code>dcat:DataService</code></a> and <a href="#Class:Catalog">dcat:Catalog</a>.
+          This class is not intended to be used directly, but is the parent class of <a href="#Class:Dataset"><code>dcat:Dataset</code></a>, <a href="#Class:Data_Service"><code>dcat:DataService</code></a> and <a href="#Class:Catalog"><code>dcat:Catalog</code></a>.
           Member items in a catalog should be members of one of the sub-classes, or of a sub-class of these, or of a sub-class of <a href="#Class:Resource"><code>dcat:Resource</code></a> defined in a DCAT application profile or other DCAT application.
           <a href="#Class:Resource"><code>dcat:Resource</code></a> is effectively an extension point for defining a catalog of any kind of resource.
         </li>
@@ -239,11 +239,11 @@ $(document).ready( function() {
           Data comes in many forms including numbers, words, pixels, imagery, sound and other multi-media, and potentially other types, any of which might be collected into a dataset.
         </li>
         <li>
-          <code><a href="#Class:Distribution">dcat:Distribution</a></code> represents an accessible form of a dataset such as a downloadable file.
+          <a href="#Class:Distribution"><code>dcat:Distribution</code></a> represents an accessible form of a dataset such as a downloadable file.
         </li>
         <li>
           <a href="#Class:Data_Service"><code>dcat:DataService</code></a> represents a data service in a catalog.
-          A data service is a collection of operations accessible through an interface (API) that provide access to one or more datasets or data processing functions.
+          A data service is a collection of operations accessible through an interface (<abbr title="Application Programming Interface">API</abbr>) that provide access to one or more datasets or data processing functions.
         </li>
         <!--
           <li>
@@ -258,15 +258,17 @@ $(document).ready( function() {
         </li>
     </ul>
 
-    <figure id="UML_DCAT_All_Attr"><img alt="UML model of DCAT classes and properties" src="UML/DCAT-summary-all-attributes.png">
-        <figcaption>
-            Overview of DCAT model, showing the classes of resources that can be members of a Catalog, and the relationships between them.
-        </figcaption>
+    <figure id="UML_DCAT_All_Attr">
+      <img alt="UML model of DCAT classes and properties" src="./UML/DCAT-summary-all-attributes.png">
+      <figcaption>
+          Overview of DCAT model, showing the classes of resources that can be members of a Catalog, and the relationships between them.
+      </figcaption>
     </figure>
+    
     <p class="note">
-        Along with the rest of the <a href="#vocabulary-overview">Vocabulary overview</a>, this diagram is <b>non-normative</b>.
+        Along with the rest of <a class="sectionRef" href="#vocabulary-overview"></a>, this diagram is <b>non-normative</b>.
         Furthermore, while the diagram uses UML-style class notation it should be interpreted following the usual RDF open-world assumptions around the presence/absence of properties, relationships, and their cardinality.
-        The properties shown in each class reflect those recommended in the descriptions of classes in the <a href="#vocabulary-specification">Vocabulary specification</a>.
+        The properties shown in each class reflect those recommended in the descriptions of classes in <a href="#vocabulary-specification"></a>.
         To assist in understanding the full scope of each class, properties are copied down from each '::super-class'.
         Cardinalities are shown in a few places to reinforce expectations, but these are not axiomatized or enforced in any way by this recommendation.
     </p>
@@ -298,8 +300,8 @@ $(document).ready( function() {
     <div class="note">
       <p>
         The scope of DCAT 2014 [[?VOCAB-DCAT-20140116]] was limited to catalogs of datasets.
-        A number of use cases for the revision involve <b>data services</b> as members of a catalog - see <a href="https://www.w3.org/TR/dcat-ucr/#ID6">DCAT Distribution to describe web services - ID6</a> and
-        <a href="https://www.w3.org/TR/dcat-ucr/#ID18">Modeling service-based data access - ID18</a>.
+        A number of use cases for the revision [[?DCAT-UCR]] involve <b>data services</b> as members of a catalog - see <a data-cite="DCAT-UCR#ID6">DCAT Distribution to describe web services - ID6</a> and
+        <a data-cite="DCAT-UCR#ID18">Modeling service-based data access - ID18</a>.
         Hence, the scope of this revision of DCAT includes both datasets and data services to enable these to be part of a DCAT conformant catalog.
         Provision for  Catalogs to be composed of other Catalogs is also made.
         See <a href="https://github.com/w3c/dxwg/issues/172">Issue #172</a>.
@@ -317,7 +319,7 @@ $(document).ready( function() {
       <p id="owl2">
         The DCAT vocabulary is an OWL2 ontology [[?OWL2-OVERVIEW]] formalized using [[?RDF-SCHEMA]].
         Each class and property in DCAT is denoted by an [[?IRI]].
-        Locally defined elements are in the namespace <a href="http://www.w3.org/ns/dcat#">http://www.w3.org/ns/dcat#</a>.
+        Locally defined elements are in the namespace <a href="http://www.w3.org/ns/dcat#"><code>http://www.w3.org/ns/dcat#</code></a>.
         Elements are also adopted from several external vocabularies, in particular [[?FOAF]], [[?DCTERMS]] and [[?PROV-O]]
       </p>
       <p id="blankNodes">
@@ -388,7 +390,7 @@ $(document).ready( function() {
         <p>
           Five distinct temporal descriptors are shown for this dataset.
           The dataset publication and revision dates are shown in <a href="#Property:resource_release_date"><code>dct:issued</code></a> and <a href="#Property:resource_update_date"><code>dct:modified</code></a>.
-          For the frequency of update of the dataset in <a href="#Property:dataset_frequency"><code>dct:accrualPeriodicity</code></a>, we use an instance from the <a href="http://www.w3.org/TR/vocab-data-cube/#dsd-cog">Content-Oriented Guidelines</a> developed as part of the <abbr title="World Wide Web Consortium">W3C</abbr> Data Cube Vocabulary [[?VOCAB-DATA-CUBE]] efforts.
+          For the frequency of update of the dataset in <a href="#Property:dataset_frequency"><code>dct:accrualPeriodicity</code></a>, we use an instance from the <a data-cite="VOCAB-DATA-CUBE#dsd-cog">Content-Oriented Guidelines</a> developed as part of the <abbr title="World Wide Web Consortium">W3C</abbr> Data Cube Vocabulary [[?VOCAB-DATA-CUBE]] efforts.
           The temporal coverage or extent is given in <a href="#Property:dataset_temporal"><code>dct:temporal</code></a> using an item from the Interval dataset (originally available from http://reference.data.gov.uk/id/interval) from data.gov.uk.
           The temporal resolution, which describes the minimum spacing of items within the dataset, is given in <a href="#Property:dataset_temporalresolution"><code>dcat:temporalResolution</code></a> using the standard datatype <code>xsd:duration</code>.
         </p>
@@ -683,7 +685,7 @@ $(document).ready( function() {
         <h3>Class: Catalog</h3>
         <p>The following properties are recommended for use on this class:
             <a href="#Property:catalog_catalog_record">catalog record</a>,
-            <a href="#Property:catalog_hasPart">hasPart</a>,
+            <a href="#Property:catalog_hasPart">has part</a>,
             <a href="#Property:catalog_dataset">dataset</a>,
             <a href="#Property:catalog_service">service</a>,
             <a href="#Property:catalog_catalog">catalog</a>,
@@ -700,7 +702,7 @@ $(document).ready( function() {
             <a href="#Property:dataset_wasgeneratedby">was generated by</a>
         </p>
         <p>The following properties are inherited from the super-class <a href="#Class:Resource"><code>dcat:Resource</code></a>:
-            <a href="#Property:resource_conformsto">conformsTo</a>,
+            <a href="#Property:resource_conformsto">conforms to</a>,
             <a href="#Property:resource_contact_point">contact point</a>,
             <a href="#Property:resource_creator">creator</a>,
             <a href="#Property:resource_description">description</a>,
@@ -766,7 +768,7 @@ $(document).ready( function() {
         </section>
 
         <section id="Property:catalog_hasPart">
-            <h4>Property: hasPart</h4>
+            <h4>Property: has part</h4>
 
             <p class="note">
                 Explicit use of this property added in this revision of DCAT.
@@ -853,8 +855,8 @@ $(document).ready( function() {
         <h3>Class: Catalogued Resource</h3>
 
         <p>The following properties are recommended for use on this class:
-            <a href="#Property:resource_accessRights">accessRights</a>,
-            <a href="#Property:resource_conformsto">conformsTo</a>,
+            <a href="#Property:resource_accessRights">access rights</a>,
+            <a href="#Property:resource_conformsto">conforms to</a>,
             <a href="#Property:resource_contact_point">contact point</a>,
             <a href="#Property:resource_creator">creator</a>,
             <a href="#Property:resource_description">description</a>,
@@ -910,7 +912,7 @@ $(document).ready( function() {
         </p>
 
         <section id="Property:resource_accessRights">
-            <h4>Property: accessRights</h4>
+            <h4>Property: access rights</h4>
 
             <table class="definition">
                 <thead><tr><th>RDF Property:</th><th><a href="http://purl.org/dc/terms/accessRights">dct:accessRights</a></th></tr></thead>
@@ -1193,7 +1195,30 @@ $(document).ready( function() {
               <tr><td class="prop">Sub-property of:</td><td><a href="http://www.w3.org/ns/prov#qualifiedInfluence">prov:qualifiedInfluence</a></td></tr>
               <tr><td class="prop">Domain:</td><td><a href="#Class:Resource">dcat:Resource</a></td></tr>
               <tr><td class="prop">Range:</td><td><a href="#Class:Relationship">dcat:Relationship</a></td></tr>
-              <tr><td class="prop">Usage note:</td><td>Used to link to another resource where the nature of the relationship is known but does not match one of the standard Dublin Core properties (dct:hasPart, dct:isPartOf, dct:conformsTo, dct:isFormatOf, dct:hasFormat, dct:isVersionOf, dct:hasVersion, dct:replaces, dct:isReplacedBy, dct:references, dct:isReferencedBy, dct:requires, dct:isRequiredBy) or PROV-O properties (prov:wasDerivedFrom, prov:wasInfluencedBy, prov:wasQuotedFrom, prov:wasRevisionOf, prov:hadPrimarySource, prov:alternateOf, prov:specializationOf).</td></tr>
+              <tr><td class="prop">Usage note:</td><td>Used to link to another resource where the nature of the relationship is known but does not match one of the standard [[?DCTERMS]] properties 
+              (<a href="http://purl.org/dc/terms/hasPart"><code>dct:hasPart</code></a>,
+              <a href="http://purl.org/dc/terms/isPartOf"><code>dct:isPartOf</code></a>,
+              <a href="http://purl.org/dc/terms/conformsTo"><code>dct:conformsTo</code></a>,
+              <a href="http://purl.org/dc/terms/isFormatOf"><code>dct:isFormatOf</code></a>,
+              <a href="http://purl.org/dc/terms/hasFormat"><code>dct:hasFormat</code></a>,
+              <a href="http://purl.org/dc/terms/isVersionOf"><code>dct:isVersionOf</code></a>,
+              <a href="http://purl.org/dc/terms/hasVersion"><code>dct:hasVersion</code></a>,
+              <a href="http://purl.org/dc/terms/replaces"><code>dct:replaces</code></a>,
+              <a href="http://purl.org/dc/terms/isReplacedBy"><code>dct:isReplacedBy</code></a>,
+              <a href="http://purl.org/dc/terms/references"><code>dct:references</code></a>,
+              <a href="http://purl.org/dc/terms/isReferencedBy"><code>dct:isReferencedBy</code></a>,
+              <a href="http://purl.org/dc/terms/requires"><code>dct:requires</code></a>,
+              <a href="http://purl.org/dc/terms/isRequiredBy"><code>dct:isRequiredBy</code></a>)
+              or [[?PROV-O]] properties 
+              (<a href="http://www.w3.org/ns/prov#wasDerivedFrom">prov:wasDerivedFrom</a>, 
+              <a href="http://www.w3.org/ns/prov#wasInfluencedBy">prov:wasInfluencedBy</a>, 
+              <a href="http://www.w3.org/ns/prov#wasQuotedFrom">prov:wasQuotedFrom</a>, 
+              <a href="http://www.w3.org/ns/prov#wasRevisionOf">prov:wasRevisionOf</a>, 
+              <a href="http://www.w3.org/ns/prov#hadPrimarySource">prov:hadPrimarySource</a>, 
+              <a href="http://www.w3.org/ns/prov#alternateOf">prov:alternateOf</a>, 
+              <a href="http://www.w3.org/ns/prov#specializationOf">prov:specializationOf</a>).
+              </td>
+              </tr>
               </tbody>
             </table>
 
@@ -1255,12 +1280,12 @@ $(document).ready( function() {
               <thead><tr><th>RDF Property:</th><th><a href="https://www.w3.org/ns/prov#qualifiedAttribution">prov:qualifiedAttribution</a></th></tr></thead>
               <tbody>
               <tr><td class="prop">Definition:</td><td>Link to an Agent having some form of responsibility for the resource</td></tr>
-              <tr><td class="prop">Sub-property of:</td><td><a href="http://www.w3.org/ns/prov#qualifiedInfluence">prov:qualifiedInfluence</a></td></tr>
+              <tr><td class="prop">Sub-property of:</td><td><a href="http://www.w3.org/ns/prov#qualifiedInfluence"><code>prov:qualifiedInfluence</code></a></td></tr>
               <tr><td class="prop">Domain:</td><td><a href="https://www.w3.org/TR/prov-o/#Entity">prov:Entity</a></td></tr>
               <tr><td class="prop">Range:</td><td><a href="https://www.w3.org/TR/prov-o/#Attribution">prov:Attribution</a></td></tr>
-              <tr><td class="prop">Usage note:</td><td>Used to link to an Agent where the nature of the relationship is known but does not match one of the standard Dublin Core properties (dct:creator, dct:publisher).
-              Use dcat:hadRole on the prov:Attribution to capture the responsibility of the Agent with respect to the Resource.
-              See https://w3c.github.io/dxwg/dcat/#qualified-attribution for usage examples.</td></tr>
+              <tr><td class="prop">Usage note:</td><td>Used to link to an Agent where the nature of the relationship is known but does not match one of the standard [[?DCTERMS]] properties (<a href="http://purl.org/dc/terms/creator"></code>dct:creator</code></a>, <a href="http://purl.org/dc/terms/creator"></code>dct:publisher</code></a>).
+              Use <code>dcat:hadRole</code> on the <a href="http://www.w3.org/ns/prov#Attribution"></code>prov:Attribution</code></a> to capture the responsibility of the Agent with respect to the Resource.
+              See <a class="sectionRef" href="#qualified-attribution></a> for usage examples.</td></tr>
               </tbody>
             </table>
 
@@ -1303,7 +1328,7 @@ $(document).ready( function() {
                 <tr><td class="prop">Range:</td><td><a href="http://purl.org/dc/terms/RightsStatement"><code>dct:RightsStatement</code></a></td></tr>
                 <tr><td class="prop">Usage note:</td><td>Information about licenses and rights <em title="MAY" class="rfc2119">MAY</em> be provided for the Resource. See also guidance at <a href="#license-rights">License and rights statements</a>.</td></tr>
 
-                <tr><td class="prop">See also:</td><td><a href="#Property:resource_license" title="">resource license</a>, <a href="#Property:distribution_rights">distribution rights</a>, <a href="#Property:resource_accessRights">resource accessRights</a></td></tr>
+                <tr><td class="prop">See also:</td><td><a href="#Property:resource_license" title="">resource license</a>, <a href="#Property:distribution_rights">distribution rights</a>, <a href="#Property:resource_accessRights">resource access rights</a></td></tr>
                 </tbody>
             </table>
         </section>
@@ -1318,7 +1343,7 @@ $(document).ready( function() {
                 <tr><td class="prop">Range:</td><td><a href="https://www.w3.org/TR/odrl-vocab/#term-Policy"><code>odrl:Policy</code></a></td></tr>
                 <tr><td class="prop">Usage note:</td><td>Information about rights expressed as ODRL [[ODRL-VOCAB]] policies <em title="MAY" class="rfc2119">MAY</em> be provided for the Resource. See also guidance at <a href="#license-rights">License and rights statements</a>.</td></tr>
 
-                <tr><td class="prop">See also:</td><td><a href="#Property:resource_license" title="">resource license</a>, <a href="#Property:resource_accessRights" title="">resource accessRights</a>, <a href="#Property:resource_rights" title="">resource rights</a></td></tr>
+                <tr><td class="prop">See also:</td><td><a href="#Property:resource_license" title="">resource license</a>, <a href="#Property:resource_accessRights" title="">resource access rights</a>, <a href="#Property:resource_rights" title="">resource rights</a></td></tr>
                 </tbody>
             </table>
         </section>
@@ -1470,8 +1495,8 @@ $(document).ready( function() {
             <a href="#Property:dataset_wasgeneratedby">was generated by</a>
         </p>
         <p>The following properties are inherited from the super-class <a href="#Class:Resource"><code>dcat:Resource</code></a>:
-            <a href="#Property:resource_accessRights">accessRights</a>,
-            <a href="#Property:resource_conformsto">conformsTo</a>,
+            <a href="#Property:resource_accessRights">access rights</a>,
+            <a href="#Property:resource_conformsto">conforms to</a>,
             <a href="#Property:resource_contact_point">contact point</a>,
             <a href="#Property:resource_creator">creator</a>,
             <a href="#Property:resource_description">description</a>,
@@ -1828,7 +1853,7 @@ $(document).ready( function() {
         </section>
 
         <section id="Property:distribution_accessRights">
-            <h4>Property: accessRights</h4>
+            <h4>Property: access rights</h4>
 
             <table class="definition">
                 <thead><tr><th>RDF Property:</th><th><a href="http://purl.org/dc/terms/accessRights">dct:accessRights</a></th></tr></thead>
@@ -1838,7 +1863,7 @@ $(document).ready( function() {
                 <tr><td class="prop">Usage note:</td><td>Information about licenses and rights <em title="MAY" class="rfc2119">MAY</em> be provided for the Distribution. See also guidance at <a href="#license-rights">License and rights statements</a>.</td></tr>
 
                 <tr><td class="prop">See also:</td><td><a href="#Property:distribution_license" title="">distribution license</a>, <a href="#Property:distribution_rights" title="">distribution rights</a>,
-                    <a href="#Property:resource_accessRights" title="">resource accessRights</a></td></tr>
+                    <a href="#Property:resource_accessRights" title="">resource access rights</a></td></tr>
                 </tbody>
             </table>
         </section>
@@ -1871,7 +1896,7 @@ $(document).ready( function() {
                 <tr><td class="prop">Range:</td><td><a href="https://www.w3.org/TR/odrl-vocab/#term-Policy"><code>odrl:Policy</code></a></td></tr>
                 <tr><td class="prop">Usage note:</td><td>Information about rights expressed as ODRL [[ODRL-VOCAB]] policies <em title="MAY" class="rfc2119">MAY</em> be provided for the Distribution. See also guidance at <a href="#license-rights">License and rights statements</a>.</td></tr>
 
-                <tr><td class="prop">See also:</td><td><a href="#Property:resource_license" title="">resource license</a>, <a href="#Property:distribution_accessRights" title="">distribution accessRights</a>, <a href="#Property:distribution_rights" title="">distribution rights</a></td></tr>
+                <tr><td class="prop">See also:</td><td><a href="#Property:resource_license" title="">resource license</a>, <a href="#Property:distribution_accessRights" title="">distribution access rights</a>, <a href="#Property:distribution_rights" title="">distribution rights</a></td></tr>
                 </tbody>
             </table>
         </section>
@@ -2095,12 +2120,12 @@ $(document).ready( function() {
             <a href="#Property:dataservice_endpointdescription">endpointDescription</a>,
             <a href="#Property:dataservice_endpointurl">endpointURL</a>,
             <a href="#Property:dataservice_license">license</a>,
-            <a href="#Property:dataservice_access_rights">accessRights</a>,
+            <a href="#Property:dataservice_access_rights">access rights</a>,
             <a href="#Property:dataservice_serves_dataset">servesDataset</a>
         </p>
         <p>The following properties are inherited from the super-class <a href="#Class:Resource"><code>dcat:Resource</code></a>:
-            <a href="#Property:resource_accessRights">accessRights</a>,
-            <a href="#Property:resource_conformsto">conformsTo</a>,
+            <a href="#Property:resource_accessRights">access rights</a>,
+            <a href="#Property:resource_conformsto">conforms to</a>,
             <a href="#Property:resource_contact_point">contact point</a>,
             <a href="#Property:resource_creator">creator</a>,
             <a href="#Property:resource_description">description</a>,
@@ -2211,10 +2236,10 @@ $(document).ready( function() {
             <a href="#Property:dataservice_endpointdescription">endpointDescription</a>,
             <a href="#Property:dataservice_endpointurl">endpointURL</a>,
             <a href="#Property:dataservice_license">license</a>,
-            <a href="#Property:dataservice_access_rights">accessRights</a>
+            <a href="#Property:dataservice_access_rights">access rights</a>
         </p>
         <p>The following properties are are inherited from the super-class <a href="#Class:Resource"><code>dcat:Resource</code></a>:
-            <a href="#Property:resource_conformsto">conformsTo</a>,
+            <a href="#Property:resource_conformsto">conforms to</a>,
             <a href="#Property:resource_contact_point">contact point</a>,
             <a href="#Property:resource_creator">creator</a>,
             <a href="#Property:resource_description">description</a>,
@@ -2265,10 +2290,10 @@ $(document).ready( function() {
             <a href="#Property:dataservice_endpointdescription">endpointDescription</a>,
             <a href="#Property:dataservice_endpointurl">endpointURL</a>,
             <a href="#Property:dataservice_license">license</a>,
-            <a href="#Property:dataservice_access_rights">accessRights</a>
+            <a href="#Property:dataservice_access_rights">access rights</a>
         </p>
         <p>The following properties are are inherited from the super-class <a href="#Class:Resource"><code>dcat:Resource</code></a>:
-            <a href="#Property:resource_conformsto">conformsTo</a>,
+            <a href="#Property:resource_conformsto">conforms to</a>,
             <a href="#Property:resource_contact_point">contact point</a>,
             <a href="#Property:resource_creator">creator</a>,
             <a href="#Property:resource_description">description</a>,
@@ -2354,12 +2379,36 @@ end class DiscoveryService -->
         </p>
 
         <table class="definition">
-            <thead><tr><th>RDF Class:</th><th><a href="http://www.w3.org/ns/dcat#Relationship">dcat:Relationship</a></th></tr></thead>
-            <tbody>
+          <thead><tr><th>RDF Class:</th><th><a href="http://www.w3.org/ns/dcat#Relationship">dcat:Relationship</a></th></tr></thead>
+          <tbody>
             <tr><td class="prop">Definition:</td><td>An association class for attaching additional information to a relationship between DCAT Resources</td></tr>
             <tr><td class="prop">Sub class of:</td><td><a href="http://www.w3.org/ns/prov#EntityInfluence"><code>prov:EntityInfluence</code></a></td></tr>
-            <tr><td class="prop">Usage note:</td><td>Use to characterize a relationship between datasets, and potentially other resources, where the nature of the relationship is known but is not adequately characterized by the standard Dublin Core properties (dct:hasPart, dct:isPartOf, dct:conformsTo, dct:isFormatOf, dct:hasFormat, dct:isVersionOf, dct:hasVersion, dct:replaces, dct:isReplacedBy, dct:references, dct:isReferencedBy, dct:requires, dct:isRequiredBy) or PROV-O properties (prov:wasDerivedFrom, prov:wasInfluencedBy, prov:wasQuotedFrom, prov:wasRevisionOf, prov:hadPrimarySource, prov:alternateOf, prov:specializationOf)</td></tr>
-            </tbody>
+            <tr><td class="prop">Usage note:</td><td>
+              Use to characterize a relationship between datasets, and potentially other resources, where the nature of the relationship is known but is not adequately characterized by the standard [[?DCTERMS]] properties 
+              (<a href="http://purl.org/dc/terms/hasPart"><code>dct:hasPart</code></a>,
+              <a href="http://purl.org/dc/terms/isPartOf"><code>dct:isPartOf</code></a>,
+              <a href="http://purl.org/dc/terms/conformsTo"><code>dct:conformsTo</code></a>,
+              <a href="http://purl.org/dc/terms/isFormatOf"><code>dct:isFormatOf</code></a>,
+              <a href="http://purl.org/dc/terms/hasFormat"><code>dct:hasFormat</code></a>,
+              <a href="http://purl.org/dc/terms/isVersionOf"><code>dct:isVersionOf</code></a>,
+              <a href="http://purl.org/dc/terms/hasVersion"><code>dct:hasVersion</code></a>,
+              <a href="http://purl.org/dc/terms/replaces"><code>dct:replaces</code></a>,
+              <a href="http://purl.org/dc/terms/isReplacedBy"><code>dct:isReplacedBy</code></a>,
+              <a href="http://purl.org/dc/terms/references"><code>dct:references</code></a>,
+              <a href="http://purl.org/dc/terms/isReferencedBy"><code>dct:isReferencedBy</code></a>,
+              <a href="http://purl.org/dc/terms/requires"><code>dct:requires</code></a>,
+              <a href="http://purl.org/dc/terms/isRequiredBy"><code>dct:isRequiredBy</code></a>)
+              or [[?PROV-O]] properties 
+              (<a href="http://www.w3.org/ns/prov#wasDerivedFrom">prov:wasDerivedFrom</a>, 
+              <a href="http://www.w3.org/ns/prov#wasInfluencedBy">prov:wasInfluencedBy</a>, 
+              <a href="http://www.w3.org/ns/prov#wasQuotedFrom">prov:wasQuotedFrom</a>, 
+              <a href="http://www.w3.org/ns/prov#wasRevisionOf">prov:wasRevisionOf</a>, 
+              <a href="http://www.w3.org/ns/prov#hadPrimarySource">prov:hadPrimarySource</a>, 
+              <a href="http://www.w3.org/ns/prov#alternateOf">prov:alternateOf</a>, 
+              <a href="http://www.w3.org/ns/prov#specializationOf">prov:specializationOf</a>).        
+            </td>
+            </tr>
+          </tbody>
         </table>
 
         <section id="Property:relationship_relation">
@@ -2526,7 +2575,7 @@ ex:InternationalDOIFundation a foaf:Organization ;
 <section id="quality-information" class="informative">
     <h2>Quality information</h2>
     <aside class="note">
-      <p>This section is not-normative as it provides guidance on how to document the quality of DCAT
+      <p>This section is non-normative as it provides guidance on how to document the quality of DCAT
       first class entities (e.g., datasets, distributions) and it does not define new DCAT terms. The guidance relies on the
       Data Quality Vocabulary (DQV) [[?VOCAB-DQV]], which is a W3C Group Note.</p>
     </aside>
@@ -2555,8 +2604,8 @@ ex:InternationalDOIFundation a foaf:Organization ;
         <p>The following examples make no comments on where the quality information would reside and how it is managed. That
 	is out of scope for the DCAT vocabulary.  The assumption made is that the quality individuals are available using
 	the URIs indicated.
-        Besides, the examples and more in general the DQV  is neutral to the data portal design choices on how to collect
-	quality information. For example, data portals can collect DQV instances by implementing specific UI to annotate
+        Besides, the examples and more in general the [[?VOCAB-DQV]]  is neutral to the data portal design choices on how to collect
+	quality information. For example, data portals can collect [[?VOCAB-DQV]] instances by implementing specific UI to annotate
 	data or by taking inputs from 3rd-party services.
         </p>
     </aside>
@@ -2865,7 +2914,7 @@ a:testingActivity a prov:Activity;
     <br/> and the <a href="https://id.loc.gov/vocabulary/relators">MARC relators</a>. While these relations could be captured with additional sub-properties of <code>dct:relation</code>, <code>dct:contributor</code>, etc, this would lead to an explosion in the number of properties, and anyway the full set of potential roles and relationships is unknown.
   </p>
   <p>
-    A common approach for meeting these kinds of requirement is to introduce an additional resource to carry parameters that qualify the relationship. Precedents are the <a href="https://www.w3.org/TR/prov-o/#description-qualified-terms">qualified terms</a> in [[?PROV-O]] and the <a href="https://www.w3.org/TR/vocab-ssn/#Sample_Relations">sample relations</a> in the Semantic Sensor Network ontology [[?VOCAB-SSN]]. The general <a href="http://patterns.dataincubator.org/book/qualified-relation.html">Qualified Relation pattern</a> is described in [[?LinkedDataPatterns]].
+    A common approach for meeting these kinds of requirement is to introduce an additional resource to carry parameters that qualify the relationship. Precedents are the <a data-cite="PROV-O#description-qualified-terms">qualified terms</a> in [[?PROV-O]] and the <a data-cite="VOCAB-SSN#Sample_Relations">sample relations</a> in the Semantic Sensor Network ontology [[?VOCAB-SSN]]. The general <a href="http://patterns.dataincubator.org/book/qualified-relation.html">Qualified Relation pattern</a> is described in [[?LinkedDataPatterns]].
   </p>
   <p>
     Many of the qualified terms from [[!PROV-O]] are relevant to the description of resources in catalogs but these are incomplete due to the activity-centric viewpoint taken by PROV-O. Addressing some of the gaps, additional forms are included in the DCAT vocabulary to satisfy requirements that do not involve explicit Activities. These are summarized in <a href="#UML-DCAT-Qualified-Relations"></a>:
@@ -2888,7 +2937,7 @@ a:testingActivity a prov:Activity;
 <section id="qualified-attribution">
   <h3>Relationships between datasets and agents</h3>
   <p>
-    The standard Dublin Core properties <a href="http://purl.org/dc/terms/contributor"><code>dct:contributor</code></a>, <a href="http://purl.org/dc/terms/creator"><code>dct:creator</code></a> and <a href="http://purl.org/dc/terms/publisher"><code>dct:publisher</code></a> [[!DC11]], and the generic <a href="https://www.w3.org/TR/prov-o/#wasAttributedTo"><code>prov:wasAttributedTo</code></a> from [[!PROV-O]], support basic associations of responsible agents with a catalogued resource.
+    The standard [[?DCTERMS]] properties <a href="http://purl.org/dc/terms/contributor"><code>dct:contributor</code></a>, <a href="http://purl.org/dc/terms/creator"><code>dct:creator</code></a> and <a href="http://purl.org/dc/terms/publisher"><code>dct:publisher</code></a> [[!DC11]], and the generic <a href="https://www.w3.org/TR/prov-o/#wasAttributedTo"><code>prov:wasAttributedTo</code></a> from [[!PROV-O]], support basic associations of responsible agents with a catalogued resource.
     However, there are many other roles of importance in relation to datasets and services - e.g. funder, distributor, custodian, editor.
     Some of these roles are enumerated in the CI_RoleCode values from [[?ISO-19115-1]], in the [[?DataCite]] metadata schema, and included within the <a href="https://id.loc.gov/vocabulary/relators">MARC relators</a>.
   </p>
@@ -2925,14 +2974,14 @@ ex:DS987
 <section id="qualified-relationship">
   <h3>Relationships between datasets and other resources</h3>
   <p>
-    The standard Dublin Core properties <a href="http://purl.org/dc/terms/relation">dct:relation</a> and sub-properties such as
-    <a href="http://purl.org/dc/terms/hasPart">dct:hasPart</a>/<a href="http://purl.org/dc/terms/isPartOf">dct:isPartOf</a>,
-    <a href="http://purl.org/dc/terms/hasVersion">dct:hasVersion</a>/<a href="http://purl.org/dc/terms/isVersionOf">dct:isVersionOf</a>,
-    <a href="http://purl.org/dc/terms/replaces">dct:replaces</a>/<a href="http://purl.org/dc/terms/isReplacedBy">dct:isReplacedBy</a>,
-    <a href="http://purl.org/dc/terms/requires">dct:requires</a>/<a href="http://purl.org/dc/terms/isRequiredBy">dct:isRequiredBy</a>,
-    <a href="http://www.w3.org/ns/prov#wasDerivedFrom">prov:wasDerivedFrom</a>,
-    <a href="http://www.w3.org/ns/prov#wasQuotedFrom">prov:wasQuotedFrom</a>,
-    support the description of relationships between datasets and other catalogued resources.
+    The standard [[?DCTERMS]] properties <a href="http://purl.org/dc/terms/relation"><code>dct:relation</code></a> and sub-properties such as
+    <a href="http://purl.org/dc/terms/hasPart"><code>dct:hasPart</code></a> / <a href="http://purl.org/dc/terms/isPartOf"><code>dct:isPartOf</code></a>,
+    <a href="http://purl.org/dc/terms/hasVersion"><code>dct:hasVersion</code></a> / <a href="http://purl.org/dc/terms/isVersionOf"><code>dct:isVersionOf</code></a>,
+    <a href="http://purl.org/dc/terms/replaces"><code>dct:replaces</code></a> / <a href="http://purl.org/dc/terms/isReplacedBy"><code>dct:isReplacedBy</code></a>,
+    <a href="http://purl.org/dc/terms/requires"><code>dct:requires</code></a> / <a href="http://purl.org/dc/terms/isRequiredBy"><code>dct:isRequiredBy</code></a>,
+    <a href="http://www.w3.org/ns/prov#wasDerivedFrom"><code>prov:wasDerivedFrom</code></a>,
+    <a href="http://www.w3.org/ns/prov#wasQuotedFrom"><code>prov:wasQuotedFrom</code></a>,
+    support the description of relationships between datasets and other catalogued resources.    
     However, there are many other relationships of importance - e.g. alternate, canonical, original, preview, stereo-mate, working-copy-of.
     Some of these roles are enumerated in the DS_AssociationTypeCode values from [[?ISO-19115-1]], the <a href="https://www.iana.org/assignments/link-relations">IANA Registry of Link Relations</a>, in the [[?DataCite]] metadata schema, and included within the <a href="https://id.loc.gov/vocabulary/relators">MARC relators</a>.
   <p>

--- a/dcat/index.html
+++ b/dcat/index.html
@@ -31,11 +31,6 @@ $(document).ready( function() {
     <link rel="stylesheet" type="text/css" href="style.css">
     <link rel="stylesheet" type="text/css" href="small.css" media="only all and (max-width: 649px)">
 
-<!-- Local style -->	
-    <style type="text/css">
-      .disclaimer {font-size:.9em;}
-    </style>
-	
 </head>
 <body>
 	
@@ -887,7 +882,7 @@ $(document).ready( function() {
         </p-->
 
         <!--
-        -- this issue already closed - prov:wasGeneratedBy added to dcat:Dataset (but not to dcat:Resource) --
+        - this issue already closed - prov:wasGeneratedBy added to dcat:Dataset (but not to dcat:Resource) -
         <p class="issue" data-number="77">
             The need to be able to link a catalogued resource with the business or project context of its production has been identified as a requirement to be satisfied in the revision of DCAT.
         </p>
@@ -1283,8 +1278,8 @@ $(document).ready( function() {
               <tr><td class="prop">Sub-property of:</td><td><a href="http://www.w3.org/ns/prov#qualifiedInfluence"><code>prov:qualifiedInfluence</code></a></td></tr>
               <tr><td class="prop">Domain:</td><td><a data-cite="?PROV-O#Entity"><code>prov:Entity</code></a></td></tr>
               <tr><td class="prop">Range:</td><td><a data-cite="?PROV-O#Attribution"><code>prov:Attribution</code></a></td></tr>
-              <tr><td class="prop">Usage note:</td><td>Used to link to an Agent where the nature of the relationship is known but does not match one of the standard [[?DCTERMS]] properties (<a href="http://purl.org/dc/terms/creator"></code>dct:creator</code></a>, <a href="http://purl.org/dc/terms/creator"></code>dct:publisher</code></a>).
-              Use <code>dcat:hadRole</code> on the <a href="http://www.w3.org/ns/prov#Attribution"></code>prov:Attribution</code></a> to capture the responsibility of the Agent with respect to the Resource.
+              <tr><td class="prop">Usage note:</td><td>Used to link to an Agent where the nature of the relationship is known but does not match one of the standard [[?DCTERMS]] properties (<a href="http://purl.org/dc/terms/creator"><code>dct:creator</code></a>, <a href="http://purl.org/dc/terms/creator"><code>dct:publisher</code></a>).
+              Use <code>dcat:hadRole</code> on the <a href="http://www.w3.org/ns/prov#Attribution"><code>prov:Attribution</code></a> to capture the responsibility of the Agent with respect to the Resource.
               See <a href="#qualified-attribution"></a> for usage examples.</td></tr>
               </tbody>
             </table>
@@ -2155,8 +2150,8 @@ $(document).ready( function() {
             <tr><td class="prop">Definition:</td><td>A site or end-point providing operations related to the discovery of, access to, or processing functions on, data or related resources</td></tr>
             <tr><td class="prop">Sub class of:</td><td><a href="#Class:Resource"><code>dcat:Resource</code></a></td></tr>
             <tr><td class="prop">Sub class of:</td><td><a href="http://purl.org/dc/dcmitype/Service"><code>dctype:Service</code></a></td></tr>
-            <tr><td class="prop">Usage note:</td><td>If a  <a href="#Class:Data_Service"><code>dcat:DataService</code></a> is bound to one or more specified Datasets, they are indicated by the dcat:servesDataset property.</td></tr>
-            <tr><td class="prop">Usage note:</td><td>The kind of service can be indicated using the <a href="http://purl.org/dc/terms/type"><code>dct:type</code></a> property. Its value may be taken from a controlled vocabulary such as the <a href="https://inspire.ec.europa.eu/metadata-codelist/SpatialDataServiceType/">INSPIRE spatial data service type vocabulary</a></td></tr>.
+            <tr><td class="prop">Usage note:</td><td>If a  <a href="#Class:Data_Service"><code>dcat:DataService</code></a> is bound to one or more specified Datasets, they are indicated by the <a href="Property:dataservice_serves_dataset"><code>dcat:servesDataset</code></a> property.</td></tr>
+            <tr><td class="prop">Usage note:</td><td>The kind of service can be indicated using the <a href="http://purl.org/dc/terms/type"><code>dct:type</code></a> property. Its value may be taken from a controlled vocabulary such as the <a href="https://inspire.ec.europa.eu/metadata-codelist/SpatialDataServiceType/">INSPIRE spatial data service type vocabulary</a>.</td></tr>
             </tbody>
         </table>
 

--- a/dcat/index.html
+++ b/dcat/index.html
@@ -75,7 +75,7 @@ $(document).ready( function() {
     </p>
     <h3 id="dcat_history">DCAT history</h3>
     <p>The original DCAT vocabulary was developed and <a href="http://vocab.deri.ie/dcat">hosted</a> at the Digital Enterprise Research Institute (DERI), then refined by the <a href="http://www.w3.org/egov/">eGov Interest Group</a>, and finally standardized in 2014 [[?VOCAB-DCAT-20140116]] by the <a href="http://www.w3.org/2011/gld/">Government Linked Data (GLD)</a> Working Group.</p>
-    <p>This revised version of DCAT was developed by the <a href="https://www.w3.org/2017/dxwg/">Dataset Exchange Working Group</a> in response to a new set of Use Cases and Requirements [[?DCAT-UCR]] gathered from peoples' experience with the DCAT vocabulary from the time of the original version, and new applications that were not considered in the first version. A summary of the changes from  [[?VOCAB-DCAT-20140116]] can be found at <a href="#changes">Change History</a></p>
+    <p>This revised version of DCAT was developed by the <a href="https://www.w3.org/2017/dxwg/">Dataset Exchange Working Group</a> in response to a new set of Use Cases and Requirements [[?DCAT-UCR]] gathered from peoples' experience with the DCAT vocabulary from the time of the original version, and new applications that were not considered in the first version. A summary of the changes from  [[?VOCAB-DCAT-20140116]] can be found at <a href="#changes"></a></p>
 
     <h3 id="external_terms">External terms</h3>
     <p>DCAT incorporates terms from pre-existing vocabularies where stable terms with appropriate meanings could be found, such as <a href="http://xmlns.com/foaf/0.1/homepage"><code>foaf:homepage</code></a> and <a href="http://purl.org/dc/terms/title"><code>dct:title</code></a>.
@@ -146,8 +146,8 @@ $(document).ready( function() {
 
 <section id="motivation" class="informative"><h2>Motivation for change</h2>
     <p>The original Recommendation [[?VOCAB-DCAT-20140116]] published in January 2014 provided the basic framework for describing datasets. It made an important distinction between a <i>dataset</i> as an abstract idea and a <i>distribution</i> as a manifestation of the dataset. Although DCAT has been widely adopted, it has become clear that the original specification lacked a number of essential features that were added either through the mechanism of an application profile, such as the European Commission's DCAT-AP [[?DCAT-AP]], or the development of larger vocabularies that to a greater or lesser extent built upon the base standard, such as the Healthcare and Life Sciences Community Profile [[?HCLS-Dataset]], the Data Tag Suite [[?DATS]] and more. This revision of DCAT has been developed to address the specific shortcomings that have come to light through the experiences of different communities, the aim being to improve interoperability between the outputs of these larger vocabularies.
-    For example, in this new DCAT version we provide classes, properties and guidance to address <a href="#Dereferenceable-identifiers">identifiers</a>, <a href="#quality-information">dataset quality information</a>, and <a href="#data-citation">data citation</a> issues.</p>
-    <p>This draft includes re-writing of the specification throughout. Significant changes from the 2014 Recommendation are marked within the text using "Note" sections, as well as being described in <a class="sectionRef" href="#changes"></a>.</p>
+    For example, in this new DCAT version we provide classes, properties and guidance to address <a href="#dereferenceable-identifiers">identifiers</a>, <a href="#quality-information">dataset quality information</a>, and <a href="#data-citation">data citation</a> issues.</p>
+    <p>This draft includes re-writing of the specification throughout. Significant changes from the 2014 Recommendation are marked within the text using "Note" sections, as well as being described in <a href="#changes"></a>.</p>
 
 </section>
 
@@ -192,11 +192,11 @@ $(document).ready( function() {
             RDF syntax, access protocol, and access policy are not mandated by this specification).</li>
         <li> The contents of all metadata fields that are held in the catalog and that contain data about the catalog itself and its datasets, distributions, and data-services, are included in this RDF description and are expressed using the appropriate classes and properties from DCAT, except where no such class or property exists.</li>
         <li> All classes and properties defined in DCAT are used in a way consistent with the semantics declared in this specification.</li>
-        <li>DCAT-compliant catalogs <em title="MAY" class="rfc2119">MAY</em> include additional non-DCAT metadata fields and additional RDF data in the catalog's RDF description.</li>
+        <li>DCAT-compliant catalogs MAY include additional non-DCAT metadata fields and additional RDF data in the catalog's RDF description.</li>
     </ul>
 
     <p>
-        A <strong>DCAT profile</strong> is a specification for a data catalog that adds additional constraints to DCAT. A data catalog that conforms to the profile also conforms to DCAT. Additional constraints in a profile <em title="MAY" class="rfc2119">MAY</em> include:
+        A <strong>DCAT profile</strong> is a specification for a data catalog that adds additional constraints to DCAT. A data catalog that conforms to the profile also conforms to DCAT. Additional constraints in a profile MAY include:
     </p>
     <ul>
         <li> Cardinality constraints, including a minimum set of required metadata fields </li>
@@ -266,7 +266,7 @@ $(document).ready( function() {
     </figure>
     
     <p class="note">
-        Along with the rest of <a class="sectionRef" href="#vocabulary-overview"></a>, this diagram is <b>non-normative</b>.
+        Along with the rest of <a href="#vocabulary-overview"></a>, this diagram is <b>non-normative</b>.
         Furthermore, while the diagram uses UML-style class notation it should be interpreted following the usual RDF open-world assumptions around the presence/absence of properties, relationships, and their cardinality.
         The properties shown in each class reflect those recommended in the descriptions of classes in <a href="#vocabulary-specification"></a>.
         To assist in understanding the full scope of each class, properties are copied down from each '::super-class'.
@@ -666,7 +666,7 @@ $(document).ready( function() {
     <section id="complements">
       <h4>Complementary vocabularies</h4>
       <p>
-          Elements from a number of complementary vocabularies <em title="MAY" class="rfc2119">MAY</em> be used together with DCAT to provide more detailed information.
+          Elements from a number of complementary vocabularies MAY be used together with DCAT to provide more detailed information.
         For example: properties from the VoID vocabulary [[?VOID]] allow the description of various statistics about a DCAT-described dataset if that dataset is in RDF format; properties from the Provenance ontology [[!PROV-O]] can be used to provide more information about the workflow that generated a dataset or service and related activities and agents; classes and properties from the Organization Ontology [[!VOCAB-ORG]] can be used to explain additional details of responsible agents.
       </p>
 
@@ -675,7 +675,7 @@ $(document).ready( function() {
         <h4>Element definitions</h4>
 
         <p>
-            The definitions (including domain and range) of terms outside the DCAT namespace are provided here only for convenience and <em title="MUST NOT" class="rfc2119">MUST NOT</em> be considered normative. The authoritative definitions of these terms are in the corresponding specifications, i.e. [[!DC11]], [[!DCTERMS]], [[!FOAF]], [[!PROV-O]], [[!RDF-SCHEMA]], [[!SKOS-REFERENCE]], [[!XMLSCHEMA11-2]] and [[?VCARD-RDF]].
+            The definitions (including domain and range) of terms outside the DCAT namespace are provided here only for convenience and MUST be considered normative. The authoritative definitions of these terms are in the corresponding specifications, i.e. [[!DC11]], [[!DCTERMS]], [[!FOAF]], [[!PROV-O]], [[!RDF-SCHEMA]], [[!SKOS-REFERENCE]], [[!XMLSCHEMA11-2]] and [[?VCARD-RDF]].
         </p>
     </section>
 
@@ -749,7 +749,7 @@ $(document).ready( function() {
                 <tbody>
                 <tr><td class="prop">Definition:</td><td>A homepage of the catalog  (a public web document usually available in HTML).</td></tr>
                 <tr><td class="prop">Range:</td><td><a href="http://xmlns.com/foaf/0.1/Document">foaf:Document</a></td></tr>
-                <tr><td class="prop">Usage note:</td><td><a href="http://xmlns.com/foaf/0.1/homepage"><code>foaf:homepage</code></a> is an inverse functional property (IFP) which means that it <em title="MUST" class="rfc2119">MUST</em> be unique and precisely identify the web-page for the resource. This property indicates the canonical web-page, which might be helpful in cases where there is more than one web-page about the resource.</td></tr>
+                <tr><td class="prop">Usage note:</td><td><a href="http://xmlns.com/foaf/0.1/homepage"><code>foaf:homepage</code></a> is an inverse functional property (IFP) which means that it MUST be unique and precisely identify the web-page for the resource. This property indicates the canonical web-page, which might be helpful in cases where there is more than one web-page about the resource.</td></tr>
                 </tbody>
             </table>
         </section>
@@ -919,7 +919,7 @@ $(document).ready( function() {
                 <tbody>
                 <tr><td class="prop">Definition:</td><td>A rights statement that concerns how the resource is accessed.</td></tr>
                 <tr><td class="prop">Range:</td><td><a href="http://purl.org/dc/terms/RightsStatement"><code>dct:RightsStatement</code></a></td></tr>
-                <tr><td class="prop">Usage note:</td><td>Information about licenses and rights <em title="MAY" class="rfc2119">MAY</em> be provided for the Resource. See also guidance at <a href="#license-rights">License and rights statements</a>.</td></tr>
+                <tr><td class="prop">Usage note:</td><td>Information about licenses and rights MAY be provided for the Resource. See also guidance at <a href="#license-rights"></a>.</td></tr>
 
                 <tr><td class="prop">See also:</td><td><a href="#Property:resource_rights" title="">resource rights</a></td></tr>
                 </tbody>
@@ -933,7 +933,7 @@ $(document).ready( function() {
                 <tbody>
                 <tr><td class="prop">Definition:</td><td>An established standard to which the described catalogued resource conforms.</td></tr>
                 <tr><td class="prop">Range:</td><td><a href="http://purl.org/dc/terms/Standard"><code>dct:Standard</code></a> (A basis for comparison; a reference point against which other things can be evaluated.)</td></tr>
-                <tr><td class="prop">Usage note:</td><td>This property <em title="SHOULD" class="rfc2119">SHOULD</em> be used to indicate the model, schema, ontology, view or profile that the catalogued resource content conforms to. </td></tr>
+                <tr><td class="prop">Usage note:</td><td>This property SHOULD be used to indicate the model, schema, ontology, view or profile that the catalogued resource content conforms to. </td></tr>
                 </tbody>
             </table>
         </section>
@@ -964,13 +964,12 @@ $(document).ready( function() {
             <div class="note">
 	      <p>
                 New property added in this revision of DCAT, specifically added when considering the data citation requirement and
-                added to the <a href="#Class:Resource"><code>dcat:Resource</code></a> class, as the Dataset superclass. For more details, see
-                the <a href="#data-citation">data citation</a> section.
+                added to the <a href="#Class:Resource"><code>dcat:Resource</code></a> class, as the Dataset superclass. For more details, see <a href="#data-citation"></a>.
 	      </p>
 
 	      <p>
-                The use of the [[?PROV-O]] qualified-attribution pattern is <a href="#qualified-attribution">described below</a>.
-                `dct:creator` corresponds with a general attribution with the role 'creator'.
+                The use of the [[?PROV-O]] qualified-attribution pattern is described in <a href="#qualified-attribution"></a>.
+                <code>dct:creator</code> corresponds with a general attribution with the role 'creator'.
               </p>
 	    </div>
 
@@ -992,7 +991,7 @@ $(document).ready( function() {
             <table class="definition">
                 <thead><tr><th>RDF Property:</th><th><a href="http://purl.org/dc/terms/description">dct:description</a></th></tr></thead>
                 <tbody>
-                <tr><td class="prop">Definition:</td><td>free-text account of the item.</td></tr>
+                <tr><td class="prop">Definition:</td><td>A free-text account of the item.</td></tr>
                 <tr><td class="prop">Range:</td><td><a href="http://www.w3.org/2000/01/rdf-schema#Literal"><code>rdfs:Literal</code></a></td></tr>
                 </tbody>
             </table>
@@ -1019,8 +1018,8 @@ $(document).ready( function() {
                 <tr><td class="prop">Range:</td><td><a href="http://www.w3.org/2000/01/rdf-schema#Literal"><code>rdfs:Literal</code></a>
                     encoded using the relevant ISO 8601 Date and Time compliant string [[?DATETIME]] and typed using the appropriate XML Schema datatype [[!XMLSCHEMA11-2]]
                 </td></tr>
-                <tr><td class="prop">Usage note:</td><td>This property <em title="SHOULD" class="rfc2119">SHOULD</em> be set using the first known date of issuance.</td></tr>
-                <tr><td class="prop">See also:</td><td> <a href="#Property:record_listing_date">catalog record listing date</a> and <a href="#Property:distribution_release_date" title=""> distribution release date</a></td></tr>
+                <tr><td class="prop">Usage note:</td><td>This property SHOULD be set using the first known date of issuance.</td></tr>
+                <tr><td class="prop">See also:</td><td> <a href="#Property:record_listing_date">catalog record listing date</a> and <a href="#Property:distribution_release_date" title="">distribution release date</a></td></tr>
                 </tbody>
             </table>
         </section>
@@ -1034,9 +1033,11 @@ $(document).ready( function() {
                 <tr><td class="prop">Range:</td><td><a href="http://www.w3.org/2000/01/rdf-schema#Literal"><code>rdfs:Literal</code></a>
                     encoded using the relevant ISO 8601 Date and Time compliant string [[?DATETIME]] and typed using the appropriate XML Schema datatype [[!XMLSCHEMA11-2]]
                 </td></tr>
-                <tr><td class="prop">Usage note:</td><td>The value of this property indicates a change to the actual item, not a change to the catalog record. An absent value <em title="MAY" class="rfc2119">MAY</em> indicate that the item has never changed after its initial publication, or that the date of last modification is not known, or that the item is continuously updated.</td></tr>
+                <tr><td class="prop">Usage note:</td><td>The value of this property indicates a change to the actual item, not a change to the catalog record. An absent value MAY indicate that the item has never changed after its initial publication, or that the date of last modification is not known, or that the item is continuously updated.</td></tr>
+<!--                
                 <tr><td class="prop">See also:</td><td><a href="#Property:dataset_frequency">dataset frequency</a></td></tr>
-                <tr><td class="prop">See also:</td><td><a href="#Property:dataset_frequency">dataset frequency</a>, <a href="#Property:record_update_date" title=""> catalog record modification date</a> and <a href="#Property:distribution_update_date" title=""> distribution modification date</a></td></tr>
+-->                
+                <tr><td class="prop">See also:</td><td><a href="#Property:dataset_frequency">dataset frequency</a>, <a href="#Property:record_update_date" title="">catalog record modification date</a> and <a href="#Property:distribution_update_date" title="">distribution modification date</a></td></tr>
                 </tbody>
             </table>
         </section>
@@ -1050,9 +1051,9 @@ $(document).ready( function() {
                 <tr><td class="prop">Range:</td><td><a href="http://purl.org/dc/terms/LinguisticSystem"><code>dct:LinguisticSystem</code></a>
                     <br>
                     Resources defined by the Library of Congress (<a href="http://id.loc.gov/vocabulary/iso639-1.html">1</a>,
-                    <a href="http://id.loc.gov/vocabulary/iso639-2.html">2</a>) <em title="SHOULD" class="rfc2119">SHOULD</em> be used.
+                    <a href="http://id.loc.gov/vocabulary/iso639-2.html">2</a>) SHOULD be used.
                     <br>
-                    If a ISO 639-1 (two-letter) code is defined for language, then its corresponding IRI <em title="SHOULD" class="rfc2119">SHOULD</em> be used; if no ISO 639-1 code is defined, then IRI corresponding to the ISO 639-2 (three-letter) code <em title="SHOULD" class="rfc2119">SHOULD</em> be used.</td></tr>
+                    If a ISO 639-1 (two-letter) code is defined for language, then its corresponding IRI SHOULD be used; if no ISO 639-1 code is defined, then IRI corresponding to the ISO 639-2 (three-letter) code SHOULD be used.</td></tr>
                 <tr><td class="prop">Usage note:</td><td>Repeat this property if the resource is available in multiple languages.</td></tr>
                 <tr><td class="prop">Usage note:</td><td>The value(s) provided for members of a catalog (i.e. dataset or service) override the value(s) provided for the catalog if they conflict.</td></tr>
                 <tr><td class="prop">Usage note:</td><td>If representations of a dataset are available for each language separately, define an instance of <code>dcat:Distribution</code> for each language and describe the specific language of each distribution using <code>dct:language</code> (i.e. the dataset will have multiple <code>dct:language</code> values and each distribution will have just one as the value of its <code>dct:language</code> property).</td></tr>
@@ -1064,8 +1065,8 @@ $(document).ready( function() {
             <h4>Property: publisher</h4>
 
             <p class="note">
-                The use of the [[?PROV-O]] qualified-attribution pattern is <a href="#qualified-attribution">described below</a>.
-                `dct:publisher` corresponds with a general attribution with the role 'publisher'.
+                The use of the [[?PROV-O]] qualified-attribution pattern is described in <a href="#qualified-attribution"></a>.
+                <code>dct:publisher</code> corresponds with a general attribution with the role 'publisher'.
             </p>
 
             <table class="definition">
@@ -1127,7 +1128,7 @@ $(document).ready( function() {
                 <tr><td class="prop">Definition:</td><td>The nature or genre of the resource.</td></tr>
                 <tr><td class="prop">Sub property of:</td><td><a href="http://purl.org/dc/elements/1.1/type"><code>dc:type</code></a></td></tr>
                 <tr><td class="prop">Range:</td><td><a href="http://www.w3.org/2000/01/rdf-schema#Class"><code>rdfs:Class</code></a></td></tr>
-                <tr><td class="prop">Usage note:</td><td>The value <em title="SHOULD" class="rfc2119">SHOULD</em> be taken from a well governed and broadly recognised controlled vocabulary, such as:
+                <tr><td class="prop">Usage note:</td><td>The value SHOULD be taken from a well governed and broadly recognised controlled vocabulary, such as:
                     <ol>
                         <li><a href="http://dublincore.org/documents/dcmi-terms/#section-7">DCMI Type vocabulary</a> [[?DCTERMS]]</li>
                         <li><a href="https://geo-ide.noaa.gov/wiki/index.php?title=ISO_19115_and_19115-2_CodeList_Dictionaries#MD_ScopeCode">ISO 19115 scope codes</a> [[?ISO-19115-1]]</li>
@@ -1148,8 +1149,8 @@ $(document).ready( function() {
                 <thead><tr><th>RDF Property:</th><th><a href="http://purl.org/dc/terms/relation">dct:relation</a></th></tr></thead>
                 <tbody>
                 <tr><td class="prop">Definition:</td><td>A resource with an unspecified relationship to the catalogued item.</td></tr>
-                <tr><td class="prop">Usage note:</td><td><a href="http://purl.org/dc/terms/relation"><code>dct:relation</code></a> <em title="SHOULD" class="rfc2119">SHOULD</em> be used where the nature of the relationship between a catalogued item and related resources is not known. A more specific sub-property <em title="SHOULD" class="rfc2119">SHOULD</em> be used if the nature of the relationship of the link is known.
-                    The property <a href="#Property:dataset_distribution"><code>dcat:distribution</code></a> <em title="SHOULD" class="rfc2119">SHOULD</em> be used to link from a <a href="#Class:Dataset"><code>dcat:Dataset</code></a> to a representation of the dataset, described as a <a href="#Class:Distribution"><code>dcat:Distribution</code></a></td></tr>
+                <tr><td class="prop">Usage note:</td><td><a href="http://purl.org/dc/terms/relation"><code>dct:relation</code></a> SHOULD be used where the nature of the relationship between a catalogued item and related resources is not known. A more specific sub-property SHOULD be used if the nature of the relationship of the link is known.
+                    The property <a href="#Property:dataset_distribution"><code>dcat:distribution</code></a> SHOULD be used to link from a <a href="#Class:Dataset"><code>dcat:Dataset</code></a> to a representation of the dataset, described as a <a href="#Class:Distribution"><code>dcat:Distribution</code></a></td></tr>
                 <tr><td class="prop">See also:</td><td>Sub-properties of <code>dct:relation</code> in particular
                     <a href="#Property:dataset_distribution"><code>dcat:distribution</code></a>,
                     <a href="http://purl.org/dc/terms/hasPart"><code>dct:hasPart</code></a>,
@@ -1176,11 +1177,11 @@ $(document).ready( function() {
 
             <p>
                 Many existing and legacy catalogues do not distinguish between dataset components, representations, documentation, schemata and other resources that are lumped together as part of a dataset.
-                <a href="http://purl.org/dc/terms/relation"><code>dct:relation</code></a> is a super-property of a number of more specific properties which express more precise relationships, so use of <code>dct:relation</code> is not inconsistent with a subsequent reclassification with more specific semantics, though the more specialized sub-properties <em title="SHOULD" class="rfc2119">SHOULD</em> be used to link a dataset to component and supplementary resources if possible.
+                <a href="http://purl.org/dc/terms/relation"><code>dct:relation</code></a> is a super-property of a number of more specific properties which express more precise relationships, so use of <code>dct:relation</code> is not inconsistent with a subsequent reclassification with more specific semantics, though the more specialized sub-properties SHOULD be used to link a dataset to component and supplementary resources if possible.
             </p>
 
             <p class="note">
-                Use of this Dublin Core Terms property in this context added in this revision of DCAT.
+                Use of this [[?DCTERMS]] property in this context added in this revision of DCAT.
             </p>
 
         </section>
@@ -1192,9 +1193,9 @@ $(document).ready( function() {
               <thead><tr><th>RDF Property:</th><th><a href="http://www.w3.org/ns/dcat#qualifiedRelation">dcat:qualifiedRelation</a></th></tr></thead>
               <tbody>
               <tr><td class="prop">Definition:</td><td>Link to a description of a relationship with another resource</td></tr>
-              <tr><td class="prop">Sub-property of:</td><td><a href="http://www.w3.org/ns/prov#qualifiedInfluence">prov:qualifiedInfluence</a></td></tr>
-              <tr><td class="prop">Domain:</td><td><a href="#Class:Resource">dcat:Resource</a></td></tr>
-              <tr><td class="prop">Range:</td><td><a href="#Class:Relationship">dcat:Relationship</a></td></tr>
+              <tr><td class="prop">Sub-property of:</td><td><a href="http://www.w3.org/ns/prov#qualifiedInfluence"><code>prov:qualifiedInfluence</code></a></td></tr>
+              <tr><td class="prop">Domain:</td><td><a href="#Class:Resource"><code>dcat:Resource</code></a></td></tr>
+              <tr><td class="prop">Range:</td><td><a href="#Class:Relationship"><code>dcat:Relationship</code></a></td></tr>
               <tr><td class="prop">Usage note:</td><td>Used to link to another resource where the nature of the relationship is known but does not match one of the standard [[?DCTERMS]] properties 
               (<a href="http://purl.org/dc/terms/hasPart"><code>dct:hasPart</code></a>,
               <a href="http://purl.org/dc/terms/isPartOf"><code>dct:isPartOf</code></a>,
@@ -1210,24 +1211,24 @@ $(document).ready( function() {
               <a href="http://purl.org/dc/terms/requires"><code>dct:requires</code></a>,
               <a href="http://purl.org/dc/terms/isRequiredBy"><code>dct:isRequiredBy</code></a>)
               or [[?PROV-O]] properties 
-              (<a href="http://www.w3.org/ns/prov#wasDerivedFrom">prov:wasDerivedFrom</a>, 
-              <a href="http://www.w3.org/ns/prov#wasInfluencedBy">prov:wasInfluencedBy</a>, 
-              <a href="http://www.w3.org/ns/prov#wasQuotedFrom">prov:wasQuotedFrom</a>, 
-              <a href="http://www.w3.org/ns/prov#wasRevisionOf">prov:wasRevisionOf</a>, 
-              <a href="http://www.w3.org/ns/prov#hadPrimarySource">prov:hadPrimarySource</a>, 
-              <a href="http://www.w3.org/ns/prov#alternateOf">prov:alternateOf</a>, 
-              <a href="http://www.w3.org/ns/prov#specializationOf">prov:specializationOf</a>).
+              (<a href="http://www.w3.org/ns/prov#wasDerivedFrom"><code>prov:wasDerivedFrom</code></a>, 
+              <a href="http://www.w3.org/ns/prov#wasInfluencedBy"><code>prov:wasInfluencedBy</code></a>, 
+              <a href="http://www.w3.org/ns/prov#wasQuotedFrom"><code>prov:wasQuotedFrom</code></a>, 
+              <a href="http://www.w3.org/ns/prov#wasRevisionOf"><code>prov:wasRevisionOf</code></a>, 
+              <a href="http://www.w3.org/ns/prov#hadPrimarySource"><code>prov:hadPrimarySource</code></a>, 
+              <a href="http://www.w3.org/ns/prov#alternateOf"><code>prov:alternateOf</code></a>, 
+              <a href="http://www.w3.org/ns/prov#specializationOf"><code>prov:specializationOf</code></a>).
               </td>
               </tr>
               </tbody>
             </table>
 
             <p>
-              This DCAT property follows the common <a href="#qualified-forms">qualified relation pattern</a> .
+              This DCAT property follows the common qualified relation pattern described in <a href="#qualified-forms"></a> .
             </p>
 
             <p class="note">
-              Since this property is a sub-property of <a href="http://www.w3.org/ns/prov#qualifiedInfluence">prov:qualifiedInfluence</a>, use of this property on an individual entails that the context resource is a member of the class <a href="http://www.w3.org/ns/prov#Entity">prov:Entity</a> [[RDF-SCHEMA]] .
+              Since this property is a sub-property of <a href="http://www.w3.org/ns/prov#qualifiedInfluence"><code>prov:qualifiedInfluence</code></a>, use of this property on an individual entails that the context resource is a member of the class <a href="http://www.w3.org/ns/prov#Entity"><code>prov:Entity</code></a> [[RDF-SCHEMA]] .
             </p>
 
             <p class="note">
@@ -1267,7 +1268,7 @@ $(document).ready( function() {
                 <tr><td class="prop">Range:</td><td><a href="http://xmlns.com/foaf/0.1/Document"><code>foaf:Document</code></a></td></tr>
                 <tr><td class="prop">Usage note:</td><td>
                     If the distribution(s) are accessible only through a landing page
-                    (i.e. direct download URLs are not known), then the landing page link <em title="SHOULD" class="rfc2119">SHOULD</em> be duplicated as <code>dcat:accessURL</code> on a distribution. (see <a href="#example-landing-page"></a>)
+                    (i.e. direct download URLs are not known), then the landing page link SHOULD be duplicated as <code>dcat:accessURL</code> on a distribution. (see <a href="#example-landing-page"></a>)
                 </td></tr>
                 </tbody>
             </table>
@@ -1281,20 +1282,20 @@ $(document).ready( function() {
               <tbody>
               <tr><td class="prop">Definition:</td><td>Link to an Agent having some form of responsibility for the resource</td></tr>
               <tr><td class="prop">Sub-property of:</td><td><a href="http://www.w3.org/ns/prov#qualifiedInfluence"><code>prov:qualifiedInfluence</code></a></td></tr>
-              <tr><td class="prop">Domain:</td><td><a href="https://www.w3.org/TR/prov-o/#Entity">prov:Entity</a></td></tr>
-              <tr><td class="prop">Range:</td><td><a href="https://www.w3.org/TR/prov-o/#Attribution">prov:Attribution</a></td></tr>
+              <tr><td class="prop">Domain:</td><td><a href="https://www.w3.org/TR/prov-o/#Entity"><code>prov:Entity</code></a></td></tr>
+              <tr><td class="prop">Range:</td><td><a href="https://www.w3.org/TR/prov-o/#Attribution"><code>prov:Attribution</code></a></td></tr>
               <tr><td class="prop">Usage note:</td><td>Used to link to an Agent where the nature of the relationship is known but does not match one of the standard [[?DCTERMS]] properties (<a href="http://purl.org/dc/terms/creator"></code>dct:creator</code></a>, <a href="http://purl.org/dc/terms/creator"></code>dct:publisher</code></a>).
               Use <code>dcat:hadRole</code> on the <a href="http://www.w3.org/ns/prov#Attribution"></code>prov:Attribution</code></a> to capture the responsibility of the Agent with respect to the Resource.
-              See <a class="sectionRef" href="#qualified-attribution"></a> for usage examples.</td></tr>
+              See <a href="#qualified-attribution"></a> for usage examples.</td></tr>
               </tbody>
             </table>
 
             <p>
-              This DCAT property follows the common <a href="#qualified-forms">qualified relation pattern</a> .
+              This DCAT property follows the common qualified relation pattern described in <a href="#qualified-forms"></a> .
             </p>
 
             <p class="note">
-              Use of this property on an individual entails that the context resource is a member of the class <a href="http://www.w3.org/ns/prov#Entity">prov:Entity</a> [[RDF-SCHEMA]] .
+              Use of this property on an individual entails that the context resource is a member of the class <a href="http://www.w3.org/ns/prov#Entity"><code>prov:Entity</code></a> [[RDF-SCHEMA]] .
             </p>
 
             <p class="note">
@@ -1311,7 +1312,7 @@ $(document).ready( function() {
                 <tbody>
                 <tr><td class="prop">Definition:</td><td>A legal document under which the resource is made available.</td></tr>
                 <tr><td class="prop">Range:</td><td><a href="http://purl.org/dc/terms/LicenseDocument"><code>dct:LicenseDocument</code></a></td></tr>
-                <tr><td class="prop">Usage note:</td><td>Information about licenses and rights <em title="MAY" class="rfc2119">MAY</em> be provided for the Resource. See also guidance at <a href="#license-rights">License and rights statements</a>.</td></tr>
+                <tr><td class="prop">Usage note:</td><td>Information about licenses and rights MAY be provided for the Resource. See also guidance at <a href="#license-rights"></a>.</td></tr>
 
                 <tr><td class="prop">See also:</td><td><a href="#Property:resource_rights">resource rights</a>, <a href="#Property:distribution_license">distribution licence</a></td></tr>
                 </tbody>
@@ -1326,7 +1327,7 @@ $(document).ready( function() {
                 <tbody>
                 <tr><td class="prop">Definition:</td><td>A statement that concerns all rights not addressed with <a href="#Property:resource_license" title="">dct:license</a> or <a href="#Property:resource_accessRights" title="">dct:accessRights</a>, such as copyright statements.</td></tr>
                 <tr><td class="prop">Range:</td><td><a href="http://purl.org/dc/terms/RightsStatement"><code>dct:RightsStatement</code></a></td></tr>
-                <tr><td class="prop">Usage note:</td><td>Information about licenses and rights <em title="MAY" class="rfc2119">MAY</em> be provided for the Resource. See also guidance at <a href="#license-rights">License and rights statements</a>.</td></tr>
+                <tr><td class="prop">Usage note:</td><td>Information about licenses and rights MAY be provided for the Resource. See also guidance at <a href="#license-rights"></a>.</td></tr>
 
                 <tr><td class="prop">See also:</td><td><a href="#Property:resource_license" title="">resource license</a>, <a href="#Property:distribution_rights">distribution rights</a>, <a href="#Property:resource_accessRights">resource access rights</a></td></tr>
                 </tbody>
@@ -1341,7 +1342,7 @@ $(document).ready( function() {
                 <tbody>
                 <tr><td class="prop">Definition:</td><td>A policy expressing the rights associated with the resource if using the ODRL vocabulary [[ODRL-VOCAB]].</td></tr>
                 <tr><td class="prop">Range:</td><td><a href="https://www.w3.org/TR/odrl-vocab/#term-Policy"><code>odrl:Policy</code></a></td></tr>
-                <tr><td class="prop">Usage note:</td><td>Information about rights expressed as ODRL [[ODRL-VOCAB]] policies <em title="MAY" class="rfc2119">MAY</em> be provided for the Resource. See also guidance at <a href="#license-rights">License and rights statements</a>.</td></tr>
+                <tr><td class="prop">Usage note:</td><td>Information about rights expressed as ODRL [[ODRL-VOCAB]] policies MAY be provided for the Resource. See also guidance at <a href="#license-rights"></a>.</td></tr>
 
                 <tr><td class="prop">See also:</td><td><a href="#Property:resource_license" title="">resource license</a>, <a href="#Property:resource_accessRights" title="">resource access rights</a>, <a href="#Property:resource_rights" title="">resource rights</a></td></tr>
                 </tbody>
@@ -1379,7 +1380,7 @@ $(document).ready( function() {
             <tr><td class="prop">Usage note</td><td>This class is optional and not all catalogs will use it. It exists for catalogs where a distinction is made between metadata about
                 a <em>dataset or service</em> and metadata about the <em>entry in the catalog about the dataset or service</em>. For example, the <i>publication date</i> property of the <i>dataset</i> reflects
                 the date when the information was originally made available by the publishing agency, while the publication date of the <i>catalog record</i> is the date when the dataset was added to the catalog.
-                In cases where both dates differ, or where only the latter is known, the <em>publication date</em> <em title="SHOULD" class="rfc2119">SHOULD</em> only be specified for the catalog record.
+                In cases where both dates differ, or where only the latter is known, the <em>publication date</em> SHOULD only be specified for the catalog record.
                 Notice that the <abbr title="World Wide Web Consortium">W3C</abbr> PROV Ontology [[?PROV-O]] allows describing further provenance information such as the details of the process and the agent involved in a particular change to a dataset or its registration.
             </td></tr>
             <tr><td class="prop">See also</td><td><a href="#Class:Dataset">Dataset</a></td></tr>
@@ -1390,7 +1391,7 @@ $(document).ready( function() {
         <p>If a catalog is represented as an RDF Dataset with named graphs (as defined in [[!SPARQL11-QUERY]]),
             then it is appropriate to place the description of each dataset
             (consisting of all RDF triples that mention the <code>dcat:Dataset</code>, <code>dcat:CatalogRecord</code>, and any of its <code>dcat:Distributions</code>)
-            into a separate named graph. The name of that graph <em title="SHOULD" class="rfc2119">SHOULD</em> be the IRI of the catalog record.
+            into a separate named graph. The name of that graph SHOULD be the IRI of the catalog record.
         </p>
 
         <section id="Property:record_title">
@@ -1470,7 +1471,7 @@ $(document).ready( function() {
                 <tbody>
                 <tr><td class="prop">Definition:</td><td>An established standard to which the described resource conforms.</td></tr>
                 <tr><td class="prop">Range:</td><td><a href="http://purl.org/dc/terms/Standard"><code>dct:Standard</code></a> (A basis for comparison; a reference point against which other things can be evaluated.)</td></tr>
-                <tr><td class="prop">Usage note:</td><td>This property <em title="SHOULD" class="rfc2119">SHOULD</em> be used to indicate the model, schema, ontology, view or profile that the catalog record metadata conforms to. </td></tr>
+                <tr><td class="prop">Usage note:</td><td>This property SHOULD be used to indicate the model, schema, ontology, view or profile that the catalog record metadata conforms to. </td></tr>
                 </tbody>
             </table>
 
@@ -1519,7 +1520,7 @@ $(document).ready( function() {
         </p>
 
         <p>
-            Information about licenses and rights <em title="SHOULD" class="rfc2119">SHOULD</em> be provided on the level of Distribution. Information about licenses and rights MAY be provided for a Dataset in addition to but not instead of the information provided for the Distributions of that Dataset. Providing license or rights information for a Dataset that is different from information provided for a Distribution of that Dataset <em title="SHOULD" class="rfc2119">SHOULD</em> be avoided as this can create legal conflicts.
+            Information about licenses and rights SHOULD be provided on the level of Distribution. Information about licenses and rights MAY be provided for a Dataset in addition to but not instead of the information provided for the Distributions of that Dataset. Providing license or rights information for a Dataset that is different from information provided for a Distribution of that Dataset SHOULD be avoided as this can create legal conflicts.
         </p>
 
 
@@ -1556,11 +1557,11 @@ $(document).ready( function() {
 
         <div class="note">
             <p>
-                In DCAT 2014 [[?VOCAB-DCAT-20140116]] <a href="#Class:Dataset"><code>dcat:Dataset</code></a> was a sub-class of <a href="http://purl.org/dc/dcmitype/Dataset"><code>dctype:Dataset</code></a>, which is a member of the <a href="http://dublincore.org/documents/dcmi-terms/#section-7">DCMI Types vocabulary</a> [[?DCTERMS]].
-                The scope of <a href="#Class:Dataset"><code>dcat:Dataset</code></a> also includes other members of the <a href="http://dublincore.org/documents/dcmi-terms/#section-7">DCMI Types vocabulary</a>, such as various multimedia (imagery, sound, video) and text, so the sub-class relationship from DCAT 2014 [[?VOCAB-DCAT-20140116]] has been removed in this revised DCAT vocabulary - see <a href="https://github.com/w3c/dxwg/issues/98">Issue #98</a>.
+                In DCAT 2014 [[?VOCAB-DCAT-20140116]] <a href="#Class:Dataset"><code>dcat:Dataset</code></a> was a sub-class of <a href="http://purl.org/dc/dcmitype/Dataset"><code>dctype:Dataset</code></a>, which is a member of the <a data-cite="?DCTERMS#section-7">DCMI Types vocabulary</a> [[?DCTERMS]].
+                The scope of <a href="#Class:Dataset"><code>dcat:Dataset</code></a> also includes other members of the <a data-cite="?DCTERMS#section-7">DCMI Types vocabulary</a>, such as various multimedia (imagery, sound, video) and text, so the sub-class relationship from DCAT 2014 [[?VOCAB-DCAT-20140116]] has been removed in this revised DCAT vocabulary - see <a href="https://github.com/w3c/dxwg/issues/98">Issue #98</a>.
             </p>
             <p>
-                Note that members of the <a href="http://dublincore.org/documents/dcmi-terms/#section-7">DCMI Types vocabulary</a> may appear as the value of the <a href="#Property:resource_type"><code>dct:type</code></a> property, as shown in <a href="#classifying-dataset-types">Classifying dataset types</a>.
+                Note that members of the <a data-cite="DCTERMS#section-7">DCMI Types vocabulary</a> may appear as the value of the <a href="#Property:resource_type"><code>dct:type</code></a> property, as shown in <a href="#classifying-dataset-types"></a>.
             </p>
         </div>
 
@@ -1645,7 +1646,7 @@ $(document).ready( function() {
                 <thead><tr><th>RDF Property:</th><th><a href="http://www.w3.org/ns/dcat#spatialResolutionInMeters">dcat:spatialResolutionInMeters</a></th></tr></thead>
                 <tbody>
                 <tr><td class="prop">Definition:</td><td>minimum spatial separation resolvable in a dataset, measured in meters</td></tr>
-                <tr><td class="prop">Range:</td><td><a href="https://www.w3.org/TR/xmlschema11-2/#decimal"><code>xsd:decimal</code></a></td></tr>
+                <tr><td class="prop">Range:</td><td><a data-cite="XMLSCHEMA11-2#decimal"><code>xsd:decimal</code></a></td></tr>
                 <tr><td class="prop">Usage note:</td><td>If the dataset is an image or grid this should correspond to the spacing of items. For other kinds of spatial dataset, this property will usually indicate the smallest distance between items in the dataset.</td></tr>
                 </tbody>
             </table>
@@ -1683,14 +1684,14 @@ $(document).ready( function() {
                 <thead><tr><th>RDF Property:</th><th><a href="http://www.w3.org/ns/dcat#temporalResolution">dcat:temporalResolution</a></th></tr></thead>
                 <tbody>
                 <tr><td class="prop">Definition:</td><td>minimum time period resolvable in the dataset</td></tr>
-                <tr><td class="prop">Range:</td><td><a href="http://www.w3.org/TR/xmlschema-2/#duration"><code>xsd:duration</code></a></td></tr>
+                <tr><td class="prop">Range:</td><td><a data-cite="XMLSCHEMA-2#duration"><code>xsd:duration</code></a></td></tr>
                 <tr><td class="prop">Usage note:</td><td>If the dataset is a time-series this should correspond to the spacing of items in the series. For other kinds of dataset, this property will usually indicate the smallest time difference between items in the dataset. </td></tr>
                 </tbody>
             </table>
 
 
         <p>This is intended to provide a summary indication of the temporal resolution of the data distribution as a single value.
-        More complex descriptions of various aspects of temporal precision, accuracy, resolution and other statistics can be provided using the Data Quality Vocabulary [[VOCAB-DQV]]. </p>
+        More complex descriptions of various aspects of temporal precision, accuracy, resolution and other statistics can be provided using the Data Quality Vocabulary [[?VOCAB-DQV]]. </p>
 
             <p class="note">
                 New property in this context in this revision of DCAT.
@@ -1713,7 +1714,7 @@ $(document).ready( function() {
             </table>
 
             <p class="note">
-              Use of this property on an individual entails that the context resource is a member of the class <a href="http://www.w3.org/ns/prov#Entity">prov:Entity</a> [[RDF-SCHEMA]] .
+              Use of this property on an individual entails that the context resource is a member of the class <a href="http://www.w3.org/ns/prov#Entity"><code>prov:Entity</code></a> [[RDF-SCHEMA]] .
             </p>
 
             <p class="note">
@@ -1802,7 +1803,7 @@ $(document).ready( function() {
             <table class="definition">
                 <thead><tr><th>RDF Property:</th><th><a href="http://purl.org/dc/terms/description">dct:description</a></th></tr></thead>
                 <tbody>
-                <tr><td class="prop">Definition:</td><td>free-text account of the distribution.</td></tr>
+                <tr><td class="prop">Definition:</td><td>A free-text account of the distribution.</td></tr>
                 <tr><td class="prop">Range:</td><td><a href="http://www.w3.org/2000/01/rdf-schema#Literal"><code>rdfs:Literal</code></a></td></tr>
                 </tbody>
             </table>
@@ -1817,7 +1818,7 @@ $(document).ready( function() {
                 <tr><td class="prop">Range:</td><td><a href="http://www.w3.org/2000/01/rdf-schema#Literal"><code>rdfs:Literal</code></a>
                     encoded using the relevant ISO 8601 Date and Time compliant string [[?DATETIME]] and typed using the appropriate XML Schema datatype [[!XMLSCHEMA11-2]]
                 </td></tr>
-                <tr><td class="prop">Usage note:</td><td>This property <em title="SHOULD" class="rfc2119">SHOULD</em> be set using the first known date of issuance.</td></tr>
+                <tr><td class="prop">Usage note:</td><td>This property SHOULD be set using the first known date of issuance.</td></tr>
                 <tr><td class="prop">See also:</td><td><a href="#Property:resource_release_date" title="">resource release date</a></td></tr>
                 </tbody>
             </table>
@@ -1844,7 +1845,7 @@ $(document).ready( function() {
                 <tbody>
                 <tr><td class="prop">Definition:</td><td>A legal document under which the distribution is made available.</td></tr>
                 <tr><td class="prop">Range:</td><td><a href="http://purl.org/dc/terms/LicenseDocument"><code>dct:LicenseDocument</code></a></td></tr>
-                <tr><td class="prop">Usage note:</td><td>Information about licenses and rights <em title="SHOULD" class="rfc2119">SHOULD</em> be provided on the level of Distribution. Information about licenses and rights <em title="MAY" class="rfc2119">MAY</em> be provided for a Dataset in addition to but not instead of the information provided for the Distributions of that Dataset. Providing license or rights information for a Dataset that is different from information provided for a Distribution of that Dataset <em title="SHOULD" class="rfc2119">SHOULD</em> be avoided as this can create legal conflicts. See also guidance at <a href="#license-rights">License and rights statements</a>.</td></tr>
+                <tr><td class="prop">Usage note:</td><td>Information about licenses and rights SHOULD be provided on the level of Distribution. Information about licenses and rights MAY be provided for a Dataset in addition to but not instead of the information provided for the Distributions of that Dataset. Providing license or rights information for a Dataset that is different from information provided for a Distribution of that Dataset SHOULD be avoided as this can create legal conflicts. See also guidance at <a href="#license-rights"></a>.</td></tr>
 
 		<tr><td class="prop">See also:</td><td><a href="#Property:distribution_rights" title="">distribution rights</a>
                     <a href="#Property:resource_license" title="">resource license</a></td></tr>
@@ -1860,7 +1861,7 @@ $(document).ready( function() {
                 <tbody>
                 <tr><td class="prop">Definition:</td><td>A rights statement that concerns how the distribution is accessed.</td></tr>
                 <tr><td class="prop">Range:</td><td><a href="http://purl.org/dc/terms/RightsStatement"><code>dct:RightsStatement</code></a></td></tr>
-                <tr><td class="prop">Usage note:</td><td>Information about licenses and rights <em title="MAY" class="rfc2119">MAY</em> be provided for the Distribution. See also guidance at <a href="#license-rights">License and rights statements</a>.</td></tr>
+                <tr><td class="prop">Usage note:</td><td>Information about licenses and rights MAY be provided for the Distribution. See also guidance at <a href="#license-rights"></a>.</td></tr>
 
                 <tr><td class="prop">See also:</td><td><a href="#Property:distribution_license" title="">distribution license</a>, <a href="#Property:distribution_rights" title="">distribution rights</a>,
                     <a href="#Property:resource_accessRights" title="">resource access rights</a></td></tr>
@@ -1879,7 +1880,7 @@ $(document).ready( function() {
                 <tr><td class="prop">Usage note:</td><td><code>dct:license</code>, which is a sub-property of <code>dct:rights</code>, can be used to link
                     a distribution to a license document. However, <code>dct:rights</code> allows linking to a rights statement that
                     can include licensing information as well as other information that supplements the license such as attribution.<br/>
-                    Information about licenses and rights <em title="SHOULD" class="rfc2119">SHOULD</em> be provided on the level of Distribution. Information about licenses and rights MAY be provided for a Dataset in addition to but not instead of the information provided for the Distributions of that Dataset. Providing license or rights information for a Dataset that is different from information provided for a Distribution of that Dataset <em title="SHOULD" class="rfc2119">SHOULD</em> be avoided as this can create legal conflicts. See also guidance at <a href="#license-rights">License and rights statements</a>.</td></tr>
+                    Information about licenses and rights SHOULD be provided on the level of Distribution. Information about licenses and rights MAY be provided for a Dataset in addition to but not instead of the information provided for the Distributions of that Dataset. Providing license or rights information for a Dataset that is different from information provided for a Distribution of that Dataset SHOULD be avoided as this can create legal conflicts. See also guidance at <a href="#license-rights"></a>.</td></tr>
                 <tr><td class="prop">See also:</td><td><a href="#Property:distribution_license" title="">distribution license</a>,
                     <a href="#Property:resource_rights" title="">resource rights</a></td></tr>
                 </tbody>
@@ -1894,7 +1895,7 @@ $(document).ready( function() {
                 <tbody>
                 <tr><td class="prop">Definition:</td><td>A policy expressing the rights associated with the distribution if using the ODRL vocabulary [[ODRL-VOCAB]].</td></tr>
                 <tr><td class="prop">Range:</td><td><a href="https://www.w3.org/TR/odrl-vocab/#term-Policy"><code>odrl:Policy</code></a></td></tr>
-                <tr><td class="prop">Usage note:</td><td>Information about rights expressed as ODRL [[ODRL-VOCAB]] policies <em title="MAY" class="rfc2119">MAY</em> be provided for the Distribution. See also guidance at <a href="#license-rights">License and rights statements</a>.</td></tr>
+                <tr><td class="prop">Usage note:</td><td>Information about rights expressed as ODRL [[ODRL-VOCAB]] policies MAY be provided for the Distribution. See also guidance at <a href="#license-rights"></a>.</td></tr>
 
                 <tr><td class="prop">See also:</td><td><a href="#Property:resource_license" title="">resource license</a>, <a href="#Property:distribution_accessRights" title="">distribution access rights</a>, <a href="#Property:distribution_rights" title="">distribution rights</a></td></tr>
                 </tbody>
@@ -1914,9 +1915,9 @@ $(document).ready( function() {
                 <tr><td class="prop">Definition:</td><td>A URL of the resource that gives access to a distribution of the dataset. E.g. landing page, feed, SPARQL endpoint.</td></tr>
                 <tr><td class="prop">Domain:</td><td><a href="#Class:Distribution"><code>dcat:Distribution</code></a></td></tr>
                 <tr><td class="prop">Range:</td><td><a href="http://www.w3.org/2000/01/rdf-schema#Resource"><code>rdfs:Resource</code></a></td></tr>
-                <tr><td class="prop">Usage note:</td><td><a href="#Property:distribution_accessurl"><code>dcat:accessURL</code></a> <em title="SHOULD" class="rfc2119">SHOULD</em> be used for the address of a service or location that can provide access to this distribution, typically through a web form, query or API call.
+                <tr><td class="prop">Usage note:</td><td><a href="#Property:distribution_accessurl"><code>dcat:accessURL</code></a> SHOULD be used for the address of a service or location that can provide access to this distribution, typically through a web form, query or API call.
                     <br/><a href="#Property:distribution_downloadurl"><code>dcat:downloadURL</code></a> is preferred for direct links to downloadable resources.
-                    <br/>If the distribution(s) are accessible only through a landing page (i.e. direct download URLs are not known), then the landingPage address associated with the <code>dcat:Dataset</code> <em title="SHOULD" class="rfc2119">SHOULD</em> be duplicated as accessURL on a distribution. (see <a href="#example-landing-page"></a>)
+                    <br/>If the distribution(s) are accessible only through a landing page (i.e. direct download URLs are not known), then the landingPage address associated with the <code>dcat:Dataset</code> SHOULD be duplicated as access URL on a distribution (see <a href="#example-landing-page"></a>).
                 </td></tr>
                 <tr><td class="prop">See also</td><td><a href="#Property:distribution_downloadurl">download address</a>, <a href="#Property:distribution_accessservice">access service</a></td></tr>
                 </tbody>
@@ -1939,7 +1940,7 @@ $(document).ready( function() {
                 <tbody>
                 <tr><td class="prop">Definition:</td><td>A site or end-point that gives access to the distribution of the dataset</td></tr>
                 <tr><td class="prop">Range:</td><td><a href="#Class:Data_Service"><code>dcat:DataService</code></a></td></tr>
-                <tr><td class="prop">Usage note:</td><td><a href="#Property:distribution_accessservice"><code>dcat:accessService</code></a> <em title="SHOULD" class="rfc2119">SHOULD</em> be used to link to a description of a <a href="#Class:Data_Service"><code>dcat:DataService</code></a> that can provide access to this distribution.</td></tr>
+                <tr><td class="prop">Usage note:</td><td><a href="#Property:distribution_accessservice"><code>dcat:accessService</code></a> SHOULD be used to link to a description of a <a href="#Class:Data_Service"><code>dcat:DataService</code></a> that can provide access to this distribution.</td></tr>
                 <tr><td class="prop">See also</td><td><a href="#Property:distribution_downloadurl">download address</a>, <a href="#Property:distribution_accessurl">access address</a></td></tr>
                 </tbody>
             </table>
@@ -1954,7 +1955,7 @@ $(document).ready( function() {
                 <tr><td class="prop">Definition:</td><td>The URL of the downloadable file in a given format. E.g. CSV file or RDF file. The format is indicated by the distribution's <code>dct:format</code> and/or <code>dcat:mediaType</code></td></tr>
                 <tr><td class="prop">Domain:</td><td><a href="#Class:Distribution"><code>dcat:Distribution</code></a></td></tr>
                 <tr><td class="prop">Range:</td><td><a href="http://www.w3.org/2000/01/rdf-schema#Resource"><code>rdfs:Resource</code></a></td></tr>
-                <tr><td class="prop">Usage note:</td><td><a href="#Property:distribution_downloadurl"><code>dcat:downloadURL</code></a> <em title="SHOULD" class="rfc2119">SHOULD</em> be used for the address at which this distribution is available directly, typically through a HTTP Get request.  </td></tr>
+                <tr><td class="prop">Usage note:</td><td><a href="#Property:distribution_downloadurl"><code>dcat:downloadURL</code></a> SHOULD be used for the address at which this distribution is available directly, typically through a HTTP Get request.  </td></tr>
                 <tr><td class="prop">See also</td><td><a href="#Property:distribution_accessurl">access address</a>, <a href="#Property:distribution_accessservice">access service</a></td></tr>
                 </tbody>
             </table>
@@ -2035,7 +2036,7 @@ $(document).ready( function() {
                 <tbody>
                 <tr><td class="prop">Definition:</td><td>An established standard to which the distribution conforms.</td></tr>
                 <tr><td class="prop">Range:</td><td><a href="http://purl.org/dc/terms/Standard"><code>dct:Standard</code></a> (A basis for comparison; a reference point against which other things can be evaluated.)</td></tr>
-                <tr><td class="prop">Usage note:</td><td>This property <em title="SHOULD" class="rfc2119">SHOULD</em> be used to indicate the model, schema, ontology, view or profile that this representation of a dataset conforms to. This is (generally) a complementary concern to the media-type or format. </td></tr>
+                <tr><td class="prop">Usage note:</td><td>This property SHOULD be used to indicate the model, schema, ontology, view or profile that this representation of a dataset conforms to. This is (generally) a complementary concern to the media-type or format. </td></tr>
                 <tr><td class="prop">See also:</td><td><a href="#Property:distribution_format">format</a>, <a href="#Property:distribution_media_type">media type</a></td></tr>
                 </tbody>
             </table>
@@ -2059,7 +2060,7 @@ $(document).ready( function() {
                 <tr><td class="prop">Sub property of:</td><td><a href="http://purl.org/dc/terms/format"><code>dct:format</code></a></td></tr>
                 <tr><td class="prop">Domain:</td><td><a href="#Class:Distribution"><code>dcat:Distribution</code></a></td></tr>
                 <tr><td class="prop">Range:</td><td><a href="http://purl.org/dc/terms/MediaType"><code>dct:MediaType</code></a></td></tr>
-                <tr><td class="prop">Usage note:</td><td>This property <em title="SHOULD" class="rfc2119">SHOULD</em> be used when the media type of the distribution is defined in IANA [[!IANA-MEDIA-TYPES]], otherwise <code>dct:format</code> <em title="MAY" class="rfc2119">MAY</em> be used with different values.</td></tr>
+                <tr><td class="prop">Usage note:</td><td>This property SHOULD be used when the media type of the distribution is defined in IANA [[!IANA-MEDIA-TYPES]], otherwise <code>dct:format</code> MAY be used with different values.</td></tr>
                 <tr><td class="prop">See also:</td><td><a href="#Property:distribution_format">format</a> , <a href="#Property:distribution_conformsto">conforms to</a></td></tr>
                 </tbody>
             </table>
@@ -2073,7 +2074,7 @@ $(document).ready( function() {
                 <tbody>
                 <tr><td class="prop">Definition:</td><td>The file format of the distribution.</td></tr>
                 <tr><td class="prop">Range:</td><td><a href="http://purl.org/dc/terms/MediaTypeOrExtent"><code>dct:MediaTypeOrExtent</code></a></td></tr>
-                <tr><td class="prop">Usage note:</td><td> <a href="#Property:distribution_media_type"><code>dcat:mediaType</code></a> <em title="SHOULD" class="rfc2119">SHOULD</em> be used if the type of the distribution is defined by IANA [[!IANA-MEDIA-TYPES]].</td></tr>
+                <tr><td class="prop">Usage note:</td><td> <a href="#Property:distribution_media_type"><code>dcat:mediaType</code></a> SHOULD be used if the type of the distribution is defined by IANA [[!IANA-MEDIA-TYPES]].</td></tr>
                 <tr><td class="prop">See also:</td><td><a href="#Property:distribution_media_type">media type</a>, <a href="#Property:distribution_conformsto">conforms to</a></td></tr>
                 </tbody>
             </table>
@@ -2087,7 +2088,7 @@ $(document).ready( function() {
                 <tbody>
                 <tr><td class="prop">Definition:</td><td>The format of the file in which the data is contained in a compressed form, e.g. to reduce the size of the downloadable file.</td></tr>
                 <tr><td class="prop">Range:</td><td><a href="http://purl.org/dc/terms/MediaType"><code>dct:MediaType</code></a></td></tr>
-                <tr><td class="prop">Usage note:</td><td>This property to be used when the files in the distribution are compressed, e.g. in a ZIP file. The format <em title="SHOULD" class="rfc2119">SHOULD</em> be expressed using a media type as defined by IANA [[!IANA-MEDIA-TYPES]], if available.</td></tr>
+                <tr><td class="prop">Usage note:</td><td>This property to be used when the files in the distribution are compressed, e.g. in a ZIP file. The format SHOULD be expressed using a media type as defined by IANA [[!IANA-MEDIA-TYPES]], if available.</td></tr>
                 <tr><td class="prop">See also:</td><td><a href="#Property:distribution_packaging_format">packaging format</a>.</td></tr>
                 </tbody>
             </table>
@@ -2102,7 +2103,7 @@ $(document).ready( function() {
                   <tbody>
                   <tr><td class="prop">Definition:</td><td>The format of the file in which one or more data files are grouped together, e.g. to enable a set of related files to be downloaded together.</td></tr>
                   <tr><td class="prop">Range:</td><td><a href="http://purl.org/dc/terms/MediaType"><code>dct:MediaType</code></a></td></tr>
-                  <tr><td class="prop">Usage note:</td><td>This property to be used when the files in the distribution are packaged, e.g. in a TAR file. The format <em title="SHOULD" class="rfc2119">SHOULD</em> be expressed using a media type as defined by IANA [[!IANA-MEDIA-TYPES]], if available.</td></tr>
+                  <tr><td class="prop">Usage note:</td><td>This property to be used when the files in the distribution are packaged, e.g. in a TAR file. The format SHOULD be expressed using a media type as defined by IANA [[!IANA-MEDIA-TYPES]], if available.</td></tr>
                   <tr><td class="prop">See also:</td><td><a href="#Property:distribution_compression_format">compression format</a>.</td></tr>
                   </tbody>
               </table>
@@ -2117,11 +2118,11 @@ $(document).ready( function() {
         </p>
 
         <p>The following properties are recommended for use on this class:
-            <a href="#Property:dataservice_endpointdescription">endpointDescription</a>,
-            <a href="#Property:dataservice_endpointurl">endpointURL</a>,
+            <a href="#Property:dataservice_endpointdescription">endpoint description</a>,
+            <a href="#Property:dataservice_endpointurl">endpoint URL</a>,
             <a href="#Property:dataservice_license">license</a>,
             <a href="#Property:dataservice_access_rights">access rights</a>,
-            <a href="#Property:dataservice_serves_dataset">servesDataset</a>
+            <a href="#Property:dataservice_serves_dataset">serves dataset</a>
         </p>
         <p>The following properties are inherited from the super-class <a href="#Class:Resource"><code>dcat:Resource</code></a>:
             <a href="#Property:resource_accessRights">access rights</a>,
@@ -2179,7 +2180,7 @@ $(document).ready( function() {
                 <tr><td class="prop">Definition:</td><td>A description of the service end-point, including its operations, parameters etc.</td></tr>
                 <tr><td class="prop">Domain:</td><td><a href="#Class:Data_Service">dcat:DataService</a> </td></tr>
                 <tr><td class="prop">Range:</td><td><a href="http://www.w3.org/2000/01/rdf-schema#Resource"><code>rdfs:Resource</code></a> </td></tr>
-                <tr><td class="prop">Usage note:</td><td>The endpoint description gives specific details of the actual endpoint instance, while <a href="#Property:resource_conformsto">dct:conformsTo</a> is used to indicate the general standard or specification that the endpoint implements.</td></tr>
+                <tr><td class="prop">Usage note:</td><td>The endpoint description gives specific details of the actual endpoint instance, while <a href="#Property:resource_conformsto"><code>dct:conformsTo</code></a> is used to indicate the general standard or specification that the endpoint implements.</td></tr>
                 <tr><td class="prop">Usage note:</td><td>An endpoint description may be expressed in a machine-readable form, such as an OpenAPI (Swagger) description [[?OpenAPI]], an OGC getCapabilities response [[?WFS]], [[?ISO-19142]], [[?WMS]], [[?ISO-19128]], a SPARQL Service Description [[?SPARQL11-SERVICE-DESCRIPTION]], an [[?OpenSearch]] or [[?WSDL20]] document, a Hydra API description [[?HYDRA]], else in text or some other informal mode if a formal representation is not possible.</td></tr>
                 </tbody>
             </table>
@@ -2203,7 +2204,7 @@ $(document).ready( function() {
             <table class="definition">
                 <thead><tr><th>RDF Property:</th><th><a href="http://purl.org/dc/terms/accessRights">dct:accessRights</a></th></tr></thead>
                 <tbody>
-                <tr><td class="prop">Definition:</td><td>Access Rights <em title="MAY" class="rfc2119">MAY</em> include information regarding access or restrictions based on privacy, security, or other policies. </td></tr>
+                <tr><td class="prop">Definition:</td><td>Access Rights MAY include information regarding access or restrictions based on privacy, security, or other policies. </td></tr>
                 <tr><td class="prop">Range:</td><td><a href="http://purl.org/dc/terms/RightsStatement"><code>dct:RightsStatement</code></a></td></tr>
                 </tbody>
             </table>
@@ -2375,7 +2376,7 @@ end class DiscoveryService -->
 
         <p>The following properties are recommended for use on this class:
           <a href="#Property:relationship_relation">relation</a>,
-          <a href="#Property:relationship_hadRole">hadRole</a>,
+          <a href="#Property:relationship_hadRole">had role</a>,
         </p>
 
         <table class="definition">
@@ -2476,7 +2477,7 @@ end class DiscoveryService -->
 </section>
 
 
-<section id="Dereferenceable-identifiers" class="informative">
+<section id="dereferenceable-identifiers" class="informative">
     <h2>Dereferenceable identifiers</h2>
 
     <p>The scientific and data provider communities use a number of different identifiers for publications, authors and data. DCAT primarily relies on persistent HTTP URIs as an effective way of making identifiers actionable. Notably, quite a few identifier schemes can be encoded as dereferenceable HTTP URIs, and some of them are also returning machine-readable metadata (e.g., <abbr title="Digital Object Identifier">DOIs</abbr> [[?ISO-26324]] and <a href="https://orcid.org/"><abbr title="Open Researcher and Contributor ID">ORCIDs</abbr></a>). Regardless, data providers still might need to refer to legacy identifiers, non-HTTP dereferenceable identifiers, locally minted or third-party-provided identifiers. In these cases, [[?DCTERMS]] and [[?VOCAB-ADMS]] can be of use.</p>
@@ -3130,7 +3131,7 @@ ex:Test543L
     <h2>Versioning</h2>
 <p>Versioning can be applied to any of the first class citizens DCAT resources including Catalogs, Datasets, Distributions. The notion of version is very much related to the community practices,  data management policy and the workflows in place. It is up to data providers to decide when and why a new version should be released. For this reason, DCAT refrains from providing definitions or rules about when changes in a resource should turn in a new release of it. </p>
 
-<p>Versioning may be understood as involving relationships between datasets, which is supported by the <a href="#Property:resource_qualifiedRelation"><code>dcat:qualifiedRelation</code></a> and described in <a href="#qualified-relationship">Relationships between datasets and other resources</a>. The class <a href="#Class:Relationship"><code>dcat:Relationship</code></a> supports providing information about the relationship, and could be extended for versioning information.</p>  
+<p>Versioning may be understood as involving relationships between datasets, which is supported by the <a href="#Property:resource_qualifiedRelation"><code>dcat:qualifiedRelation</code></a> and described in <a href="#qualified-relationship"></a>. The class <a href="#Class:Relationship"><code>dcat:Relationship</code></a> supports providing information about the relationship, and could be extended for versioning information.</p>  
 	<!--backlog p class="issue" data-number="90">
 	<p class="issue" data-number="90">
         The need to be able to describe version relationships of datasets has been identified as a requirement to be satisfied in the revision of DCAT. Also see detailed requirements in
@@ -3165,7 +3166,7 @@ ex:Test543L
     </p>
 
     <p>
-        In order to support data citation, this DCAT revision has added the consideration of <a href="#Dereferenceable-identifiers">dereferenceable identifiers</a> and support for indicating
+        In order to support data citation, this DCAT revision has added the consideration of <a href="#dereferenceable-identifiers">dereferenceable identifiers</a> and support for indicating
         <a href="#Property:resource_creator">the creators of the catalogued resources</a>. The remaining properties necessary for data citation were already available in DCAT 2014 [[?VOCAB-DCAT-20140116]].
     </p>
 
@@ -3206,7 +3207,7 @@ ex:Test543L
     <p>
     The DCAT vocabulary supports the attribution of data and metadata to various participants such as resource <a href="#Property:resource_creator">creators</a>, <a href="#Property:resource_publisher">publishers</a> and other parties or agents via <a href="#qualified-forms">qualified relations</a>,
 	    and as such defines terms that may be related to personal information.  In addition, it also supports the association of <a href="#Property:resource_rights">rights</a> and <a href="#Property:resource_license">licenses</a> with cataloged Resources and Distributions.
-	    These rights and licences could potentially include or reference sensitive information such as user and asset identifiers as <a href="https://www.w3.org/TR/odrl-vocab/#privacy-consideration">described</a> in [[!ODRL-VOCAB]].   Implementations that produce, maintain, publish or
+	    These rights and licences could potentially include or reference sensitive information such as user and asset identifiers as <a data-cite="?ODRL-VOCAB#privacy-consideration">described</a> in [[!ODRL-VOCAB]].   Implementations that produce, maintain, publish or
 	    consume such vocabulary terms must take steps to ensure security and privacy considerations are addressed at the application level.
     </p>
 </section>
@@ -3308,7 +3309,7 @@ ex:Test543L
 &lt;/datasets/001/distributions/001&gt; a dcat:Distribution .</pre>
 
         <p class="note">For catalogs with many datasets, catalog records, data services or distributions,
-            the Linked Data Platform Paging mechanism [[?LDP-Paging]] <em title="SHOULD" class="rfc2119">SHOULD</em> be used to provide access to them.</p>
+            the Linked Data Platform Paging mechanism [[?LDP-Paging]] SHOULD be used to provide access to them.</p>
 
         <p>
             In the next sections we formally define the additional properties used for discovery of LDP containers.
@@ -3909,7 +3910,7 @@ rdfs:seeAlso &lt;https://doi.org/10.1111/j.1365-2966.2006.10100.x&gt; ;
           </li>
       </ul>
       <p>
-          Further patterns for the use of <i>qualified properties</i> for resource attribution and interrelationships are described in the chapter on <a href="#qualified-forms">Qualified relations</a> below.
+          Further patterns for the use of <i>qualified properties</i> for resource attribution and interrelationships are described in  <a href="#qualified-forms"></a>.
       </p>
 
   </section>
@@ -4103,26 +4104,26 @@ dcat:servesDataset ga-courts:jc ;
 
         <ul>
           <li>
-              A new property <a href="#Property:dataset_spatialresolution">dcat:spatialResolutionInMeters</a> added to support description of the spatial resolution of datasets and distributions. See <a href="https://github.com/w3c/dxwg/issues/84">Issue #84</a>
+              A new property <a href="#Property:dataset_spatialresolution"><code>dcat:spatialResolutionInMeters</code></a> added to support description of the spatial resolution of datasets and distributions. See <a href="https://github.com/w3c/dxwg/issues/84">Issue #84</a>
           </li>
 
           <li>
-              A new property <a href="#Property:dataset_temporalresolution">dcat:temporalResolution</a> added to support description of the temporal resolution of datasets and distributions. See <a href="https://github.com/w3c/dxwg/issues/84">Issue #84</a>
+              A new property <a href="#Property:dataset_temporalresolution"><code>dcat:temporalResolution</code></a> added to support description of the temporal resolution of datasets and distributions. See <a href="https://github.com/w3c/dxwg/issues/84">Issue #84</a>
           </li>
 
           <li>
-              Two new properties were added to specify packaged and compressed distributions: <a href="#Property:distribution_packaging_format">dcat:packageFormat</a> and <a href="#Property:distribution_compression_format">dcat:compressFormat</a>. See <a href="https://github.com/w3c/dxwg/issues/54">Issue #54</a>
+              Two new properties were added to specify packaged and compressed distributions: <a href="#Property:distribution_packaging_format"><code>dcat:packageFormat</code></a> and <a href="#Property:distribution_compression_format"><code>dcat:compressFormat</code></a>. See <a href="https://github.com/w3c/dxwg/issues/54">Issue #54</a>
           </li>
           <li>
-              A new section <a href="#qualified-relationship">Relationships between datasets and other resources</a> and new property <a href="#Property:resource_qualifiedRelation">dcat:qualifiedRelation</a> and class <a href="#Class:Relationship">dcat:Relationship</a> added to support relationships between datasets or other resources. See <a href="https://github.com/w3c/dxwg/issues/79">Issue #79</a>
+              A new section <a href="#qualified-relationship"></a>, a new property <a href="#Property:resource_qualifiedRelation"><code>dcat:qualifiedRelation</code></a> and a new class <a href="#Class:Relationship"><code>dcat:Relationship</code></a> added to support relationships between datasets or other resources. See <a href="https://github.com/w3c/dxwg/issues/79">Issue #79</a>
           </li>
 
           <li>
-                A new  section, <a href="#Dereferenceable-identifiers">Dereferenceable identifiers</a>, is added to describe how to indicate different types of identifiers by using [[!DCTERMS]] and [[?VOCAB-ADMS]] - see <a href="https://github.com/w3c/dxwg/issues/53">Issue #53</a> and <a href="https://github.com/w3c/dxwg/issues/68">Issue #68</a>.
+                A new  section <a href="#dereferenceable-identifiers"></a> was added to describe how to indicate different types of identifiers by using [[!DCTERMS]] and [[?VOCAB-ADMS]] - see <a href="https://github.com/w3c/dxwg/issues/53">Issue #53</a> and <a href="https://github.com/w3c/dxwg/issues/68">Issue #68</a>.
             </li>
 
             <li>
-                A new section on <a href="#qualified-attribution">Attribution roles</a> was added to recommend a pattern for assigning an agent to a catalogued resource with a qualified relationship.
+                A new section on <a href="#qualified-attribution"></a> was added to recommend a pattern for assigning an agent to a catalogued resource with a qualified relationship.
             </li>
 
             <li>
@@ -4130,7 +4131,7 @@ dcat:servesDataset ga-courts:jc ;
             </li>
 
             <li>
-               The section <a href="#license-rights">License and rights statements</a> was added to describe patterns for linking <code>dcat:Datasets</code> and <code>dcat:Distribution</code>s to the relevant license and rights expressions.
+               The section <a href="#license-rights"></a> was added to describe patterns for linking <code>dcat:Datasets</code> and <code>dcat:Distribution</code>s to the relevant license and rights expressions.
             </li>
 
             <li>
@@ -4231,7 +4232,7 @@ dcat:servesDataset ga-courts:jc ;
                 - see <a href="https://github.com/w3c/dxwg/issues/502">Issue #502</a>.
             </li>
             <li>
-                A new  section, <a href="#license-rights">License and rights statements</a>, is added to provide guidance and recommendations for the use of <a href="http://dublincore.org/documents/dcmi-terms/#terms-license"><code>dct:license</code></a>, <a href="http://dublincore.org/documents/dcmi-terms/#terms-accessRights"><code>dct:accessRights</code></a>,
+                A new section <a href="#license-rights"></a> was added to provide guidance and recommendations for the use of <a href="http://dublincore.org/documents/dcmi-terms/#terms-license"><code>dct:license</code></a>, <a href="http://dublincore.org/documents/dcmi-terms/#terms-accessRights"><code>dct:accessRights</code></a>,
 		and <a href="http://dublincore.org/documents/dcmi-terms/#terms-rights"><code>dct:rights</code></a> in the context of dcat catalogs and distributions.
 		See <a href="https://github.com/w3c/dxwg/issues/114">Issue #114</a> for the background discussion.
             </li>

--- a/dcat/index.html
+++ b/dcat/index.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html lang="en" dir="ltr">
 <head>
-    <title>Data Catalog Vocabulary (DCAT) - revised edition</title>
+    <title>Data Catalog Vocabulary (DCAT) - Revised edition</title>
     <meta content="text/html; charset=utf-8" http-equiv="content-type" />
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
     <script class="remove" src="https://www.w3.org/Tools/respec/respec-w3c-common"></script>
@@ -390,8 +390,8 @@ $(document).ready( function() {
         <p>
           Five distinct temporal descriptors are shown for this dataset.
           The dataset publication and revision dates are shown in <a href="#Property:resource_release_date"><code>dct:issued</code></a> and <a href="#Property:resource_update_date"><code>dct:modified</code></a>.
-          For the frequency of update of the dataset in <a href="#Property:dataset_frequency"><code>dct:accrualPeriodicity</code></a>, we use an instance from the <a data-cite="VOCAB-DATA-CUBE#dsd-cog">Content-Oriented Guidelines</a> developed as part of the <abbr title="World Wide Web Consortium">W3C</abbr> Data Cube Vocabulary [[?VOCAB-DATA-CUBE]] efforts.
-          The temporal coverage or extent is given in <a href="#Property:dataset_temporal"><code>dct:temporal</code></a> using an item from the Interval dataset (originally available from http://reference.data.gov.uk/id/interval) from data.gov.uk.
+          For the frequency of update of the dataset in <a href="#Property:dataset_frequency"><code>dct:accrualPeriodicity</code></a>, we use an instance from the <a data-cite="VOCAB-DATA-CUBE#dsd-cog">Content-Oriented Guidelines</a> developed as part of the W3C Data Cube Vocabulary [[?VOCAB-DATA-CUBE]] efforts.
+          The temporal coverage or extent is given in <a href="#Property:dataset_temporal"><code>dct:temporal</code></a> using an item from the Interval dataset (originally available from <code>http://reference.data.gov.uk/id/interval</code>) from data.gov.uk.
           The temporal resolution, which describes the minimum spacing of items within the dataset, is given in <a href="#Property:dataset_temporalresolution"><code>dcat:temporalResolution</code></a> using the standard datatype <code>xsd:duration</code>.
         </p>
         <p>
@@ -419,7 +419,7 @@ $(document).ready( function() {
 
     <section id="classifying-datasets">
         <h3>Classifying datasets thematically</h3>
-        <p>The catalog classifies its datasets according to a set of domains represented by the relative URI&nbsp;<code>:themes</code>. SKOS can be used to describe the domains used:
+        <p>The catalog classifies its datasets according to a set of domains represented by the relative URI&nbsp;<code>:themes</code>. SKOS [[?SKOS-REFERENCE]] can be used to describe the domains used:
         </p>
 <pre id="ex-thematic-classification" class="example nohighlight turtle">
 :catalog&nbsp;dcat:themeTaxonomy&nbsp;:themes&nbsp;.
@@ -449,9 +449,9 @@ $(document).ready( function() {
         <p>
             The type or genre of a dataset can be indicated using the <a href="http://purl.org/dc/terms/type"><code>dct:type</code></a> property.
             It is recommended that the value of the property is be taken from a well governed and broadly recognised set of resource types,
-            such as the <a href="http://dublincore.org/documents/dcmi-terms/#section-7">DCMI Type Vocabulary</a>,
+            such as the <a data-cite="?DCTERMS#section-7">DCMI Type Vocabulary</a> [[?DCTERMS]],
             the <a href="https://id.loc.gov/vocabulary/marcgt.html">MARC Genre/Terms Scheme</a>,
-            the <a href="https://geo-ide.noaa.gov/wiki/index.php?title=ISO_19115_and_19115-2_CodeList_Dictionaries#MD_ScopeCode">ISO 19115 MD_Scope codes</a>,
+            the [[?ISO-19115-1]] <a href="https://geo-ide.noaa.gov/wiki/index.php?title=ISO_19115_and_19115-2_CodeList_Dictionaries#MD_ScopeCode"><code>MD_Scope codes</code></a>,
             the <a href="https://schema.datacite.org/meta/kernel-4.1/include/datacite-resourceType-v4.1.xsd">DataCite resource types</a>,
             or the PARSE.Insight content-types from Re3data [[?RE3DATA-SCHEMA]].
         </p>
@@ -748,7 +748,7 @@ $(document).ready( function() {
                 <thead><tr><th>RDF Property:</th><th><a href="http://xmlns.com/foaf/0.1/homepage">foaf:homepage</a></th></tr></thead>
                 <tbody>
                 <tr><td class="prop">Definition:</td><td>A homepage of the catalog  (a public web document usually available in HTML).</td></tr>
-                <tr><td class="prop">Range:</td><td><a href="http://xmlns.com/foaf/0.1/Document">foaf:Document</a></td></tr>
+                <tr><td class="prop">Range:</td><td><a href="http://xmlns.com/foaf/0.1/Document"><code>foaf:Document</code></a></td></tr>
                 <tr><td class="prop">Usage note:</td><td><a href="http://xmlns.com/foaf/0.1/homepage"><code>foaf:homepage</code></a> is an inverse functional property (IFP) which means that it MUST be unique and precisely identify the web-page for the resource. This property indicates the canonical web-page, which might be helpful in cases where there is more than one web-page about the resource.</td></tr>
                 </tbody>
             </table>
@@ -1129,13 +1129,13 @@ $(document).ready( function() {
                 <tr><td class="prop">Range:</td><td><a href="http://www.w3.org/2000/01/rdf-schema#Class"><code>rdfs:Class</code></a></td></tr>
                 <tr><td class="prop">Usage note:</td><td>The value SHOULD be taken from a well governed and broadly recognised controlled vocabulary, such as:
                     <ol>
-                        <li><a href="http://dublincore.org/documents/dcmi-terms/#section-7">DCMI Type vocabulary</a> [[?DCTERMS]]</li>
-                        <li><a href="https://geo-ide.noaa.gov/wiki/index.php?title=ISO_19115_and_19115-2_CodeList_Dictionaries#MD_ScopeCode">ISO 19115 scope codes</a> [[?ISO-19115-1]]</li>
+                        <li><a data-cite="?DCTERMS#section-7">DCMI Type vocabulary</a> [[?DCTERMS]]</li>
+                        <li>[[?ISO-19115-1]] <a href="https://geo-ide.noaa.gov/wiki/index.php?title=ISO_19115_and_19115-2_CodeList_Dictionaries#MD_ScopeCode">scope codes</a></li>
                         <li><a href="https://schema.datacite.org/meta/kernel-4.1/include/datacite-resourceType-v4.1.xsd">Datacite resource types</a> [[?DataCite]]</li>
                         <li>PARSE.Insight content-types used by <a href="https://www.re3data.org/">re3data.org</a> [[?RE3DATA-SCHEMA]] (see item 15 contentType)</li>
                         <li><a href="http://id.loc.gov/vocabulary/marcgt.html">MARC intellectual resource types</a></li>
                   </ol>
-                Some members of these controlled vocabularies are not strictly suitable for datasets or data services (e.g. DCMI Type <i>Event</i>, <i>PhysicalObject</i>; ISO 19115 <i>CollectionHardware</i>, <i>CollectionSession</i>, <i>Initiative</i>, <i>Sample</i>, <i>Repository</i>), but might be used in the context of other kinds of catalogs defined in DCAT profiles or applications. </td></tr>
+                Some members of these controlled vocabularies are not strictly suitable for datasets or data services (e.g. DCMI Type <i>Event</i>, <i>PhysicalObject</i>; [[?ISO-19115-1]] <i>CollectionHardware</i>, <i>CollectionSession</i>, <i>Initiative</i>, <i>Sample</i>, <i>Repository</i>), but might be used in the context of other kinds of catalogs defined in DCAT profiles or applications. </td></tr>
                 <tr><td class="prop">Usage note:</td><td>To describe the file format, physical medium, or dimensions of the resource, use the <a href="http://purl.org/dc/terms/format"><code>dct:format</code></a> element.</td></tr>
               </tbody>
             </table>
@@ -1281,8 +1281,8 @@ $(document).ready( function() {
               <tbody>
               <tr><td class="prop">Definition:</td><td>Link to an Agent having some form of responsibility for the resource</td></tr>
               <tr><td class="prop">Sub-property of:</td><td><a href="http://www.w3.org/ns/prov#qualifiedInfluence"><code>prov:qualifiedInfluence</code></a></td></tr>
-              <tr><td class="prop">Domain:</td><td><a href="https://www.w3.org/TR/prov-o/#Entity"><code>prov:Entity</code></a></td></tr>
-              <tr><td class="prop">Range:</td><td><a href="https://www.w3.org/TR/prov-o/#Attribution"><code>prov:Attribution</code></a></td></tr>
+              <tr><td class="prop">Domain:</td><td><a data-cite="?PROV-O#Entity"><code>prov:Entity</code></a></td></tr>
+              <tr><td class="prop">Range:</td><td><a data-cite="?PROV-O#Attribution"><code>prov:Attribution</code></a></td></tr>
               <tr><td class="prop">Usage note:</td><td>Used to link to an Agent where the nature of the relationship is known but does not match one of the standard [[?DCTERMS]] properties (<a href="http://purl.org/dc/terms/creator"></code>dct:creator</code></a>, <a href="http://purl.org/dc/terms/creator"></code>dct:publisher</code></a>).
               Use <code>dcat:hadRole</code> on the <a href="http://www.w3.org/ns/prov#Attribution"></code>prov:Attribution</code></a> to capture the responsibility of the Agent with respect to the Resource.
               See <a href="#qualified-attribution"></a> for usage examples.</td></tr>
@@ -2697,8 +2697,8 @@ ex:InternationalDOIFundation a foaf:Organization ;
 
         <section id="quality-conformance-statement">
             <h3>Conformance to a standard</h3>
-            <p>The use of <a href="http://dublincore.org/documents/dcmi-terms/#terms-conformsTo"><code>dct:conformsTo</code></a> and
-	    <a href="http://dublincore.org/documents/dcmi-terms/#terms-Standard"><code>dct:Standard</code></a> is a well-known pattern
+            <p>The use of <a data-cite="?DCTERMS#terms-conformsTo"><code>dct:conformsTo</code></a> and
+	    <a data-cite="?DCTERMS#terms-Standard"><code>dct:Standard</code></a> is a well-known pattern
             to represent the conformance to a standard. The following example, directly borrowed from [[?SDW-BP]] (<a data-cite="SDW-BP#ex-geodcat-ap-dataset-conformance-with-specification">Example 51</a>), declares a fictional <code>a:dataset</code>
 	    conformant to the EU INSPIRE Regulation on interoperability of spatial data sets and services (<a href="http://data.europa.eu/eli/reg/2014/1312/oj">"Commission Regulation (EU) No 1089/2010
 	    of 23 November 2010 implementing Directive 2007/2/EC of the European Parliament and of the Council as regards
@@ -2721,7 +2721,7 @@ a:dataset a dcat:Dataset;
 	    to express non-conformance and non-evaluation beside the full compliance. Similar controlled vocabularies can
 	    be defined in other contexts.</p>
 	    <p>The following example specifies some newly minted concepts representing the degree of conformance (i.e., conformant, not conformant) and  declares the
-	    <a href="http://dublincore.org/documents/dcmi-terms/#terms-type"><code>dct:type</code></a> for indicating
+	    <a data-cite="?DCTERMS#terms-type"><code>dct:type</code></a> for indicating
 	    the result of conformance test. Following a pattern used in [[?GeoDCAT-AP]], the example uses a <code>prov:Entity</code> to model the  conformance test (e.g.,
 	    <code>a:testResult</code>), a <code>prov:Activity</code> to model the testing activity (e.g.,
 	    <code>a:testingActivity</code>), a <code>prov:Plan</code> derived from the Data on the Web Best Practices [[?DWBP]] (e.g., <code>a:conformanceTest</code>) to check for the whole set of best practices. A qualified PROV association binds the testing activity to the conformance test.</p>
@@ -2932,22 +2932,22 @@ a:testingActivity a prov:Activity;
   </figure>
 
   <p>
-    Note that, while the focus of these qualified forms is to allow for additional <i>roles</i> on a relationship, other aspect of the relationships, such as the applicable time interval, are easily attached when a specific node is used to describe the relationship like this (e.g. see the <a href="https://www.w3.org/TR/prov-o/#qualified-terms-figure">chart of Influence relations</a> in [[?PROV-O]] for some examples).
+    Note that, while the focus of these qualified forms is to allow for additional <i>roles</i> on a relationship, other aspect of the relationships, such as the applicable time interval, are easily attached when a specific node is used to describe the relationship like this (e.g. see the <a data-cite="?PROV-O#qualified-terms-figure">chart of Influence relations</a> in [[?PROV-O]] for some examples).
   </p>
   <p class="note">
-    Because of the global domain constraints on <a href="https://www.w3.org/TR/prov-o/#qualifiedAttribution">prov:qualifiedAttribution</a> and the super-property of <a href="#Property:resource_qualifiedRelation">dcat:qualifiedRelation</a>, use of the qualified forms entail that the context resources is a member of the class <a href="http://www.w3.org/ns/prov#Entity">prov:Entity</a> [[RDF-SCHEMA]] .
+    Because of the global domain constraints on <a data-cite="?PROV-O#qualifiedAttribution">prov:qualifiedAttribution</a> and the super-property of <a href="#Property:resource_qualifiedRelation">dcat:qualifiedRelation</a>, use of the qualified forms entail that the context resources is a member of the class <a href="http://www.w3.org/ns/prov#Entity">prov:Entity</a> [[RDF-SCHEMA]] .
   </p>
 
 
 <section id="qualified-attribution">
   <h3>Relationships between datasets and agents</h3>
   <p>
-    The standard [[!DCTERMS]] properties <a href="http://purl.org/dc/terms/contributor"><code>dct:contributor</code></a>, <a href="http://purl.org/dc/terms/creator"><code>dct:creator</code></a> and <a href="http://purl.org/dc/terms/publisher"><code>dct:publisher</code></a>, and the generic <a href="https://www.w3.org/TR/prov-o/#wasAttributedTo"><code>prov:wasAttributedTo</code></a> from [[!PROV-O]], support basic associations of responsible agents with a catalogued resource.
+    The standard [[!DCTERMS]] properties <a href="http://purl.org/dc/terms/contributor"><code>dct:contributor</code></a>, <a href="http://purl.org/dc/terms/creator"><code>dct:creator</code></a> and <a href="http://purl.org/dc/terms/publisher"><code>dct:publisher</code></a>, and the generic <a data-cite="?PROV-O#wasAttributedTo"><code>prov:wasAttributedTo</code></a> from [[!PROV-O]], support basic associations of responsible agents with a catalogued resource.
     However, there are many other roles of importance in relation to datasets and services - e.g. funder, distributor, custodian, editor.
     Some of these roles are enumerated in the <code>CI_RoleCode</code> values from [[?ISO-19115-1]], in the [[?DataCite]] metadata schema, and included within the <a href="https://id.loc.gov/vocabulary/relators">MARC relators</a>.
   </p>
   <p>
-    A general method for assigning an agent to a resource with a specified role is provided by using the qualified form <a href="https://www.w3.org/TR/prov-o/#qualifiedAttribution"><code>prov:qualifiedAttribution</code></a> from [[!PROV-O]].
+    A general method for assigning an agent to a resource with a specified role is provided by using the qualified form <a data-cite="?PROV-O#qualifiedAttribution"><code>prov:qualifiedAttribution</code></a> from [[!PROV-O]].
     The following provides an illustration:
   </p>
 <pre id="ex-qualified-attribution" class="example nohighlight turtle">
@@ -3015,7 +3015,7 @@ ex:Test543L
 </pre>
 
 <p class="note">
-  The property <a href="#Property:resource_qualifiedRelation"><code>dcat:qualifiedRelation</code></a> and association-class <a href="#Class:Relationship"><code>dcat:Relationship</code></a> follow the pattern established in W3C [[!PROV-O]] and described in the section <a href="https://www.w3.org/TR/prov-o/#description-qualified-terms">Qualified Terms</a>.
+  The property <a href="#Property:resource_qualifiedRelation"><code>dcat:qualifiedRelation</code></a> and association-class <a href="#Class:Relationship"><code>dcat:Relationship</code></a> follow the pattern established in W3C [[!PROV-O]] and described in the section <a data-cite="?PROV-O#description-qualified-terms">Qualified Terms</a>.
   However, [[!PROV-O]] is activity-centric, and does not support Entity-Entity relations except for the single case of 'was derived from', thus necessitating the new elements shown here to support the general case.
 </p>
 </section>
@@ -3069,11 +3069,11 @@ ex:Test543L
 	</p>
 	<p>The following approach is recommended:</p>
 		<ol>
-			<li>use <a href="http://dublincore.org/documents/dcmi-terms/#terms-license"><code>dct:license</code></a> to refer to well-known licenses such as <a href="https://creativecommons.org/share-your-work/licensing-types-examples/">those defined by Creative Commons</a></br>
-			The object of <code>dct:license</code>, a <a href="http://dublincore.org/documents/dcmi-terms/#terms-LicenseDocument"><code>dct:LicenseDocument</code></a>, is "A legal document giving official permission to do something with a Resource."</li>
-			<li>use <a href="http://dublincore.org/documents/dcmi-terms/#terms-rights"><code>dct:rights</code></a> to refer to rights statements that are not licenses, such as copyright statements</br>
-			The object of <code>dct:rights</code>, a <a href="http://dublincore.org/documents/dcmi-terms/#terms-RightsStatement"><code>dct:RightsStatement</code></a>, is "A statement about the intellectual property rights (IPR) held in or over a Resource, a legal document giving official permission to do something with a resource, or a statement about access rights."
-			This is more general than a <a href="http://dublincore.org/documents/dcmi-terms/#terms-LicenseDocument"><code>dct:LicenseDocument</code></a> and therefore should be used if it the statement contains more general information about rights.</li>
+			<li>use <a data-cite="?DCTERMS#terms-license"><code>dct:license</code></a> to refer to well-known licenses such as <a href="https://creativecommons.org/share-your-work/licensing-types-examples/">those defined by Creative Commons</a></br>
+			The object of <code>dct:license</code>, a <a data-cite="?DCTERMS#terms-LicenseDocument"><code>dct:LicenseDocument</code></a>, is "A legal document giving official permission to do something with a Resource."</li>
+			<li>use <a data-cite="?DCTERMS#terms-rights"><code>dct:rights</code></a> to refer to rights statements that are not licenses, such as copyright statements</br>
+			The object of <code>dct:rights</code>, a <a data-cite="?DCTERMS#terms-RightsStatement"><code>dct:RightsStatement</code></a>, is "A statement about the intellectual property rights (IPR) held in or over a Resource, a legal document giving official permission to do something with a resource, or a statement about access rights."
+			This is more general than a <a data-cite="?DCTERMS#terms-LicenseDocument"><code>dct:LicenseDocument</code></a> and therefore should be used if it the statement contains more general information about rights.</li>
 			<li>use <a href="https://www.w3.org/TR/odrl-vocab/#term-hasPolicy"><code>odrl:hasPolicy</code></a> for linking to <a href="https://www.w3.org/TR/odrl-vocab/#term-Policy">ODRL policies</a></br>
 			The Open Digital Rights Language (ODRL) is a policy expression language that provides a flexible and interoperable information model, vocabulary, and encoding mechanisms for representing statements about usage (i.e. permissions, prohibitions, and obligations) of content and services.</li>
 		</ol>
@@ -3097,7 +3097,7 @@ ex:Test543L
 			<li>
 			  <p>use <a data-cite="?DCTERMS#terms-license"><code>dct:license</code></a> to refer to licenses;</p>
 <!--
-			<p>The object of <code>dct:license</code>, a <a href="http://dublincore.org/documents/dcmi-terms/#terms-LicenseDocument"><code>dct:LicenseDocument</code></a>, is "A legal document giving official permission to do something with a Resource."</p>
+			<p>The object of <code>dct:license</code>, a <a data-cite="?DCTERMS#terms-LicenseDocument"><code>dct:LicenseDocument</code></a>, is "A legal document giving official permission to do something with a Resource."</p>
 -->
         <p class="note">
           For interoperability, it is recommended to use canonical URIs of well-known licenses such as <a href="https://creativecommons.org/share-your-work/licensing-types-examples/">those defined by Creative Commons</a>.
@@ -3115,8 +3115,8 @@ ex:Test543L
 			<li>
 			  <p>use <a data-cite="?DCTERMS#terms-rights"><code>dct:rights</code></a> for all the other types of rights statements - those which are not covered by <code>dct:license</code> and <code>dct:accessRights</code>, such as copyright statements.</p>
 <!--
-			  <p>The object of <code>dct:rights</code>, a <a href="http://dublincore.org/documents/dcmi-terms/#terms-RightsStatement"><code>dct:RightsStatement</code></a>, is "A statement about the intellectual property rights (IPR) held in or over a Resource, a legal document giving official permission to do something with a resource, or a statement about access rights."
-			This is more general than a <a href="http://dublincore.org/documents/dcmi-terms/#terms-LicenseDocument"><code>dct:LicenseDocument</code></a> and therefore should be used if it the statement contains more general information about rights.</p>
+			  <p>The object of <code>dct:rights</code>, a <a data-cite="?DCTERMS#terms-RightsStatement"><code>dct:RightsStatement</code></a>, is "A statement about the intellectual property rights (IPR) held in or over a Resource, a legal document giving official permission to do something with a resource, or a statement about access rights."
+			This is more general than a <a data-cite="?DCTERMS#terms-LicenseDocument"><code>dct:LicenseDocument</code></a> and therefore should be used if it the statement contains more general information about rights.</p>
 -->
 			  <p class="note">
 			    A more sophisticated approach to express rights, based on and extending [[?DCTERMS]], is provided by the Open Data Rights Statement Vocabulary (ODRS) [[?ODRS]], which defines properties for specifying, among others, copyright statements and copyright notices.
@@ -4138,7 +4138,7 @@ dcat:servesDataset ga-courts:jc ;
             </li>
 
             <li>
-                <a href="#Property:relationship_hadRole">Property: had role</a>: The property <code>dcat:hadRole</code> is added to support the use of <a href="https://www.w3.org/TR/prov-o/#qualifiedAttribution"><code>prov:qualifiedAttribution</code></a> to associate an agent with a DCAT resource, where the role of the agent with relation to the resource is specified, and is something other than the standard Dublin Core roles: creator, publisher or contributor - see <a href="https://github.com/w3c/dxwg/issues/79">Issue #79</a>
+                <a href="#Property:relationship_hadRole">Property: had role</a>: The property <code>dcat:hadRole</code> is added to support the use of <a data-cite="?PROV-O#qualifiedAttribution"><code>prov:qualifiedAttribution</code></a> to associate an agent with a DCAT resource, where the role of the agent with relation to the resource is specified, and is something other than the standard Dublin Core roles: creator, publisher or contributor - see <a href="https://github.com/w3c/dxwg/issues/79">Issue #79</a>
             </li>
 
             <li>
@@ -4194,7 +4194,7 @@ dcat:servesDataset ga-courts:jc ;
 -->
 
             <li><a href="#Class:Dataset">Class: Dataset</a>:
-                In DCAT 2014 [[?VOCAB-DCAT-20140116]] <a href="#Class:Dataset"><code>dcat:Dataset</code></a> was a sub-class of <a href="http://purl.org/dc/dcmitype/Dataset"><code>dctype:Dataset</code></a>, which is a term of the <a href="http://dublincore.org/documents/dcmi-terms/#section-7">DCMI Types vocabulary</a> [[!DCTERMS]]. This relationship has been removed in the revised DCAT vocabulary - see <a href="https://github.com/w3c/dxwg/issues/98">Issue #98</a>.
+                In DCAT 2014 [[?VOCAB-DCAT-20140116]] <a href="#Class:Dataset"><code>dcat:Dataset</code></a> was a sub-class of <a href="http://purl.org/dc/dcmitype/Dataset"><code>dctype:Dataset</code></a>, which is a term of the <a data-cite="?DCTERMS#section-7">DCMI Types vocabulary</a> [[!DCTERMS]]. This relationship has been removed in the revised DCAT vocabulary - see <a href="https://github.com/w3c/dxwg/issues/98">Issue #98</a>.
             </li>
 
             <li>
@@ -4243,8 +4243,8 @@ dcat:servesDataset ga-courts:jc ;
                 - see <a href="https://github.com/w3c/dxwg/issues/502">Issue #502</a>.
             </li>
             <li>
-                A new section <a href="#license-rights"></a> was added to provide guidance and recommendations for the use of <a href="http://dublincore.org/documents/dcmi-terms/#terms-license"><code>dct:license</code></a>, <a href="http://dublincore.org/documents/dcmi-terms/#terms-accessRights"><code>dct:accessRights</code></a>,
-		and <a href="http://dublincore.org/documents/dcmi-terms/#terms-rights"><code>dct:rights</code></a> in the context of dcat catalogs and distributions.
+                A new section <a href="#license-rights"></a> was added to provide guidance and recommendations for the use of <a data-cite="?DCTERMS#terms-license"><code>dct:license</code></a>, <a data-cite="?DCTERMS#terms-accessRights"><code>dct:accessRights</code></a>,
+		and <a data-cite="?DCTERMS#terms-rights"><code>dct:rights</code></a> in the context of dcat catalogs and distributions.
 		See <a href="https://github.com/w3c/dxwg/issues/114">Issue #114</a> for the background discussion.
             </li>
             <li>

--- a/dcat/index.html
+++ b/dcat/index.html
@@ -1683,7 +1683,7 @@ $(document).ready( function() {
                 <thead><tr><th>RDF Property:</th><th><a href="http://www.w3.org/ns/dcat#temporalResolution">dcat:temporalResolution</a></th></tr></thead>
                 <tbody>
                 <tr><td class="prop">Definition:</td><td>minimum time period resolvable in the dataset</td></tr>
-                <tr><td class="prop">Range:</td><td><a data-cite="XMLSCHEMA-2#duration"><code>xsd:duration</code></a></td></tr>
+                <tr><td class="prop">Range:</td><td><a data-cite="XMLSCHEMA11-2#duration"><code>xsd:duration</code></a></td></tr>
                 <tr><td class="prop">Usage note:</td><td>If the dataset is a time-series this should correspond to the spacing of items in the series. For other kinds of dataset, this property will usually indicate the smallest time difference between items in the dataset. </td></tr>
                 </tbody>
             </table>
@@ -1973,7 +1973,7 @@ $(document).ready( function() {
                 <tbody>
                 <tr><td class="prop">Definition:</td><td>The size of a distribution in bytes.</td></tr>
                 <tr><td class="prop">Domain:</td><td><a href="#Class:Distribution"><code>dcat:Distribution</code></a></td></tr>
-                <tr><td class="prop">Range:</td><td><a href="http://www.w3.org/2000/01/rdf-schema#Literal"><code>rdfs:Literal</code></a> typed as <a href="http://www.w3.org/TR/xmlschema-2/#decimal"><code>xsd:decimal</code></a>.</td></tr>
+                <tr><td class="prop">Range:</td><td><a href="http://www.w3.org/2000/01/rdf-schema#Literal"><code>rdfs:Literal</code></a> typed as <a data-cite="XMLSCHEMA11-2#decimal"><code>xsd:decimal</code></a>.</td></tr>
                 <tr><td class="prop">Usage note:</td><td>The size in bytes can be approximated when the precise size is not known.</td></tr>
                 </tbody>
             </table>
@@ -2009,7 +2009,7 @@ $(document).ready( function() {
                 <thead><tr><th>RDF Property:</th><th><a href="http://www.w3.org/ns/dcat#temporalResolution">dcat:temporalResolution</a></th></tr></thead>
                 <tbody>
                 <tr><td class="prop">Definition:</td><td>minimum time period resolvable in the dataset distribution</td></tr>
-                <tr><td class="prop">Range:</td><td><a href="http://www.w3.org/TR/xmlschema-2/#duration"><code>xsd:duration</code></a></td></tr>
+                <tr><td class="prop">Range:</td><td><a data-cite="XMLSCHEMA11-2#duration"><code>xsd:duration</code></a></td></tr>
                 <tr><td class="prop">Usage note:</td><td>If the dataset is a time-series this should correspond to the spacing of items in the series. For other kinds of dataset, this property will usually indicate the smallest time difference between items in the dataset. </td></tr>
                 <tr><td class="prop">Usage note:</td><td>Alternative temporal resolutions might be provided in different dataset distributions</td></tr>
                 </tbody>

--- a/dcat/index.html
+++ b/dcat/index.html
@@ -163,20 +163,20 @@ $(document).ready( function() {
     <table id="namespaces">
         <thead><tr><th>Prefix</th><th>Namespace</th></tr></thead>
         <tbody>
-        <tr><td>adms</td><td>https://www.w3.org/ns/adms#</td></tr>
-        <tr><td>dcat</td><td>http://www.w3.org/ns/dcat#</td></tr>
-        <tr><td>dct</td><td>http://purl.org/dc/terms/</td></tr>
-        <tr><td>dctype</td><td>http://purl.org/dc/dcmitype/</td></tr>
-        <tr><td>dqv</td><td>http://www.w3.org/ns/dqv#</td></tr>
-        <tr><td>foaf</td><td>http://xmlns.com/foaf/0.1/</td></tr>
-        <tr><td>owl</td><td>http://www.w3.org/2002/07/owl#</td></tr>
-        <tr><td>prov</td><td>http://www.w3.org/ns/prov#</td></tr>
-        <tr><td>rdf</td><td>http://www.w3.org/1999/02/22-rdf-syntax-ns#</td></tr>
-        <tr><td>rdfs</td><td>http://www.w3.org/2000/01/rdf-schema#</td></tr>
-        <tr><td>sdo</td><td>https://schema.org/</td></tr>
-        <tr><td>skos</td><td>http://www.w3.org/2004/02/skos/core#</td></tr>
-        <tr><td>vcard</td><td>http://www.w3.org/2006/vcard/ns#</td></tr>
-        <tr><td>xsd</td><td>http://www.w3.org/2001/XMLSchema#</td></tr>
+        <tr><td><code>adms</code></td><td><code>https://www.w3.org/ns/adms#</code></td></tr>
+        <tr><td><code>dcat</code></td><td><code>http://www.w3.org/ns/dcat#</code></td></tr>
+        <tr><td><code>dct</code></td><td><code>http://purl.org/dc/terms/</code></td></tr>
+        <tr><td><code>dctype</code></td><td><code>http://purl.org/dc/dcmitype/</code></td></tr>
+        <tr><td><code>dqv</code></td><td><code>http://www.w3.org/ns/dqv#</code></td></tr>
+        <tr><td><code>foaf</code></td><td><code>http://xmlns.com/foaf/0.1/</code></td></tr>
+        <tr><td><code>owl</code></td><td><code>http://www.w3.org/2002/07/owl#</code></td></tr>
+        <tr><td><code>prov</code></td><td><code>http://www.w3.org/ns/prov#</code></td></tr>
+        <tr><td><code>rdf</code></td><td><code>http://www.w3.org/1999/02/22-rdf-syntax-ns#</code></td></tr>
+        <tr><td><code>rdfs</code></td><td><code>http://www.w3.org/2000/01/rdf-schema#</code></td></tr>
+        <tr><td><code>sdo</code></td><td><code>https://schema.org/</code></td></tr>
+        <tr><td><code>skos</code></td><td><code>http://www.w3.org/2004/02/skos/core#</code></td></tr>
+        <tr><td><code>vcard</code></td><td><code>http://www.w3.org/2006/vcard/ns#</code></td></tr>
+        <tr><td><code>xsd</code></td><td><code>http://www.w3.org/2001/XMLSchema#</code></td></tr>
         </tbody>
     </table>
 </section>
@@ -3972,56 +3972,59 @@ a:EEA-CSW-Endpoint
 
 <pre id="ex-service-gsa" class="example nohighlight turtle">
 ga-courts:jc
-rdf:type dcat:Dataset ;
-dct:description "The dataset contains spatial locations, in point format, of the Australian High Court, Australian Federal Courts and the Australian Magistrates Courts." ;
-dct:spatial [
+  rdf:type dcat:Dataset ;
+  dct:description "The dataset contains spatial locations, in point format, of the Australian High Court, Australian Federal Courts and the Australian Magistrates Courts." ;
+  dct:spatial [
     rdf:type dct:Location ;
     locn:geometry "&lt;gml:Envelope srsName=\"http://www.opengis.net/def/crs/EPSG/0/4283\"&gt;&lt;gml:lowerCorner&gt;115.864566 -42.885989&lt;/gml:lowerCorner&gt;&lt;gml:upperCorner&gt;153.276835 -12.460578&lt;/gml:upperCorner&gt;&lt;/gml:Envelope&gt;"^^gsp:gmlLiteral ;
   ] ;
-dct:title "Judicial Courts" ;
-dct:type &lt;http://purl.org/dc/dcmitype/Dataset&gt; ;
-dcat:landingPage &lt;https://ecat.ga.gov.au/geonetwork/srv/eng/catalog.search#/metadata/cc365600-294a-597d-e044-00144fdd4fa6&gt; ;
+  dct:title "Judicial Courts" ;
+  dct:type &lt;http://purl.org/dc/dcmitype/Dataset&gt; ;
+  dcat:landingPage &lt;https://ecat.ga.gov.au/geonetwork/srv/eng/catalog.search#/metadata/cc365600-294a-597d-e044-00144fdd4fa6&gt; ;
 .
+
 ga-courts:jc-esri
-rdf:type dcat:DataService ;
-dct:conformsTo &lt;https://developers.arcgis.com/rest/&gt; ;
-dct:description "This web service provides access to the National Judicial Courts dataset and presents the spatial locations of all the known Australian High Courts, Australian Federal Courts and the Australian Federal Circuit Courts located within Australia, all complemented with feature attribution." ;
-dct:identifier "2b8540c8-4a43-144d-e053-12a3070a3ff7" ;
-dct:title "National Judicial Courts MapServer" ;
-dct:type &lt;http://purl.org/dc/dcmitype/Service&gt; ;
-dct:type &lt;https://inspire.ec.europa.eu/metadata-codelist/SpatialDataServiceType/download&gt; ;
-dct:type &lt;https://inspire.ec.europa.eu/metadata-codelist/SpatialDataServiceType/view&gt; ;
-dcat:endpointURL &lt;http://services.ga.gov.au/gis/rest/services/Judicial_Courts/MapServer&gt; ;
-dcat:landingPage &lt;https://ecat.ga.gov.au/geonetwork/srv/eng/catalog.search#/metadata/2b8540c8-4a43-144d-e053-12a3070a3ff7&gt; ;
-dcat:servesDataset ga-courts:jc ;
+  rdf:type dcat:DataService ;
+  dct:conformsTo &lt;https://developers.arcgis.com/rest/&gt; ;
+  dct:description "This web service provides access to the National Judicial Courts dataset and presents the spatial locations of all the known Australian High Courts, Australian Federal Courts and the Australian Federal Circuit Courts located within Australia, all complemented with feature attribution." ;
+  dct:identifier "2b8540c8-4a43-144d-e053-12a3070a3ff7" ;
+  dct:title "National Judicial Courts MapServer" ;
+  dct:type &lt;http://purl.org/dc/dcmitype/Service&gt; ;
+  dct:type &lt;https://inspire.ec.europa.eu/metadata-codelist/SpatialDataServiceType/download&gt; ;
+  dct:type &lt;https://inspire.ec.europa.eu/metadata-codelist/SpatialDataServiceType/view&gt; ;
+  dcat:endpointURL &lt;http://services.ga.gov.au/gis/rest/services/Judicial_Courts/MapServer&gt; ;
+  dcat:landingPage &lt;https://ecat.ga.gov.au/geonetwork/srv/eng/catalog.search#/metadata/2b8540c8-4a43-144d-e053-12a3070a3ff7&gt; ;
+  dcat:servesDataset ga-courts:jc ;
 .
+
 ga-courts:jc-wfs
-rdf:type dcat:DataService ;
-dct:conformsTo &lt;http://www.opengis.net/def/serviceType/ogc/wfs/2.0.0&gt; ;
-dct:conformsTo &lt;http://www.opengis.net/def/serviceType/ogc/wfs/1.1.0&gt; ;
-dct:conformsTo &lt;http://www.opengis.net/def/serviceType/ogc/wfs/1.0.0&gt; ;
-dct:description "This web service provides access to the National Judicial Courts dataset and presents the spatial locations of all the known Australian High Courts, Australian Federal Courts and the Australian Federal Circuit Courts located within Australia, all complemented with feature attribution." ;
-dct:identifier "2b8540c8-4a42-144d-e053-12a3070a3ff7" ;
-dct:title "National Judicial Courts WFS" ;
-dct:type &lt;http://purl.org/dc/dcmitype/Service&gt; ;
-dct:type &lt;https://inspire.ec.europa.eu/metadata-codelist/SpatialDataServiceType/download&gt; ;
-dcat:endpointDescription &lt;http://services.ga.gov.au/gis/services/Judicial_Courts/MapServer/WFSServer?request=GetCapabilities&service=WFS&gt; ;
-dcat:endpointURL &lt;http://services.ga.gov.au/gis/services/Judicial_Courts/MapServer/WFSServer&gt; ;
-dcat:landingPage &lt;https://ecat.ga.gov.au/geonetwork/srv/eng/catalog.search#/metadata/2b8540c8-4a42-144d-e053-12a3070a3ff7&gt; ;
-dcat:servesDataset ga-courts:jc ;
+  rdf:type dcat:DataService ;
+  dct:conformsTo &lt;http://www.opengis.net/def/serviceType/ogc/wfs/2.0.0&gt; ;
+  dct:conformsTo &lt;http://www.opengis.net/def/serviceType/ogc/wfs/1.1.0&gt; ;
+  dct:conformsTo &lt;http://www.opengis.net/def/serviceType/ogc/wfs/1.0.0&gt; ;
+  dct:description "This web service provides access to the National Judicial Courts dataset and presents the spatial locations of all the known Australian High Courts, Australian Federal Courts and the Australian Federal Circuit Courts located within Australia, all complemented with feature attribution." ;
+  dct:identifier "2b8540c8-4a42-144d-e053-12a3070a3ff7" ;
+  dct:title "National Judicial Courts WFS" ;
+  dct:type &lt;http://purl.org/dc/dcmitype/Service&gt; ;
+  dct:type &lt;https://inspire.ec.europa.eu/metadata-codelist/SpatialDataServiceType/download&gt; ;
+  dcat:endpointDescription &lt;http://services.ga.gov.au/gis/services/Judicial_Courts/MapServer/WFSServer?request=GetCapabilities&service=WFS&gt; ;
+  dcat:endpointURL &lt;http://services.ga.gov.au/gis/services/Judicial_Courts/MapServer/WFSServer&gt; ;
+  dcat:landingPage &lt;https://ecat.ga.gov.au/geonetwork/srv/eng/catalog.search#/metadata/2b8540c8-4a42-144d-e053-12a3070a3ff7&gt; ;
+  dcat:servesDataset ga-courts:jc ;
 .
+
 ga-courts:jc-wms
-rdf:type dcat:DataService ;
-dct:conformsTo &lt;http://www.opengis.net/def/serviceType/ogc/wms/1.3&gt; ;
-dct:description "This web service provides access to the National Judicial Courts dataset and presents the spatial locations of all the known Australian High Courts, Australian Federal Courts and the Australian Federal Circuit Courts located within Australia, all complemented with feature attribution." ;
-dct:identifier "2b8540c8-4a41-144d-e053-12a3070a3ff7" ;
-dct:title "National Judicial Courts WMS" ;
-dct:type &lt;http://purl.org/dc/dcmitype/Service&gt; ;
-dct:type &lt;https://inspire.ec.europa.eu/metadata-codelist/SpatialDataServiceType/view&gt; ;
-dcat:endpointDescription &lt;http://services.ga.gov.au/gis/services/Judicial_Courts/MapServer/WMSServer?request=GetCapabilities&service=WMS&gt; ;
-dcat:endpointURL &lt;http://services.ga.gov.au/gis/services/Judicial_Courts/MapServer/WMSServer&gt; ;
-dcat:landingPage &lt;https://ecat.ga.gov.au/geonetwork/srv/eng/catalog.search#/metadata/2b8540c8-4a41-144d-e053-12a3070a3ff7&gt; ;
-dcat:servesDataset ga-courts:jc ;
+  rdf:type dcat:DataService ;
+  dct:conformsTo &lt;http://www.opengis.net/def/serviceType/ogc/wms/1.3&gt; ;
+  dct:description "This web service provides access to the National Judicial Courts dataset and presents the spatial locations of all the known Australian High Courts, Australian Federal Courts and the Australian Federal Circuit Courts located within Australia, all complemented with feature attribution." ;
+  dct:identifier "2b8540c8-4a41-144d-e053-12a3070a3ff7" ;
+  dct:title "National Judicial Courts WMS" ;
+  dct:type &lt;http://purl.org/dc/dcmitype/Service&gt; ;
+  dct:type &lt;https://inspire.ec.europa.eu/metadata-codelist/SpatialDataServiceType/view&gt; ;
+  dcat:endpointDescription &lt;http://services.ga.gov.au/gis/services/Judicial_Courts/MapServer/WMSServer?request=GetCapabilities&service=WMS&gt; ;
+  dcat:endpointURL &lt;http://services.ga.gov.au/gis/services/Judicial_Courts/MapServer/WMSServer&gt; ;
+  dcat:landingPage &lt;https://ecat.ga.gov.au/geonetwork/srv/eng/catalog.search#/metadata/2b8540c8-4a41-144d-e053-12a3070a3ff7&gt; ;
+  dcat:servesDataset ga-courts:jc ;
 .
 </pre>
 
@@ -4033,60 +4036,57 @@ dcat:servesDataset ga-courts:jc ;
         <p>The first example is for a distribution with a downloadable file that is compressed into a GZIP file.
         </p>
 
-        <pre id="compressed-distribution" class="example nohighlight turtle">
+<pre id="compressed-distribution" class="example nohighlight turtle">
+@prefix dcat: &lt;http://www.w3.org/ns/dcat#&gt; .
+@prefix dct: &lt;http://purl.org/dc/terms/&gt; .
 
-        @prefix dcat: &lt;http://www.w3.org/ns/dcat#&gt; .
-        @prefix dct: &lt;http://purl.org/dc/terms/&gt; .
-
-        &lt;https://data.gov.cz/zdroj/datová-sada/247025684/22&gt; a dcat:Distribution ;
-          dcat:accessURL &lt;https://mvcr1.opendata.cz/czechpoint/2007.csv.gz&gt; ;
-          dcat:downloadURL &lt;https://mvcr1.opendata.cz/czechpoint/2007.csv.gz&gt; ;
-          dct:license &lt;https://data.gov.cz/podmínky-užití/volný-přístup/&gt; ;
-          dct:conformsTo &lt;https://mvcr1.opendata.cz/czechpoint/2007.json&gt; ;
-          dct:format &lt;http://publications.europa.eu/resource/authority/file-type/CSV&gt; ;
-          dcat:mediaType &lt;http://www.iana.org/assignments/media-types/text/csv&gt; ;
-          dcat:compressFormat &lt;http://www.iana.org/assignments/media-types/application/gzip&gt; .
-
-        </pre>
+&lt;https://data.gov.cz/zdroj/datová-sada/247025684/22&gt; a dcat:Distribution ;
+  dcat:accessURL &lt;https://mvcr1.opendata.cz/czechpoint/2007.csv.gz&gt; ;
+  dcat:downloadURL &lt;https://mvcr1.opendata.cz/czechpoint/2007.csv.gz&gt; ;
+  dct:license &lt;https://data.gov.cz/podmínky-užití/volný-přístup/&gt; ;
+  dct:conformsTo &lt;https://mvcr1.opendata.cz/czechpoint/2007.json&gt; ;
+  dct:format &lt;http://publications.europa.eu/resource/authority/file-type/CSV&gt; ;
+  dcat:mediaType &lt;http://www.iana.org/assignments/media-types/text/csv&gt; ;
+  dcat:compressFormat &lt;http://www.iana.org/assignments/media-types/application/gzip&gt;
+.
+</pre>
 
         <p>The second example is for a distribution with several files packed into a TAR file.
         </p>
 
-        <pre id="packaged-distribution" class="example nohighlight turtle">
+<pre id="packaged-distribution" class="example nohighlight turtle">
+  @prefix dcat: &lt;http://www.w3.org/ns/dcat#> .
+  @prefix dct: &lt;http://purl.org/dc/terms/> .
 
-          @prefix dcat: &lt;http://www.w3.org/ns/dcat#> .
-          @prefix dct: &lt;http://purl.org/dc/terms/> .
-
-          &lt;https://data.gov.cz/zdroj/datová-sada/247025684/22&gt; a dcat:Distribution ;
-            dcat:accessURL &lt;https://mvcr1.opendata.cz/czechpoint/data.tar&gt; ;
-            dcat:downloadURL &lt;https://mvcr1.opendata.cz/czechpoint/data.tar&gt; ;
-            dct:license &lt;https://data.gov.cz/podmínky-užití/volný-přístup/&gt; ;
-            dct:conformsTo &lt;https://mvcr1.opendata.cz/czechpoint/2007.json&gt; ;
-            dct:format &lt;http://publications.europa.eu/resource/authority/file-type/CSV&gt; ;
-            dcat:mediaType &lt;http://www.iana.org/assignments/media-types/text/csv&gt; ;
-            dcat:packageFormat &lt;http://publications.europa.eu/resource/authority/file-type/TAR&gt; .
-
-        </pre>
+  &lt;https://data.gov.cz/zdroj/datová-sada/247025684/22&gt; a dcat:Distribution ;
+    dcat:accessURL &lt;https://mvcr1.opendata.cz/czechpoint/data.tar&gt; ;
+    dcat:downloadURL &lt;https://mvcr1.opendata.cz/czechpoint/data.tar&gt; ;
+    dct:license &lt;https://data.gov.cz/podmínky-užití/volný-přístup/&gt; ;
+    dct:conformsTo &lt;https://mvcr1.opendata.cz/czechpoint/2007.json&gt; ;
+    dct:format &lt;http://publications.europa.eu/resource/authority/file-type/CSV&gt; ;
+    dcat:mediaType &lt;http://www.iana.org/assignments/media-types/text/csv&gt; ;
+    dcat:packageFormat &lt;http://publications.europa.eu/resource/authority/file-type/TAR&gt; 
+.
+</pre>
 
         <p>The third example is for a distribution with several files packed into a TAR file which has been compressed into a GZIP file.
         </p>
 
-        <pre id="packaged-and-compressed-distribution" class="example nohighlight turtle">
+<pre id="packaged-and-compressed-distribution" class="example nohighlight turtle">
+  @prefix dcat: &lt;http://www.w3.org/ns/dcat#&gt; .
+  @prefix dct: &lt;http://purl.org/dc/terms/&gt; .
 
-          @prefix dcat: &lt;http://www.w3.org/ns/dcat#&gt; .
-          @prefix dct: &lt;http://purl.org/dc/terms/&gt; .
-
-          &lt;https://data.gov.cz/zdroj/datová-sada/247025684/22&gt; a dcat:Distribution ;
-            dcat:accessURL &lt;https://mvcr1.opendata.cz/czechpoint/data.tar.gz&gt; ;
-            dcat:downloadURL &lt;https://mvcr1.opendata.cz/czechpoint/data.tar.gz&gt; ;
-            dct:conformsTo &lt;https://mvcr1.opendata.cz/czechpoint/2007.json&gt; ;
-            dct:license &lt;https://data.gov.cz/podmínky-užití/volný-přístup/&gt; ;
-            dct:format &lt;http://publications.europa.eu/resource/authority/file-type/CSV&gt; ;
-            dcat:mediaType &lt;http://www.iana.org/assignments/media-types/text/csv&gt; ;
-            dcat:packageFormat &lt;http://publications.europa.eu/resource/authority/file-type/TAR&gt; ;
-            dcat:compressFormat &lt;http://www.iana.org/assignments/media-types/application/gzip&gt; .
-
-        </pre>
+  &lt;https://data.gov.cz/zdroj/datová-sada/247025684/22&gt; a dcat:Distribution ;
+    dcat:accessURL &lt;https://mvcr1.opendata.cz/czechpoint/data.tar.gz&gt; ;
+    dcat:downloadURL &lt;https://mvcr1.opendata.cz/czechpoint/data.tar.gz&gt; ;
+    dct:conformsTo &lt;https://mvcr1.opendata.cz/czechpoint/2007.json&gt; ;
+    dct:license &lt;https://data.gov.cz/podmínky-užití/volný-přístup/&gt; ;
+    dct:format &lt;http://publications.europa.eu/resource/authority/file-type/CSV&gt; ;
+    dcat:mediaType &lt;http://www.iana.org/assignments/media-types/text/csv&gt; ;
+    dcat:packageFormat &lt;http://publications.europa.eu/resource/authority/file-type/TAR&gt; ;
+    dcat:compressFormat &lt;http://www.iana.org/assignments/media-types/application/gzip&gt; 
+.
+</pre>
         <p>
             These examples are available from the <a href="https://github.com/w3c/dxwg/tree/gh-pages/dcat/examples">DXWG code repository</a> at <a href="https://w3c.github.io/dxwg/dcat/examples/compress-and-package.ttl"><code>compress-and-package.ttl</code></a>
         </p>

--- a/dcat/index.html
+++ b/dcat/index.html
@@ -347,7 +347,7 @@ $(document).ready( function() {
 
         <p>First, the catalog description:
         </p>
-<pre id="ex-catalog" class="example nohighlight turtle" aria-busy="false" aria-live="polite">
+<pre id="ex-catalog" class="example nohighlight turtle">
 :catalog
   a dcat:Catalog&nbsp;;
   dct:title "Imaginary Catalog"&nbsp;;
@@ -360,7 +360,7 @@ $(document).ready( function() {
 </pre>
         <p>The publisher of the catalog has the relative URI&nbsp;<code>:transparency-office</code>. Further description of the publisher can be provided as in the following example:
         </p>
-<pre id="ex-publisher" class="example nohighlight turtle" aria-busy="false" aria-live="polite">
+<pre id="ex-publisher" class="example nohighlight turtle">
 :transparency-office
   a foaf:Organization&nbsp;;
   rdfs:label "Transparency Office"&nbsp;;
@@ -368,7 +368,7 @@ $(document).ready( function() {
 </pre>
         <p>The catalog lists each of its datasets via the <code>dcat:dataset</code> property. In the example above, an example dataset was mentioned with the relative URI&nbsp;<code>:dataset-001</code>. A possible description of it using DCAT is shown below:
         </p>
-<pre id="ex-dataset" class="example nohighlight turtle" aria-busy="false" aria-live="polite">
+<pre id="ex-dataset" class="example nohighlight turtle">
 :dataset-001
   a dcat:Dataset&nbsp;;
   dct:title "Imaginary dataset"&nbsp;;
@@ -406,7 +406,7 @@ $(document).ready( function() {
         <p>One representation of the dataset <code>:dataset-001-csv</code> can be downloaded as a 5Kb CSV file. This is
             represented as an RDF resource of type <code>dcat:Distribution</code>.
         </p>
-<pre id="ex-distribution" class="example nohighlight turtle" aria-busy="false" aria-live="polite">
+<pre id="ex-distribution" class="example nohighlight turtle">
 :dataset-001-csv
   a dcat:Distribution&nbsp;;
   dcat:downloadURL &lt;http://www.example.org/files/001.csv&gt; ;
@@ -421,7 +421,7 @@ $(document).ready( function() {
         <h3>Classifying datasets thematically</h3>
         <p>The catalog classifies its datasets according to a set of domains represented by the relative URI&nbsp;<code>:themes</code>. SKOS can be used to describe the domains used:
         </p>
-<pre id="ex-thematic-classification" class="example nohighlight turtle" aria-busy="false" aria-live="polite">
+<pre id="ex-thematic-classification" class="example nohighlight turtle">
 :catalog&nbsp;dcat:themeTaxonomy&nbsp;:themes&nbsp;.
 
 :themes
@@ -434,7 +434,7 @@ $(document).ready( function() {
         <p>Notice that this dataset is classified under the domain represented by the relative URI&nbsp;<code>:accountability</code>.
             It is recommended to define the concept as part of the concepts scheme identified by the URI&nbsp;<code>:themes</code> that was used to describe the catalog domains. An example SKOS description:
         </p>
-<pre id="ex-theme-accountability" class="example nohighlight turtle" aria-busy="false" aria-live="polite">
+<pre id="ex-theme-accountability" class="example nohighlight turtle">
 :accountability
   a skos:Concept&nbsp;;
   skos:inScheme&nbsp;:themes&nbsp;;
@@ -458,7 +458,7 @@ $(document).ready( function() {
         <p>
             In the following examples, a (notional) dataset is classified separately using values from different vocabularies.
         </p>
-<pre id="ex-dataset-type" class="example nohighlight turtle" aria-busy="false" aria-live="polite">
+<pre id="ex-dataset-type" class="example nohighlight turtle">
 :dataset-001
   rdf:type  dcat:Dataset ;
   dct:type  &lt;http://purl.org/dc/dcmitype/Text&gt; ;
@@ -473,7 +473,7 @@ $(document).ready( function() {
             It is also possible for multiple classifications to be present in a single description.
         </p>
 
-<pre id="ex-dataset-multiple-types" class="example nohighlight turtle" aria-busy="false" aria-live="polite">
+<pre id="ex-dataset-multiple-types" class="example nohighlight turtle">
 :dataset-001
   rdf:type  dcat:Dataset ;
   dct:type  &lt;http://purl.org/dc/dcmitype/Text&gt; ;
@@ -502,7 +502,7 @@ $(document).ready( function() {
             describing the datasets), <code>dcat:CatalogRecord</code> can be used. For example,
             while <code>:dataset-001</code> was issued on 2011-12-05, its description on Imaginary Catalog was added on 2011-12-11. This can be represented by DCAT as in the following:
         </p>
-<pre id="ex-catalog-record" class="example nohighlight turtle" aria-busy="false" aria-live="polite">
+<pre id="ex-catalog-record" class="example nohighlight turtle">
 :catalog  dcat:record&nbsp;:record-001&nbsp; .
 
 :record-001
@@ -519,7 +519,7 @@ $(document).ready( function() {
             where the user needs to follow some links, provide some information and check some boxes
             before accessing the data.</p>
 
-<pre id="ex-landing-page" class="example nohighlight turtle" aria-busy="false" aria-live="polite">
+<pre id="ex-landing-page" class="example nohighlight turtle">
 :dataset-002
   a dcat:Dataset ;
   dcat:landingPage &lt;http://example.org/dataset-002.html&gt; ;
@@ -539,7 +539,7 @@ $(document).ready( function() {
         <h3>A dataset available as a download and behind some Web page</h3>
         <p>On the other hand, <code>:dataset-003</code> can be obtained through some landing page but also can be downloaded from a known URL.
         </p>
-<pre id="ex-access-and-download-url" class="example nohighlight turtle" aria-busy="false" aria-live="polite">
+<pre id="ex-access-and-download-url" class="example nohighlight turtle">
 :dataset-003
   a dcat:Dataset ;
   dcat:landingPage &lt;http://example.org/dataset-003.html&gt; ;
@@ -563,7 +563,7 @@ $(document).ready( function() {
           its specific API definition using <code>dct:conformsTo</code>,
           with the detailed description of the individual endpoint parameters and options linked using <code>dcat:endpointDescription</code>.
         </p>
-<pre id="ex-access-service" class="example nohighlight turtle" aria-busy="false" aria-live="polite">
+<pre id="ex-access-service" class="example nohighlight turtle">
 :dataset-004
   rdf:type dcat:Dataset ;
   dcat:distribution :dataset-004-csv ;
@@ -675,7 +675,7 @@ $(document).ready( function() {
         <h4>Element definitions</h4>
 
         <p>
-            The definitions (including domain and range) of terms outside the DCAT namespace are provided here only for convenience and MUST be considered normative. The authoritative definitions of these terms are in the corresponding specifications, i.e. [[!DC11]], [[!DCTERMS]], [[!FOAF]], [[!PROV-O]], [[!RDF-SCHEMA]], [[!SKOS-REFERENCE]], [[!XMLSCHEMA11-2]] and [[?VCARD-RDF]].
+            The definitions (including domain and range) of terms outside the DCAT namespace are provided here only for convenience and MUST NOT be considered normative. The authoritative definitions of these terms are in the corresponding specifications, i.e. [[!DC11]], [[!DCTERMS]], [[!FOAF]], [[!PROV-O]], [[!RDF-SCHEMA]], [[!SKOS-REFERENCE]], [[!XMLSCHEMA11-2]] and [[?VCARD-RDF]].
         </p>
     </section>
 
@@ -1561,7 +1561,7 @@ $(document).ready( function() {
                 The scope of <a href="#Class:Dataset"><code>dcat:Dataset</code></a> also includes other members of the <a data-cite="?DCTERMS#section-7">DCMI Types vocabulary</a>, such as various multimedia (imagery, sound, video) and text, so the sub-class relationship from DCAT 2014 [[?VOCAB-DCAT-20140116]] has been removed in this revised DCAT vocabulary - see <a href="https://github.com/w3c/dxwg/issues/98">Issue #98</a>.
             </p>
             <p>
-                Note that members of the <a data-cite="DCTERMS#section-7">DCMI Types vocabulary</a> may appear as the value of the <a href="#Property:resource_type"><code>dct:type</code></a> property, as shown in <a href="#classifying-dataset-types"></a>.
+                Note that members of the <a data-cite="?DCTERMS#section-7">DCMI Types vocabulary</a> may appear as the value of the <a href="#Property:resource_type"><code>dct:type</code></a> property, as shown in <a href="#classifying-dataset-types"></a>.
             </p>
         </div>
 
@@ -1597,7 +1597,7 @@ $(document).ready( function() {
       <p>
         For example, a 15-minute time-series that is published daily could be described
       </p>
-      <pre id="ex-freq-daily" class="example nohighlight turtle" aria-busy="false" aria-live="polite">
+      <pre id="ex-freq-daily" class="example nohighlight turtle">
 &lt;ds913&gt;
     a dcat:Dataset ;
     dct:accrualPeriodicity &lt;http://purl.org/cld/freq/daily&gt; ;
@@ -1608,7 +1608,7 @@ $(document).ready( function() {
     <p>
       A dataset composed of items added hourly and published immediately could be described
     </p>
-    <pre id="ex-freq-hourly" class="example nohighlight turtle" aria-busy="false" aria-live="polite">
+    <pre id="ex-freq-hourly" class="example nohighlight turtle">
 &lt;ds782&gt;
     a dcat:Dataset ;
     dct:accrualPeriodicity &lt;http://purl.org/cld/freq/continuous&gt; ;
@@ -1903,7 +1903,7 @@ $(document).ready( function() {
         </section>
 
         <section id="Property:distribution_accessurl">
-            <h4>Property: access address</h4>
+            <h4>Property: access URL</h4>
 
             <!--NoBacklogNorCR p class="issue" data-number="145">
                 The granularity of <code>dcat:accessURL</code> is being re-considered to provide different usages for list and item endpoints as well as supporting the declaration of different profiles (for list results and data payload).
@@ -1915,11 +1915,11 @@ $(document).ready( function() {
                 <tr><td class="prop">Definition:</td><td>A URL of the resource that gives access to a distribution of the dataset. E.g. landing page, feed, SPARQL endpoint.</td></tr>
                 <tr><td class="prop">Domain:</td><td><a href="#Class:Distribution"><code>dcat:Distribution</code></a></td></tr>
                 <tr><td class="prop">Range:</td><td><a href="http://www.w3.org/2000/01/rdf-schema#Resource"><code>rdfs:Resource</code></a></td></tr>
-                <tr><td class="prop">Usage note:</td><td><a href="#Property:distribution_accessurl"><code>dcat:accessURL</code></a> SHOULD be used for the address of a service or location that can provide access to this distribution, typically through a web form, query or API call.
+                <tr><td class="prop">Usage note:</td><td><a href="#Property:distribution_accessurl"><code>dcat:accessURL</code></a> SHOULD be used for the URL of a service or location that can provide access to this distribution, typically through a web form, query or API call.
                     <br/><a href="#Property:distribution_downloadurl"><code>dcat:downloadURL</code></a> is preferred for direct links to downloadable resources.
-                    <br/>If the distribution(s) are accessible only through a landing page (i.e. direct download URLs are not known), then the landingPage address associated with the <code>dcat:Dataset</code> SHOULD be duplicated as access URL on a distribution (see <a href="#example-landing-page"></a>).
+                    <br/>If the distribution(s) are accessible only through a landing page (i.e. direct download URLs are not known), then the landing page URL associated with the <code>dcat:Dataset</code> SHOULD be duplicated as access URL on a distribution (see <a href="#example-landing-page"></a>).
                 </td></tr>
-                <tr><td class="prop">See also</td><td><a href="#Property:distribution_downloadurl">download address</a>, <a href="#Property:distribution_accessservice">access service</a></td></tr>
+                <tr><td class="prop">See also</td><td><a href="#Property:distribution_downloadurl">download URL</a>, <a href="#Property:distribution_accessservice">access service</a></td></tr>
                 </tbody>
             </table>
 
@@ -1941,13 +1941,13 @@ $(document).ready( function() {
                 <tr><td class="prop">Definition:</td><td>A site or end-point that gives access to the distribution of the dataset</td></tr>
                 <tr><td class="prop">Range:</td><td><a href="#Class:Data_Service"><code>dcat:DataService</code></a></td></tr>
                 <tr><td class="prop">Usage note:</td><td><a href="#Property:distribution_accessservice"><code>dcat:accessService</code></a> SHOULD be used to link to a description of a <a href="#Class:Data_Service"><code>dcat:DataService</code></a> that can provide access to this distribution.</td></tr>
-                <tr><td class="prop">See also</td><td><a href="#Property:distribution_downloadurl">download address</a>, <a href="#Property:distribution_accessurl">access address</a></td></tr>
+                <tr><td class="prop">See also</td><td><a href="#Property:distribution_downloadurl">download URL</a>, <a href="#Property:distribution_accessurl">access URL</a></td></tr>
                 </tbody>
             </table>
         </section>
 
         <section id="Property:distribution_downloadurl">
-            <h4>Property: download address</h4>
+            <h4>Property: download URL</h4>
 
             <table class="definition">
                 <thead><tr><th>RDF Property:</th><th><a href="http://www.w3.org/ns/dcat#downloadURL">dcat:downloadURL</a></th></tr></thead>
@@ -1955,8 +1955,8 @@ $(document).ready( function() {
                 <tr><td class="prop">Definition:</td><td>The URL of the downloadable file in a given format. E.g. CSV file or RDF file. The format is indicated by the distribution's <code>dct:format</code> and/or <code>dcat:mediaType</code></td></tr>
                 <tr><td class="prop">Domain:</td><td><a href="#Class:Distribution"><code>dcat:Distribution</code></a></td></tr>
                 <tr><td class="prop">Range:</td><td><a href="http://www.w3.org/2000/01/rdf-schema#Resource"><code>rdfs:Resource</code></a></td></tr>
-                <tr><td class="prop">Usage note:</td><td><a href="#Property:distribution_downloadurl"><code>dcat:downloadURL</code></a> SHOULD be used for the address at which this distribution is available directly, typically through a HTTP Get request.  </td></tr>
-                <tr><td class="prop">See also</td><td><a href="#Property:distribution_accessurl">access address</a>, <a href="#Property:distribution_accessservice">access service</a></td></tr>
+                <tr><td class="prop">Usage note:</td><td><a href="#Property:distribution_downloadurl"><code>dcat:downloadURL</code></a> SHOULD be used for the URL at which this distribution is available directly, typically through a HTTP Get request.  </td></tr>
+                <tr><td class="prop">See also</td><td><a href="#Property:distribution_accessurl">access URL</a>, <a href="#Property:distribution_accessservice">access service</a></td></tr>
                 </tbody>
             </table>
         </section>
@@ -2161,7 +2161,7 @@ $(document).ready( function() {
         </table>
 
         <section id="Property:dataservice_endpointurl">
-            <h4>Property: endpoint address</h4>
+            <h4>Property: endpoint URL</h4>
             <table class="definition">
                 <thead><tr><th>RDF Property:</th><th><a href="http://www.w3.org/ns/dcat#endpointURL">dcat:endpointURL</a></th></tr></thead>
                 <tbody>
@@ -2483,28 +2483,28 @@ end class DiscoveryService -->
     <p>The scientific and data provider communities use a number of different identifiers for publications, authors and data. DCAT primarily relies on persistent HTTP URIs as an effective way of making identifiers actionable. Notably, quite a few identifier schemes can be encoded as dereferenceable HTTP URIs, and some of them are also returning machine-readable metadata (e.g., <abbr title="Digital Object Identifier">DOIs</abbr> [[?ISO-26324]] and <a href="https://orcid.org/"><abbr title="Open Researcher and Contributor ID">ORCIDs</abbr></a>). Regardless, data providers still might need to refer to legacy identifiers, non-HTTP dereferenceable identifiers, locally minted or third-party-provided identifiers. In these cases, [[?DCTERMS]] and [[?VOCAB-ADMS]] can be of use.</p>
     <p>The property <a href="#Property:resource_identifier"><code>dct:identifier</code></a> explicitly indicates HTTP URIs as well as legacy identifiers. In the following examples,  <a href="#Property:resource_identifier"><code>dct:identifier</code></a> identifies a dataset, but it can similarly be used with any kind of resources.</p>
 
-<pre id="ex-identifier" class="example nohighlight turtle" aria-busy="false" aria-live="polite">
+<pre id="ex-identifier" class="example nohighlight turtle">
 &lt;https://example.org/id&gt; a dcat:Dataset;
 	dct:identifier "https://example.org/id"^^xsd:anyURI
   .</pre>
 
     <p> Proxy dereferenceable URIs can be used when resources have not HTTP dereferenceable IDs. For example, in the following example, <code>https://example.org/proxyid</code> is a proxy for <code>id</code>.</p>
 
-<pre id="ex-proxy-id" class="example nohighlight turtle" aria-busy="false" aria-live="polite">
+<pre id="ex-proxy-id" class="example nohighlight turtle">
 &lt;https://example.org/proxyid&gt; a dcat:Dataset;
 	dct:identifier  "id"^^xsd:string
     .</pre>
     <p>The property <a data-cite="VOCAB-ADMS#adms-identifier"><code>adms:identifier</code></a> [[?VOCAB-ADMS]] can express other locally minted identifiers or external identifiers, like DOI, <a href="https://eur-lex.europa.eu/eli-register/about.html"><abbr title="European Legislation Identifier">ELI</abbr></a>, <a href="https://arxiv.org/">ar&Chi;iv</a> for creative works and <a href="https://orcid.org/">ORCID</a>, <a href="https://viaf.org/"><abbr title="Virtual International Authority File">VIAF</abbr></a>, <a href="http://www.isni.org/"><abbr title="International Standard Name Identifier">ISNI</abbr></a> for actors such as authors and publishers, as long as the identifiers are globally unique and stable.</p>
-    <p>The following example uses <a data-cite="VOCAB-ADMS#schemaAgency"><code>adms:schemaAgency</code></a> and <a data-cite="DCTERMS#creator"><code>dct:creator</code></a> to represent the authority that defines the identifier scheme (e.g., the <a href="https://www.doi.org/">DOI foundation</a> in the example), <code>adms:schemaAgency</code> is used when the authority has no URI associated. The <a href="https://www.crossref.org/display-guidelines/">CrossRef</a> and <a href="https://support.datacite.org/docs/datacite-doi-display-guidelines">DataCite</a> display guidelines recommend displaying DOIs as full URL link in the form <code>https://doi.org/10.xxxx/xxxxx/</code>.
+    <p>The following example uses <a data-cite="VOCAB-ADMS#schemaAgency"><code>adms:schemaAgency</code></a> and <a data-cite="?DCTERMS#creator"><code>dct:creator</code></a> to represent the authority that defines the identifier scheme (e.g., the <a href="https://www.doi.org/">DOI foundation</a> in the example), <code>adms:schemaAgency</code> is used when the authority has no URI associated. The <a href="https://www.crossref.org/display-guidelines/">CrossRef</a> and <a href="https://support.datacite.org/docs/datacite-doi-display-guidelines">DataCite</a> display guidelines recommend displaying DOIs as full URL link in the form <code>https://doi.org/10.xxxx/xxxxx/</code>.
     </p>
 
-<pre id="ex-adms-identifier" class="example nohighlight turtle" aria-busy="false" aria-live="polite">
+<pre id="ex-adms-identifier" class="example nohighlight turtle">
 &lt;https://example.org/id&gt; a dcat:Dataset;
-    adms:identifier  &lt;https://example.org/iddoi&gt; ;
-    dct:publisher &lt;https://example.org/PoelenJorritH&gt;.
+   adms:identifier  &lt;https://example.org/iddoi&gt; ;
+   dct:publisher &lt;https://example.org/PoelenJorritH&gt;.
 
 &lt;https://example.org/iddoi&gt; a adms:Identifier ;
-    # reading https://www.w3.org/TR/skos-reference/#notations more than one skos:notation can be set
+   # reading https://www.w3.org/TR/skos-reference/#notations more than one skos:notation can be set
    skos:notation "https://doi.org/10.5281/zenodo.1486279"^^xsd:anyURI;
    # the authority/agency defining the identifier scheme, used if the agency has no URI
    adms:schemaAgency "International DOI Foundation" ;
@@ -2520,15 +2520,15 @@ ex:InternationalDOIFundation a foaf:Organization ;
     adms:identifier &lt;https://example.org/PoelenJorritHID&gt; .
 
 &lt;https://example.org/PoelenJorritHID&gt; a adms:Identifier;
-    skos:notation "https://orcid.org/0000-0003-3138-4118"^^xsd:anyURI ;
-    # the authority/agency defining the identifier scheme, used if the agency has no URI
+   skos:notation "https://orcid.org/0000-0003-3138-4118"^^xsd:anyURI ;
+   # the authority/agency defining the identifier scheme, used if the agency has no URI
    adms:schemaAgency "ORCID" .
 </pre>
 
     <p> The example does not represent the authority responsible for assigning and maintaining identifiers using that scheme (e.g., <a href="https://zenodo.org/">Zenodo</a>) as naming the registrant goes against the philosophy of DOI, where the sub-spaces are abstracted from the organisation that registers them, with the advantage that DOIs do not change when the organization changes or the responsibility for that sub-space is handed over to someone else. The example shows a locally minted identifier for the creator of the dataset (e.g., <code>https://example.org/PoelenJorritHID</code>) and its correspondent ORCID identifier (e.g., <code>https://orcid.org/0000-0003-3138-4118</code>). </p>
     <p>When the HTTP dereferenceable ID returns an RDF/OWL description for the dataset, the use of <code>owl:sameAs</code> might be considered. For example,</p>
 
-<pre id="ex-owl-sameas" class="example nohighlight turtle" aria-busy="false" aria-live="polite">
+<pre id="ex-owl-sameas" class="example nohighlight turtle">
 &lt;https://example.org/id&gt; a dcat:Dataset;
 	...
 	owl:sameAs &lt;https://doi.org/10.5281/zenodo.1486279&gt; .
@@ -2546,9 +2546,9 @@ ex:InternationalDOIFundation a foaf:Organization ;
     <section id="identifiers-type">
     <h2>Indicating common identifier types</h2>
 
-        <p> If identifiers are not HTTP dereferenceable, common identifier types can be served as <a data-cite="RDF11-CONCEPTS#dfn-recognized-datatype-iris">RDF datatypes</a> or custom <a data-cite="OWL2-SYNTAX#Datatype_Definitions">OWL datatypes</a> for the sake of interoperability, see <code>ex:type</code> in the following example.</p>
+        <p> If identifiers are not HTTP dereferenceable, common identifier types can be served as <a data-cite="?RDF11-CONCEPTS#dfn-recognized-datatype-iris">RDF datatypes</a> [[?RDF11-CONCEPTS]] or custom <a data-cite="?OWL2-SYNTAX#Datatype_Definitions">OWL datatypes</a> [[OWL2-SYNTAX]] for the sake of interoperability, see <code>ex:type</code> in the following example.</p>
 
-<pre id="ex-identifier-type" class="example nohighlight turtle" aria-busy="false" aria-live="polite">
+<pre id="ex-identifier-type" class="example nohighlight turtle">
 &lt;https://example.org/id&gt; a dcat:Dataset;
 	...
 	adms:identifier &lt;https://example.org/sid&gt; .
@@ -2563,7 +2563,7 @@ ex:InternationalDOIFundation a foaf:Organization ;
 
         <p>If a registered URI type is used (following [[?RFC3986]], <a href="https://tools.ietf.org/html/rfc3986#section-3.1">Section 3.1</a>), the identifier scheme is part of the URI; thus indicating a separate identifier scheme in 'type' is redundant. For example, DOI is registered as a namespace in the <code>info</code> URI scheme [[IANA-URI-SCHEMES]] (see <a href="https://www.doi.org/faq.html">DOI FAQ #11</a>), so according to [[?RFC3986]], it should be encoded as in the following</p>
 
-<pre id="ex-identifier-type-in-uri" class="example nohighlight turtle" aria-busy="false" aria-live="polite">&lt;https://example.org/sid&gt; rdf:type adms:Identifier ;
+<pre id="ex-identifier-type-in-uri" class="example nohighlight turtle">&lt;https://example.org/sid&gt; rdf:type adms:Identifier ;
  # the actual id
 	 skos:notation "info:doi/10.1109/5.771073"^^xsd:anyURI
  .
@@ -2622,7 +2622,7 @@ ex:InternationalDOIFundation a foaf:Organization ;
         </p>
 
         <aside class="example" id="ex-genoa-bus-stops-dataset-completeness-note">
-  <pre class="nohighlight turtle" aria-busy="false" aria-live="polite">
+  <pre class="nohighlight turtle">
 :genoaBusStopsDataset a dcat:Dataset ;
     dqv:hasQualityAnnotation :genoaBusStopsDatasetCompletenessNote .
 
@@ -2648,7 +2648,7 @@ ex:InternationalDOIFundation a foaf:Organization ;
 	<code>:genoaBusStopsDatasetCompletenessMeasurement</code>.
 	</p>
         <aside class="example" id="ex-genoa-bus-stops-dataset-completeness-measure">
-  <pre class="nohighlight turtle" aria-busy="false" aria-live="polite">
+  <pre class="nohighlight turtle">
 :genoaBusStopsDataset
     dqv:hasQualityMeasurement :genoaBusStopsDatasetCompletenessMeasurement .
 
@@ -2700,7 +2700,7 @@ ex:InternationalDOIFundation a foaf:Organization ;
 	    of 23 November 2010 implementing Directive 2007/2/EC of the European Parliament and of the Council as regards
 	    interoperability of spatial data sets and services"</a>).</p>
             <aside class="example" id="ex-inspire-conformant-dataset">
-  <pre class="nohighlight turtle" aria-busy="false" aria-live="polite">
+  <pre class="nohighlight turtle">
 a:dataset a dcat:Dataset;
     dct:conformsTo &lt;http://data.europa.eu/eli/reg/2014/1312/oj&gt; .
 
@@ -2725,7 +2725,7 @@ a:dataset a dcat:Dataset;
 	    <p>Depending of the kind of dataset, other best practices and standards, such as the FAIR Principles [[?FAIR]] or the Spatial Data on the Web Best Practices [[?SDW-BP]], can be considered as a replacement or used in combination with [[?DWBP]].</p>
        </aside>
        <aside class="example" id="ex-conformance-degree">
-<pre class="nohighlight turtle" aria-busy="false" aria-live="polite">
+<pre class="nohighlight turtle">
 a:dataset a dcat:Dataset ;
     prov:wasUsedBy a:testingActivity .
 
@@ -2750,7 +2750,7 @@ a:conformanceTest a prov:Plan ;
     </pre></aside>
             <p>Also, [[?VOCAB-DQV]] can be deployed to  measure the compliance to a specific standard. In the following example, the <code>:levelOfComplianceToDWBP</code> is a quality metrics which measures the compliance of a dataset to [[?DWBP]] in terms of the percentage of passed compliance tests. The example assumes <code>iso</code> as a namespace prefix representing the quality dimensions and categories defined in the ISO/IEC 25012 [[?ISOIEC25012]].</p>
             <aside class="example" id="ex-conformance-degree-percentage">
-  <pre class="nohighlight turtle" aria-busy="false" aria-live="polite">
+  <pre class="nohighlight turtle">
 :levelOfComplianceToDWBP a dqv:Metric ;
     skos:definition "The degree of compliance to DWBP defined as the percentage of passed compliance tests."@en ;
     dqv:expectedDataType xsd:double ;
@@ -2766,7 +2766,7 @@ iso:inherentandSystemDependentDataQuality a dqv:Category ;
         </pre></aside>
             <p>The quality measurement <code>:measurement_complianceToDWBP</code> represents the level of compliance for dataset <code>a:dataset</code>, namely, measurement of the metric <code>:levelOfComplianceToDWBP</code>. If only a part of the compliance tests succeeds (e.g. half of the compliance tests), the measurement would look like in the following:</p>
   <aside class="example" id="ex-conformance-test-partial-success">
-<pre class="nohighlight turtle" aria-busy="false" aria-live="polite">
+<pre class="nohighlight turtle">
 :measurement_complianceToDWBP a dqv:QualityMeasurement ;
    dqv:computedOn a:dataset ;
    dqv:value "50"^^xsd:double ;
@@ -2786,7 +2786,7 @@ iso:inherentandSystemDependentDataQuality a dqv:Category ;
 		    has passed the test as described in <code>a:testResult</code>.
             </p>
             <aside class="example" id="ex-conformance-test-results-earl">
-  <pre class="nohighlight turtle" aria-busy="false" aria-live="polite">
+  <pre class="nohighlight turtle">
 a:assertion a earl:Assertion ;
     earl:subject a:dataset ;
     earl:test a:conformanceTest ;
@@ -2822,7 +2822,7 @@ a:testingActivity a prov:Activity ;
     </pre></aside>
             <p>The following example shows how the description would have looked like if the subtest <code>a:testq1</code> had failed. In particular, <code>dcterms:description</code> and <code>earl:info</code> provide additional warnings or error messages in a human-readable form.</p>
             <aside class="example" id="ex-conformance-test-earl-fail">
-  <pre class="nohighlight turtle" aria-busy="false" aria-live="polite">
+  <pre class="nohighlight turtle">
 
 a:assertion1 a earl:Assertion ;
     earl:subject a:dataset ;
@@ -2855,7 +2855,7 @@ a:assertion1 a earl:Assertion ;
     </pre></aside>
             <p>Depending on the details required about tests, [[?VOCAB-DQV]] can express the testing activity and errors as well. In the following, <code>:error</code> is a quality annotation that represents the previous error, and  <code>a:testResult</code> is defined as a <code>dqv:QualityMetadata</code> to  collect the above annotations and the compliance measurements providing  provenance information.
             <aside class="example" id="ex-conformance-test-error">
-  <pre class="nohighlight turtle" aria-busy="false" aria-live="polite">
+  <pre class="nohighlight turtle">
 :error
     a dqv:QualityAnnotation ;
     #this annotation is derived by the measurement
@@ -2946,7 +2946,7 @@ a:testingActivity a prov:Activity;
     A general method for assigning an agent to a resource with a specified role is provided by using the qualified form <a href="https://www.w3.org/TR/prov-o/#qualifiedAttribution"><code>prov:qualifiedAttribution</code></a> from [[!PROV-O]].
     The following provides an illustration:
   </p>
-<pre id="ex-qualified-attribution" class="example nohighlight turtle" aria-busy="false" aria-live="polite">
+<pre id="ex-qualified-attribution" class="example nohighlight turtle">
 ex:DS987
   a dcat:Dataset ;
   prov:qualifiedAttribution [
@@ -2990,7 +2990,7 @@ ex:DS987
     A general method for relating a resource to another resource with a specified role is provided by using the qualified form <a href="#Property:resource_qualifiedRelation">dcat:qualifiedRelation</a>.
     The following provides illustrations:
   </p>
-<pre id="ex-dataset-resource" class="example nohighlight turtle" aria-busy="false" aria-live="polite">
+<pre id="ex-dataset-resource" class="example nohighlight turtle">
 ex:Test987
   a dcat:Dataset ;
   dcat:qualifiedRelation [
@@ -3236,7 +3236,7 @@ ex:Test543L
             The dataset is contained in the <code>&lt;/datasets/&gt;</code> LDP Direct Container.
             To ensure the <abbr title="Linked Data Platform Container">LDPC</abbr> discovery, we connect it to the Catalog using the <code>dcat:datasets</code> predicate.
         </p>
-<pre id="ex-ldpc-dataset" class="example nohighlight turtle" aria-busy="false" aria-live="polite">
+<pre id="ex-ldpc-dataset" class="example nohighlight turtle">
 @prefix dcat: &lt;http://www.w3.org/ns/dcat#&gt; .
 @prefix ldp:  &lt;http://www.w3.org/ns/ldp#&gt; .
 
@@ -3255,7 +3255,7 @@ ex:Test543L
 
         <p>In the second example, we add LDPCs <code>&lt;/records/&gt;</code> for Catalog Records and <code>&lt;/services/&gt;</code> for Data Services, discoverable using <code>dcat:records</code> and <code>dcat:services</code> predicates from the Catalog:
         </p>
-<pre id="ex-ldpc-record" class="example nohighlight turtle" aria-busy="false" aria-live="polite">
+<pre id="ex-ldpc-record" class="example nohighlight turtle">
 @prefix dcat: &lt;http://www.w3.org/ns/dcat#&gt; .
 @prefix ldp:  &lt;http://www.w3.org/ns/ldp#&gt; .
 
@@ -3291,7 +3291,7 @@ ex:Test543L
 
         <p>Each dataset has its own LDPC for its distributions.
             In the third example, we show the LDPC <code>&lt;/datasets/001/distributions/&gt;</code> for distributions of a single dataset, <code>&lt;/datasets/001&gt;</code>, discoverable through the <code>dcat:distributions</code> predicate.</p>
-<pre id="ex-ldpc-distribution" class="example nohighlight turtle" aria-busy="false" aria-live="polite">
+<pre id="ex-ldpc-distribution" class="example nohighlight turtle">
 @prefix dcat: &lt;http://www.w3.org/ns/dcat#&gt; .
 @prefix ldp:  &lt;http://www.w3.org/ns/ldp#&gt; .
 
@@ -3377,7 +3377,7 @@ ex:Test543L
             Any resource can have an LDN Inbox.
             In the following example we show a dataset <code>&lt;/datasets/001&gt;</code> as an LDN Target with an LDN Inbox.
         </p>
-<pre id="ex-ldn-dataset" class="example nohighlight turtle" aria-busy="false" aria-live="polite">
+<pre id="ex-ldn-dataset" class="example nohighlight turtle">
 @prefix dcat: &lt;http://www.w3.org/ns/dcat#&gt; .
 @prefix ldp:  &lt;http://www.w3.org/ns/ldp#&gt; .
 
@@ -3695,7 +3695,7 @@ ex:Test543L
       <p>
           If the nature of the relationships between a dataset and component resources in a catalogue, repository, or elsewhere are not known, <code>dct:relation</code> can be used:
       </p>
-<pre id="ex-dataset-as-bag-of-files" class="example nohighlight turtle" aria-busy="false" aria-live="polite">
+<pre id="ex-dataset-as-bag-of-files" class="example nohighlight turtle">
 :d33937
   dct:description "A set of RDF graphs representing the International [Chrono]stratigraphic Chart, ..." ;
   dct:identifier "https://doi.org/10.25919/5b4d2b83cbf2d"^^xsd:anyURI ;
@@ -3715,7 +3715,7 @@ ex:Test543L
           If it is clear that any of these related resources is a proper <i>representation</i> of the dataset, <code>dcat:distribution</code> should be used.
       </p>
 
-<pre id="ex-when-using-distribution" class="example nohighlight turtle" aria-busy="false" aria-live="polite">
+<pre id="ex-when-using-distribution" class="example nohighlight turtle">
 :d33937
   rdf:type dcat:Dataset ;
   dct:description "A set of RDF graphs representing the International [Chrono]stratigraphic Chart, ..." ;
@@ -3759,7 +3759,7 @@ ex:Test543L
         Additional detail about the nature of the related resources can be given using suitable elements from other RDF vocabularies, along with dataset descriptors from DCAT. For example, the example above might be more fully expressed as follows (embedded comments explain the different resources in the graph):
       </p>
 
-            <pre id="ex-elaborated-bag" class="example nohighlight turtle" aria-busy="false" aria-live="polite">
+            <pre id="ex-elaborated-bag" class="example nohighlight turtle">
 dap:d33937
   rdf:type dcat:Dataset ;
   rdfs:comment "The data" ;
@@ -3871,7 +3871,7 @@ dap:d33937
       <p>
           For example, a simple link from a dataset description to the project that generated the dataset can be formalized as follows (other details elided for clarity):
       </p>
-<pre id="ex-dataset-project" class="example nohighlight turtle" aria-busy="false" aria-live="polite">
+<pre id="ex-dataset-project" class="example nohighlight turtle">
 dap:atnf-P366-2003SEPT
 rdf:type dcat:Dataset ;
 dct:bibliographicCitation "Burgay, M; McLaughlin, M; Kramer, M; Lyne, A; Joshi, B; Pearce, G; D'Amico, N; Possenti, A; Manchester, R; Camilo, F (2017): Parkes observations for project P366 semester 2003SEPT. v1. CSIRO. Data Collection. https://doi.org/10.4225/08/598dc08d07bb7" ;
@@ -3928,7 +3928,7 @@ rdfs:seeAlso &lt;https://doi.org/10.1111/j.1365-2966.2006.10100.x&gt; ;
       <p>
           This example is available from the <a href="https://github.com/w3c/dxwg/tree/gh-pages/dcat/examples">DXWG code repository</a> at <a href="https://raw.githubusercontent.com/w3c/dxwg/gh-pages/dcat/examples/eea-csw.ttl">eea-csw.ttl</a>
       </p>
-<pre id="ex-service-eea" class="example nohighlight turtle" aria-busy="false" aria-live="polite">
+<pre id="ex-service-eea" class="example nohighlight turtle">
 a:EEA-CSW-Endpoint
 rdf:type dcat:DataService ;
 dc:subject "infoCatalogueService"@en ;
@@ -3959,7 +3959,7 @@ dcat:endpointURL &lt;http://sdi.eea.europa.eu/catalogue/srv/eng/csw&gt; ;
           This example is available from the <a href="https://github.com/w3c/dxwg/tree/gh-pages/dcat/examples">DXWG code repository</a> at <a href="https://raw.githubusercontent.com/w3c/dxwg/gh-pages/dcat/examples/ga-courts.ttl">ga-courts.ttl</a>
       </p>
 
-<pre id="ex-service-gsa" class="example nohighlight turtle" aria-busy="false" aria-live="polite">
+<pre id="ex-service-gsa" class="example nohighlight turtle">
 ga-courts:jc
 rdf:type dcat:Dataset ;
 dct:description "The dataset contains spatial locations, in point format, of the Australian High Court, Australian Federal Courts and the Australian Magistrates Courts." ;
@@ -4022,7 +4022,7 @@ dcat:servesDataset ga-courts:jc ;
         <p>The first example is for a distribution with a downloadable file that is compressed into a GZIP file.
         </p>
 
-        <pre id="compressed-distribution" class="example nohighlight turtle" aria-busy="false" aria-live="polite">
+        <pre id="compressed-distribution" class="example nohighlight turtle">
 
         @prefix dcat: &lt;http://www.w3.org/ns/dcat#&gt; .
         @prefix dct: &lt;http://purl.org/dc/terms/&gt; .
@@ -4041,7 +4041,7 @@ dcat:servesDataset ga-courts:jc ;
         <p>The second example is for a distribution with several files packed into a TAR file.
         </p>
 
-        <pre id="packaged-distribution" class="example nohighlight turtle" aria-busy="false" aria-live="polite">
+        <pre id="packaged-distribution" class="example nohighlight turtle">
 
           @prefix dcat: &lt;http://www.w3.org/ns/dcat#> .
           @prefix dct: &lt;http://purl.org/dc/terms/> .
@@ -4060,7 +4060,7 @@ dcat:servesDataset ga-courts:jc ;
         <p>The third example is for a distribution with several files packed into a TAR file which has been compressed into a GZIP file.
         </p>
 
-        <pre id="packaged-and-compressed-distribution" class="example nohighlight turtle" aria-busy="false" aria-live="polite">
+        <pre id="packaged-and-compressed-distribution" class="example nohighlight turtle">
 
           @prefix dcat: &lt;http://www.w3.org/ns/dcat#&gt; .
           @prefix dct: &lt;http://purl.org/dc/terms/&gt; .
@@ -4077,7 +4077,7 @@ dcat:servesDataset ga-courts:jc ;
 
         </pre>
         <p>
-            These examples are available from the <a href="https://github.com/w3c/dxwg/tree/gh-pages/dcat/examples">DXWG code repository</a> at <a href="https://raw.githubusercontent.com/w3c/dxwg/gh-pages/dcat/examples/compress-and-package.ttl">compress-and-package.ttl</a>
+            These examples are available from the <a href="https://github.com/w3c/dxwg/tree/gh-pages/dcat/examples">DXWG code repository</a> at <a href="https://raw.githubusercontent.com/w3c/dxwg/gh-pages/dcat/examples/compress-and-package.ttl"><code>compress-and-package.ttl</code></a>
         </p>
 
   </section>

--- a/dcat/index.html
+++ b/dcat/index.html
@@ -4238,7 +4238,7 @@ dcat:servesDataset ga-courts:jc ;
             </li>
             <li>
                 Each relevant class section was extended with properties to deal with licensing, acccess rights, other rights and policies associated with the classes, as
-                recommended in the  <a href="#license-rights">License and rights statements</a> section.
+                recommended in <a href="#license-rights"></a>.
             </li>
         </ul>
 

--- a/dcat/index.html
+++ b/dcat/index.html
@@ -50,7 +50,7 @@ $(document).ready( function() {
         Aggregated DCAT metadata can serve as a manifest file as part of the digital preservation process.</p>
     <p style="text-indent: 100px;">The namespace for DCAT terms is <code>http://www.w3.org/ns/dcat#</code></p>
     <p style="text-indent: 100px;">The suggested prefix for the DCAT namespace is <code>dcat</code></p>
-    <p style="text-indent: 100px;">The (revised) DCAT vocabulary is available <a href="https://raw.githubusercontent.com/w3c/dxwg/gh-pages/dcat/rdf/dcat.ttl">here</a>.</p>
+    <p style="text-indent: 100px;">The (revised) DCAT vocabulary is available <a href="https://w3c.github.io/dxwg/dcat/rdf/dcat.ttl">here</a>.</p>
 </section>
 
 <section id="sotd">
@@ -312,7 +312,7 @@ $(document).ready( function() {
       </p>
     </div>
 
-    <p>A <b>CatalogRecord</b> describes an entry in the catalog. Notice that while <a href="#Class:Resource"><code>dcat:Resource</code></a> represents the dataset or service itself, <a href="#Class:Catalog_Record"><code>dcat:CatalogRecord</code></a> is the record that describes the registration of an item in the catalog. The use of explicit <a href="#Class:Catalog_Record"><code>dcat:CatalogRecord</code></a> is considered optional. It is used to capture provenance information about entries in a catalog explicitly. If this is not necessary then <a href="#Class:Catalog_Record"><code>dcat:CatalogRecord</code></a> can be safely ignored.</p>
+    <p>A <b>catalog record</b> describes an entry in the catalog. Notice that while <a href="#Class:Resource"><code>dcat:Resource</code></a> represents the dataset or service itself, <a href="#Class:Catalog_Record"><code>dcat:CatalogRecord</code></a> is the record that describes the registration of an item in the catalog. The use of <a href="#Class:Catalog_Record"><code>dcat:CatalogRecord</code></a> is considered optional. It is used to capture provenance information about entries in a catalog explicitly. If this is not necessary then <a href="#Class:Catalog_Record"><code>dcat:CatalogRecord</code></a> can be safely ignored.</p>
   </section>
   <section id="dcat-rdf">
     <h3>RDF considerations</h3>
@@ -620,7 +620,7 @@ $(document).ready( function() {
                 Guidance on the use DCAT in a weakly-axiomatized environment, such as schema.org, has been identified as a requirement to be satisfied in this revision of DCAT.
             </p>
             <p>
-                An <a href="https://raw.githubusercontent.com/w3c/dxwg/gh-pages/dcat/rdf/dcat-schema.ttl">RDF graph containing a proposed alignment of DCAT with schema.org</a> is available. Comments on this alignment are invited.
+                An <a href="https://w3c.github.io/dxwg/dcat/rdf/dcat-schema.ttl">RDF graph containing a proposed alignment of DCAT with schema.org</a> is available. Comments on this alignment are invited.
             </p>
         </div-->
 
@@ -633,7 +633,7 @@ $(document).ready( function() {
         </p-->
 
         <p>The (revised) DCAT vocabulary is <a href="https://github.com/w3c/dxwg/tree/gh-pages/dcat/rdf/">available in RDF</a>.
-            The primary artefact <a href="https://raw.githubusercontent.com/w3c/dxwg/gh-pages/dcat/rdf/dcat.ttl">dcat.ttl</a> is a serialization of the core DCAT vocabulary.
+            The primary artefact <a href="https://w3c.github.io/dxwg/dcat/rdf/dcat.ttl">dcat.ttl</a> is a serialization of the core DCAT vocabulary.
             Alongside it are a set of other RDF files that provide additional information, including:</p>
         <ol>
             <li>
@@ -1048,12 +1048,11 @@ $(document).ready( function() {
                 <thead><tr><th>RDF Property:</th><th><a href="http://purl.org/dc/terms/language">dct:language</a></th></tr></thead>
                 <tbody>
                 <tr><td class="prop">Definition:</td><td>A language of the item. This refers to the natural language used for textual metadata (i.e. titles, descriptions, etc) of a catalogued resource (i.e. dataset or service) or the textual values of a dataset distribution</td></tr>
-                <tr><td class="prop">Range:</td><td><a href="http://purl.org/dc/terms/LinguisticSystem"><code>dct:LinguisticSystem</code></a>
-                    <br>
-                    Resources defined by the Library of Congress (<a href="http://id.loc.gov/vocabulary/iso639-1.html">1</a>,
-                    <a href="http://id.loc.gov/vocabulary/iso639-2.html">2</a>) SHOULD be used.
-                    <br>
-                    If a ISO 639-1 (two-letter) code is defined for language, then its corresponding IRI SHOULD be used; if no ISO 639-1 code is defined, then IRI corresponding to the ISO 639-2 (three-letter) code SHOULD be used.</td></tr>
+                <tr><td class="prop">Range:</td><td>
+                <p><a href="http://purl.org/dc/terms/LinguisticSystem"><code>dct:LinguisticSystem</code></a></p>
+                <p>Resources defined by the Library of Congress (<a href="http://id.loc.gov/vocabulary/iso639-1.html">ISO 639-1</a>, <a href="http://id.loc.gov/vocabulary/iso639-2.html">ISO 639-2</a>) SHOULD be used.</p>
+                <p>If a ISO 639-1 (two-letter) code is defined for language, then its corresponding IRI SHOULD be used; if no ISO 639-1 code is defined, then IRI corresponding to the ISO 639-2 (three-letter) code SHOULD be used.</p>
+                </td></tr>
                 <tr><td class="prop">Usage note:</td><td>Repeat this property if the resource is available in multiple languages.</td></tr>
                 <tr><td class="prop">Usage note:</td><td>The value(s) provided for members of a catalog (i.e. dataset or service) override the value(s) provided for the catalog if they conflict.</td></tr>
                 <tr><td class="prop">Usage note:</td><td>If representations of a dataset are available for each language separately, define an instance of <code>dcat:Distribution</code> for each language and describe the specific language of each distribution using <code>dct:language</code> (i.e. the dataset will have multiple <code>dct:language</code> values and each distribution will have just one as the value of its <code>dct:language</code> property).</td></tr>
@@ -1534,7 +1533,7 @@ $(document).ready( function() {
 
         <!--backlog p class="issue" data-number="76">
             The need provide a more comprehensive method for describing dataset provenance has been identified as a requirement to be satisfied in the revision of DCAT.
-            A preliminary <a href="https://raw.githubusercontent.com/w3c/dxwg/gh-pages/dcat/rdf/dcat-prov.ttl">alignment of DCAT with PROV-O is available</a>.
+            A preliminary <a href="https://w3c.github.io/dxwg/dcat/rdf/dcat-prov.ttl">alignment of DCAT with PROV-O is available</a>.
         </p-->
 
         <!--backlog p class="issue" data-number="84">
@@ -1748,7 +1747,7 @@ $(document).ready( function() {
             <a href="#Property:distribution_description">description</a>,
             <a href="#Property:distribution_downloadurl">download URL</a>,
             <a href="#Property:distribution_format">format</a>,
-            <a href="#Property:distribution_hasPolicy">has Policy</a>,
+            <a href="#Property:distribution_hasPolicy">has policy</a>,
             <a href="#Property:distribution_license">license</a>,
             <a href="#Property:distribution_media_type">media type</a>,
             <a href="#Property:distribution_packaging_format">packaging format</a>,
@@ -1877,10 +1876,10 @@ $(document).ready( function() {
                 <tbody>
                 <tr><td class="prop">Definition:</td><td>Information about rights held in and over the distribution.</td></tr>
                 <tr><td class="prop">Range:</td><td><a href="http://purl.org/dc/terms/RightsStatement"><code>dct:RightsStatement</code></a></td></tr>
-                <tr><td class="prop">Usage note:</td><td><code>dct:license</code>, which is a sub-property of <code>dct:rights</code>, can be used to link
-                    a distribution to a license document. However, <code>dct:rights</code> allows linking to a rights statement that
-                    can include licensing information as well as other information that supplements the license such as attribution.<br/>
-                    Information about licenses and rights SHOULD be provided on the level of Distribution. Information about licenses and rights MAY be provided for a Dataset in addition to but not instead of the information provided for the Distributions of that Dataset. Providing license or rights information for a Dataset that is different from information provided for a Distribution of that Dataset SHOULD be avoided as this can create legal conflicts. See also guidance at <a href="#license-rights"></a>.</td></tr>
+                <tr><td class="prop">Usage note:</td><td>
+                <p><code>dct:license</code>, which is a sub-property of <code>dct:rights</code>, can be used to link a distribution to a license document. However, <code>dct:rights</code> allows linking to a rights statement that can include licensing information as well as other information that supplements the license such as attribution.</p>
+                <p>Information about licenses and rights SHOULD be provided on the level of Distribution. Information about licenses and rights MAY be provided for a Dataset in addition to but not instead of the information provided for the Distributions of that Dataset. Providing license or rights information for a Dataset that is different from information provided for a Distribution of that Dataset SHOULD be avoided as this can create legal conflicts. See also guidance at <a href="#license-rights"></a>.</p>
+                </td></tr>
                 <tr><td class="prop">See also:</td><td><a href="#Property:distribution_license" title="">distribution license</a>,
                     <a href="#Property:resource_rights" title="">resource rights</a></td></tr>
                 </tbody>
@@ -1915,9 +1914,10 @@ $(document).ready( function() {
                 <tr><td class="prop">Definition:</td><td>A URL of the resource that gives access to a distribution of the dataset. E.g. landing page, feed, SPARQL endpoint.</td></tr>
                 <tr><td class="prop">Domain:</td><td><a href="#Class:Distribution"><code>dcat:Distribution</code></a></td></tr>
                 <tr><td class="prop">Range:</td><td><a href="http://www.w3.org/2000/01/rdf-schema#Resource"><code>rdfs:Resource</code></a></td></tr>
-                <tr><td class="prop">Usage note:</td><td><a href="#Property:distribution_accessurl"><code>dcat:accessURL</code></a> SHOULD be used for the URL of a service or location that can provide access to this distribution, typically through a web form, query or API call.
-                    <br/><a href="#Property:distribution_downloadurl"><code>dcat:downloadURL</code></a> is preferred for direct links to downloadable resources.
-                    <br/>If the distribution(s) are accessible only through a landing page (i.e. direct download URLs are not known), then the landing page URL associated with the <code>dcat:Dataset</code> SHOULD be duplicated as access URL on a distribution (see <a href="#example-landing-page"></a>).
+                <tr><td class="prop">Usage note:</td><td>
+                <p><a href="#Property:distribution_accessurl"><code>dcat:accessURL</code></a> SHOULD be used for the URL of a service or location that can provide access to this distribution, typically through a web form, query or API call.</p>
+                <p><a href="#Property:distribution_downloadurl"><code>dcat:downloadURL</code></a> is preferred for direct links to downloadable resources.</p>
+                <p>If the distribution(s) are accessible only through a landing page (i.e. direct download URLs are not known), then the landing page URL associated with the <code>dcat:Dataset</code> SHOULD be duplicated as access URL on a distribution (see <a href="#example-landing-page"></a>).</p>
                 </td></tr>
                 <tr><td class="prop">See also</td><td><a href="#Property:distribution_downloadurl">download URL</a>, <a href="#Property:distribution_accessservice">access service</a></td></tr>
                 </tbody>
@@ -2153,17 +2153,17 @@ $(document).ready( function() {
             <thead><tr><th>RDF Class:</th><th><a href="http://www.w3.org/ns/dcat#DataService">dcat:DataService</a></th></tr></thead>
             <tbody>
             <tr><td class="prop">Definition:</td><td>A site or end-point providing operations related to the discovery of, access to, or processing functions on, data or related resources</td></tr>
-            <tr><td class="prop">Sub class of:</td><td><a href="#Class:Resource">dcat:Resource</a></td></tr>
-            <tr><td class="prop">Sub class of:</td><td><a href="http://purl.org/dc/dcmitype/Service">dctype:Service</a></td></tr>
+            <tr><td class="prop">Sub class of:</td><td><a href="#Class:Resource"><code>dcat:Resource</code></a></td></tr>
+            <tr><td class="prop">Sub class of:</td><td><a href="http://purl.org/dc/dcmitype/Service"><code>dctype:Service</code></a></td></tr>
             <tr><td class="prop">Usage note:</td><td>If a  <a href="#Class:Data_Service"><code>dcat:DataService</code></a> is bound to one or more specified Datasets, they are indicated by the dcat:servesDataset property.</td></tr>
-            <tr><td class="prop">Usage note:</td><td>The kind of service can be indicated using the <a href="http://purl.org/dc/terms/type">dct:type</a> property. Its value may be taken from a controlled vocabulary such as the <a href="https://inspire.ec.europa.eu/metadata-codelist/SpatialDataServiceType/">INSPIRE spatial data service type vocabulary</a></td></tr>.
+            <tr><td class="prop">Usage note:</td><td>The kind of service can be indicated using the <a href="http://purl.org/dc/terms/type"><code>dct:type</code></a> property. Its value may be taken from a controlled vocabulary such as the <a href="https://inspire.ec.europa.eu/metadata-codelist/SpatialDataServiceType/">INSPIRE spatial data service type vocabulary</a></td></tr>.
             </tbody>
         </table>
 
         <section id="Property:dataservice_endpointurl">
             <h4>Property: endpoint URL</h4>
             <table class="definition">
-                <thead><tr><th>RDF Property:</th><th><a href="http://www.w3.org/ns/dcat#endpointURL">dcat:endpointURL</a></th></tr></thead>
+                <thead><tr><th>RDF Property:</th><th><a href="http://www.w3.org/ns/dcat#endpointURL"><code>dcat:endpointURL</code></a></th></tr></thead>
                 <tbody>
                 <tr><td class="prop">Definition:</td><td>The location of the service end-point (an IRI).</td></tr>
                 <tr><td class="prop">Domain:</td><td><a href="#Class:Data_Service"><code>dcat:DataService</code></a> </td></tr>
@@ -2178,7 +2178,7 @@ $(document).ready( function() {
                 <thead><tr><th>RDF Property:</th><th><a href="http://www.w3.org/ns/dcat#endpointDescription">dcat:endpointDescription</a></th></tr></thead>
                 <tbody>
                 <tr><td class="prop">Definition:</td><td>A description of the service end-point, including its operations, parameters etc.</td></tr>
-                <tr><td class="prop">Domain:</td><td><a href="#Class:Data_Service">dcat:DataService</a> </td></tr>
+                <tr><td class="prop">Domain:</td><td><a href="#Class:Data_Service"><code>dcat:DataService</code></a> </td></tr>
                 <tr><td class="prop">Range:</td><td><a href="http://www.w3.org/2000/01/rdf-schema#Resource"><code>rdfs:Resource</code></a> </td></tr>
                 <tr><td class="prop">Usage note:</td><td>The endpoint description gives specific details of the actual endpoint instance, while <a href="#Property:resource_conformsto"><code>dct:conformsTo</code></a> is used to indicate the general standard or specification that the endpoint implements.</td></tr>
                 <tr><td class="prop">Usage note:</td><td>An endpoint description may be expressed in a machine-readable form, such as an OpenAPI (Swagger) description [[?OpenAPI]], an OGC getCapabilities response [[?WFS]], [[?ISO-19142]], [[?WMS]], [[?ISO-19128]], a SPARQL Service Description [[?SPARQL11-SERVICE-DESCRIPTION]], an [[?OpenSearch]] or [[?WSDL20]] document, a Hydra API description [[?HYDRA]], else in text or some other informal mode if a formal representation is not possible.</td></tr>
@@ -2432,7 +2432,7 @@ end class DiscoveryService -->
               <tr><td class="prop">Definition:</td><td>The function of an entity or agent with respect to another entity or resource.</td></tr>
               <tr><td class="prop">Domain:</td><td><a href="http://www.w3.org/ns/prov#Attribution"><code>prov:Attribution</code></a> or <a href="#Class:Relationship"><code>dcat:Relationship</code></a></td></tr>
               <tr><td class="prop">Range:</td><td><a href="http://www.w3.org/ns/prov#Role"><code>dcat:Role</code></a></td></tr>
-              <tr><td class="prop">Usage note:</td><td>May be used in a qualified-attribution to specify the role of an Agent with respect to an Entity. It is recommended that the value be taken from a controlled vocabulary of agent roles, such as <a href="http://registry.it.csiro.au/def/isotc211/CI_RoleCode">ISO 19115 CI_RoleCode</a>.</td></tr>
+              <tr><td class="prop">Usage note:</td><td>May be used in a qualified-attribution to specify the role of an Agent with respect to an Entity. It is recommended that the value be taken from a controlled vocabulary of agent roles, such as [[?ISO-19115]] <a href="http://registry.it.csiro.au/def/isotc211/CI_RoleCode"><code>CI_RoleCode</code></a>.</td></tr>
               <tr><td class="prop">Usage note:</td><td>May be used in a qualified-relation to specify the role of an Entity with respect to another Entity. It is recommended that the value be taken from a controlled vocabulary of entity roles.</td></tr>
               </tbody>
             </table>
@@ -2456,13 +2456,17 @@ end class DiscoveryService -->
             <tbody>
             <tr><td class="prop">Definition:</td><td>A role is the function of a resource or agent with respect to another resource, in the context of resource attribution or resource relationships.</td></tr>
             <tr><td class="prop">Sub class of:</td><td><a href="http://www.w3.org/2004/02/skos/core#Concept"><code>skos:Concept</code></a></td></tr>
-            <tr><td class="prop">Usage note:</td><td>Used in a qualified-attribution to specify the role of an Agent with respect to an Entity. It is recommended that the values be managed as a controlled vocabulary of agent roles, such as <a href="http://registry.it.csiro.au/def/isotc211/CI_RoleCode">ISO 19115 CI_RoleCode</a> </td></tr>
-            <tr><td class="prop">Usage note:</td><td>Used in a qualified-relation to specify the role of an Entity with respect to another Entity.
-            It is recommended that the values be managed as a controlled vocabulary of entity roles such as
-            <br/>- <a href="http://registry.it.csiro.au/def/isotc211/DS_AssociationTypeCode">ISO 19115 DS_AssociationTypeCode</a>
-            <br/>- <a href="https://www.iana.org/assignments/link-relations">IANA Registry of Link Relations</a>
-            <br/>- DataCite metadata schema [[?DataCite]]
-            <br/>- <a href="https://id.loc.gov/vocabulary/relators">MARC relators</a> </td></tr>
+            <tr><td class="prop">Usage note:</td><td>Used in a qualified-attribution to specify the role of an Agent with respect to an Entity. It is recommended that the values be managed as a controlled vocabulary of agent roles, such as [[?ISO-19115-1]] <a href="http://registry.it.csiro.au/def/isotc211/CI_RoleCode"><code>CI_RoleCode</code></a> </td></tr>
+            <tr><td class="prop">Usage note:</td><td>
+            <p>Used in a qualified-relation to specify the role of an Entity with respect to another Entity.
+            It is recommended that the values be managed as a controlled vocabulary of entity roles such as</p>
+            <ul>
+            <li>[[?ISO-19115-1]] <a href="http://registry.it.csiro.au/def/isotc211/DS_AssociationTypeCode"><code>DS_AssociationTypeCode</code></a></li>
+            <li>IANA Registry of Link Relations [[?IANA-RELATIONS]]</li>
+            <li>DataCite metadata schema [[?DataCite]]</li>
+            <li><a href="https://id.loc.gov/vocabulary/relators">MARC relators</a></li>
+            </ul>
+            </td></tr>
             </tbody>
         </table>
         <p>
@@ -2911,14 +2915,14 @@ a:testingActivity a prov:Activity;
   <h2>Qualified relations</h2>
 
   <p>
-    DCAT includes elements to support description of many aspects of datasets and data-services. Nevertheless, additional information is required in order to fully express the semantics of some relationships. An example is that, while Dublin Core [[!DC11]] provides the standard roles <b>creator</b>, <b>contributor</b> and <b>publisher</b> for attribution of a resource to a responsible party or agent, there are many other potential roles, see for example the CI_RoleCode values from [[?ISO-19115-1]]. Similarly, while Dublin Core and [[!PROV-O]] provide some properties to capture relationships between resources, including <b>was derived from</b>, <b>was quoted from</b>, <b>is version of</b>, <b>references</b> and several others, many additional concerns are seen in the list of <a href="http://registry.it.csiro.au/def/isotc211/DS_AssociationTypeCode">ISO 19115 DS_AssociationTypeCodes</a>, the <a href="https://www.iana.org/assignments/link-relations">IANA Registry of Link Relations</a>, the DataCite metadata schema [[?DataCite]]
-    <br/> and the <a href="https://id.loc.gov/vocabulary/relators">MARC relators</a>. While these relations could be captured with additional sub-properties of <code>dct:relation</code>, <code>dct:contributor</code>, etc, this would lead to an explosion in the number of properties, and anyway the full set of potential roles and relationships is unknown.
+    DCAT includes elements to support description of many aspects of datasets and data-services. Nevertheless, additional information is required in order to fully express the semantics of some relationships. An example is that, while [[!DCTERMS]] provides the standard roles <b>creator</b>, <b>contributor</b> and <b>publisher</b> for attribution of a resource to a responsible party or agent, there are many other potential roles, see for example the <code>CI_RoleCode</code> values from [[?ISO-19115-1]]. Similarly, while [[!DCTERMS]] and [[!PROV-O]] provide some properties to capture relationships between resources, including <b>was derived from</b>, <b>was quoted from</b>, <b>is version of</b>, <b>references</b> and several others, many additional concerns are seen in the list of [[?ISO-19115-1]] <a href="http://registry.it.csiro.au/def/isotc211/DS_AssociationTypeCode"><code>DS_AssociationTypeCodes</code></a>, the IANA Registry of Link Relations [[?IANA-RELATIONS]], the DataCite metadata schema [[?DataCite]]
+    and the <a href="https://id.loc.gov/vocabulary/relators">MARC relators</a>. While these relations could be captured with additional sub-properties of <code>dct:relation</code>, <code>dct:contributor</code>, etc, this would lead to an explosion in the number of properties, and anyway the full set of potential roles and relationships is unknown.
   </p>
   <p>
-    A common approach for meeting these kinds of requirement is to introduce an additional resource to carry parameters that qualify the relationship. Precedents are the <a data-cite="PROV-O#description-qualified-terms">qualified terms</a> in [[?PROV-O]] and the <a data-cite="VOCAB-SSN#Sample_Relations">sample relations</a> in the Semantic Sensor Network ontology [[?VOCAB-SSN]]. The general <a href="http://patterns.dataincubator.org/book/qualified-relation.html">Qualified Relation pattern</a> is described in [[?LinkedDataPatterns]].
+    A common approach for meeting these kinds of requirement is to introduce an additional resource to carry parameters that qualify the relationship. Precedents are the <a data-cite="?PROV-O#description-qualified-terms">qualified terms</a> in [[?PROV-O]] and the <a data-cite="?VOCAB-SSN#Sample_Relations">sample relations</a> in the Semantic Sensor Network ontology [[?VOCAB-SSN]]. The general <a href="http://patterns.dataincubator.org/book/qualified-relation.html">Qualified Relation pattern</a> is described in [[?LinkedDataPatterns]].
   </p>
   <p>
-    Many of the qualified terms from [[!PROV-O]] are relevant to the description of resources in catalogs but these are incomplete due to the activity-centric viewpoint taken by PROV-O. Addressing some of the gaps, additional forms are included in the DCAT vocabulary to satisfy requirements that do not involve explicit Activities. These are summarized in <a href="#UML-DCAT-Qualified-Relations"></a>:
+    Many of the qualified terms from [[!PROV-O]] are relevant to the description of resources in catalogs but these are incomplete due to the activity-centric viewpoint taken by PROV-O. Addressing some of the gaps, additional forms are included in the DCAT vocabulary to satisfy requirements that do not involve explicit activities. These are summarized in <a href="#UML-DCAT-Qualified-Relations"></a>:
   </p>
 
   <figure id="UML-DCAT-Qualified-Relations"><img alt="UML model of DCAT qualified relationships" src="UML/DCAT-Relationships.png">
@@ -2938,9 +2942,9 @@ a:testingActivity a prov:Activity;
 <section id="qualified-attribution">
   <h3>Relationships between datasets and agents</h3>
   <p>
-    The standard [[?DCTERMS]] properties <a href="http://purl.org/dc/terms/contributor"><code>dct:contributor</code></a>, <a href="http://purl.org/dc/terms/creator"><code>dct:creator</code></a> and <a href="http://purl.org/dc/terms/publisher"><code>dct:publisher</code></a> [[!DC11]], and the generic <a href="https://www.w3.org/TR/prov-o/#wasAttributedTo"><code>prov:wasAttributedTo</code></a> from [[!PROV-O]], support basic associations of responsible agents with a catalogued resource.
+    The standard [[!DCTERMS]] properties <a href="http://purl.org/dc/terms/contributor"><code>dct:contributor</code></a>, <a href="http://purl.org/dc/terms/creator"><code>dct:creator</code></a> and <a href="http://purl.org/dc/terms/publisher"><code>dct:publisher</code></a>, and the generic <a href="https://www.w3.org/TR/prov-o/#wasAttributedTo"><code>prov:wasAttributedTo</code></a> from [[!PROV-O]], support basic associations of responsible agents with a catalogued resource.
     However, there are many other roles of importance in relation to datasets and services - e.g. funder, distributor, custodian, editor.
-    Some of these roles are enumerated in the CI_RoleCode values from [[?ISO-19115-1]], in the [[?DataCite]] metadata schema, and included within the <a href="https://id.loc.gov/vocabulary/relators">MARC relators</a>.
+    Some of these roles are enumerated in the <code>CI_RoleCode</code> values from [[?ISO-19115-1]], in the [[?DataCite]] metadata schema, and included within the <a href="https://id.loc.gov/vocabulary/relators">MARC relators</a>.
   </p>
   <p>
     A general method for assigning an agent to a resource with a specified role is provided by using the qualified form <a href="https://www.w3.org/TR/prov-o/#qualifiedAttribution"><code>prov:qualifiedAttribution</code></a> from [[!PROV-O]].
@@ -2984,10 +2988,10 @@ ex:DS987
     <a href="http://www.w3.org/ns/prov#wasQuotedFrom"><code>prov:wasQuotedFrom</code></a>,
     support the description of relationships between datasets and other catalogued resources.    
     However, there are many other relationships of importance - e.g. alternate, canonical, original, preview, stereo-mate, working-copy-of.
-    Some of these roles are enumerated in the DS_AssociationTypeCode values from [[?ISO-19115-1]], the <a href="https://www.iana.org/assignments/link-relations">IANA Registry of Link Relations</a>, in the [[?DataCite]] metadata schema, and included within the <a href="https://id.loc.gov/vocabulary/relators">MARC relators</a>.
+    Some of these roles are enumerated in the <code>DS_AssociationTypeCode</code> values from [[?ISO-19115-1]], the IANA Registry of Link Relations [[?IANA-RELATIONS]], in the [[?DataCite]] metadata schema, and included within the <a href="https://id.loc.gov/vocabulary/relators">MARC relators</a>.
   <p>
   <p>
-    A general method for relating a resource to another resource with a specified role is provided by using the qualified form <a href="#Property:resource_qualifiedRelation">dcat:qualifiedRelation</a>.
+    A general method for relating a resource to another resource with a specified role is provided by using the qualified form <a href="#Property:resource_qualifiedRelation"><code>dcat:qualifiedRelation</code></a>.
     The following provides illustrations:
   </p>
 <pre id="ex-dataset-resource" class="example nohighlight turtle">
@@ -3011,8 +3015,8 @@ ex:Test543L
 </pre>
 
 <p class="note">
-  The property <a href="#Property:resource_qualifiedRelation">dcat:qualifiedRelation</a> and association-class <a href="#Class:Relationship">dcat:Relationship</a> follow the pattern established in W3C [[!PROV-O]] and described in the section <a href="https://www.w3.org/TR/prov-o/#description-qualified-terms">Qualified Terms</a>.
-  However, PROV-O is activity-centric, and does not support Entity-Entity relations except for the single case of 'was derived from', thus necessitating the new elements shown here to support the general case.
+  The property <a href="#Property:resource_qualifiedRelation"><code>dcat:qualifiedRelation</code></a> and association-class <a href="#Class:Relationship"><code>dcat:Relationship</code></a> follow the pattern established in W3C [[!PROV-O]] and described in the section <a href="https://www.w3.org/TR/prov-o/#description-qualified-terms">Qualified Terms</a>.
+  However, [[!PROV-O]] is activity-centric, and does not support Entity-Entity relations except for the single case of 'was derived from', thus necessitating the new elements shown here to support the general case.
 </p>
 </section>
 
@@ -3037,7 +3041,7 @@ ex:Test543L
 
     Many of the requirements can be satisfied by using capabilities from the [[?PROV-O]] ontology,
     in particular by treating <a href="#Class:Resource"><code>dcat:Resource</code></a> and/or <a href="#Class:Catalog_Record"><code>dcat:CatalogRecord</code></a> a sub-class of <a href="http://www.w3.org/ns/prov#Entity"><code>prov:Entity</code></a>.
-    See <a href="https://github.com/w3c/dxwg/issues/128">Issue #128</a> for the relevant discussion. A preliminary <a href="https://raw.githubusercontent.com/w3c/dxwg/gh-pages/dcat/rdf/dcat-prov.ttl">alignment of DCAT with PROV-O is available</a>.
+    See <a href="https://github.com/w3c/dxwg/issues/128">Issue #128</a> for the relevant discussion. A preliminary <a href="https://w3c.github.io/dxwg/dcat/rdf/dcat-prov.ttl">alignment of DCAT with PROV-O is available</a>.
     See the wiki page on <a href="https://github.com/w3c/dxwg/wiki/Provenance-patterns">Provenance Patterns</a> for more discussion.
 
 </section>
@@ -3083,7 +3087,7 @@ ex:Test543L
 	</p>
 
 	<p class="note">
-	  The provision of licensing conditions and access rights complies with the Best Practices 4 ("<a data-cite="DWBP#licenses">Provide data license information</a>") and 22. ("<a data-cite="DWBP#DataUnavailabilityReference">Provide an explanation for data that is not available</a>"), respectively, from [[DWBP]].
+	  The provision of licensing conditions and access rights complies with the Best Practices 4 ("<a data-cite="DWBP#licenses">Provide data license information</a>") and 22 ("<a data-cite="DWBP#DataUnavailabilityReference">Provide an explanation for data that is not available</a>"), respectively, from [[DWBP]].
 	</p>
 
 	<p>
@@ -3091,7 +3095,7 @@ ex:Test543L
   </p>
 		<ol>
 			<li>
-			  <p>use <a href="http://dublincore.org/documents/dcmi-terms/#terms-license"><code>dct:license</code></a> to refer to licenses;</p>
+			  <p>use <a data-cite="?DCTERMS#terms-license"><code>dct:license</code></a> to refer to licenses;</p>
 <!--
 			<p>The object of <code>dct:license</code>, a <a href="http://dublincore.org/documents/dcmi-terms/#terms-LicenseDocument"><code>dct:LicenseDocument</code></a>, is "A legal document giving official permission to do something with a Resource."</p>
 -->
@@ -3100,7 +3104,7 @@ ex:Test543L
         </p>
 			</li>
 			<li>
-			  <p>use <a href="http://dublincore.org/documents/dcmi-terms/#terms-accessRights"><code>dct:accessRights</code></a>  to express statements concerning only access rights (e.g., whether data can be accessed by anyone or just by authorized parties);</p>
+			  <p>use <a data-cite="?DCTERMS#terms-accessRights"><code>dct:accessRights</code></a>  to express statements concerning only access rights (e.g., whether data can be accessed by anyone or just by authorized parties);</p>
 <!--
         <p>The object of <code>dct:accessRights</code> is a <code>dct:RightsStatement</code> providing "Information about who can access the resource or an indication of its security status."</p>
 -->
@@ -3109,7 +3113,7 @@ ex:Test543L
         </p>
       </li>
 			<li>
-			  <p>use <a href="http://dublincore.org/documents/dcmi-terms/#terms-rights"><code>dct:rights</code></a> for all the other types of rights statements - those which are not covered by <code>dct:license</code> and <code>dct:accessRights</code>, such as copyright statements.</p>
+			  <p>use <a data-cite="?DCTERMS#terms-rights"><code>dct:rights</code></a> for all the other types of rights statements - those which are not covered by <code>dct:license</code> and <code>dct:accessRights</code>, such as copyright statements.</p>
 <!--
 			  <p>The object of <code>dct:rights</code>, a <a href="http://dublincore.org/documents/dcmi-terms/#terms-RightsStatement"><code>dct:RightsStatement</code></a>, is "A statement about the intellectual property rights (IPR) held in or over a Resource, a legal document giving official permission to do something with a resource, or a statement about access rights."
 			This is more general than a <a href="http://dublincore.org/documents/dcmi-terms/#terms-LicenseDocument"><code>dct:LicenseDocument</code></a> and therefore should be used if it the statement contains more general information about rights.</p>
@@ -3120,7 +3124,7 @@ ex:Test543L
 			</li>
 		</ol>
 
-	<p>Finally, in the particular case when rights are expressed via <a href="https://www.w3.org/TR/odrl-vocab/#term-Policy">ODRL policies</a>, it is recommended to use use the <a href="https://www.w3.org/TR/odrl-vocab/#term-hasPolicy"><code>odrl:hasPolicy</code></a> property as the link from the description of the catalogued resource or distribution to the ODRL policy, in addition to the relevant <code>dct</code> property.</p>
+	<p>Finally, in the particular case when rights are expressed via <a data-cite="?ODRL-VOCAB#term-Policy">ODRL policies</a>, it is recommended to use use the <a data-cite="?ODRL-VOCAB#term-hasPolicy"><code>odrl:hasPolicy</code></a> property as the link from the description of the catalogued resource or distribution to the ODRL policy, in addition to the relevant <code>dct</code> property.</p>
   <p class="note">The Open Digital Rights Language (ODRL) [[!ODRL-VOCAB]] is a policy expression language that provides a flexible and interoperable information model, vocabulary, and encoding mechanisms for representing statements about usage (i.e. permissions, prohibitions, and obligations) of content and services.</p>
 
   <p>Recommendations on the use of these properties on the different types of resources defined in DCAT are provided in the relevant class descriptions.</p>
@@ -3429,7 +3433,7 @@ ex:Test543L
             <a href="https://www.w3.org/2015/spatial/wiki/ISO_19115_-_DCAT_-_Schema.org_mapping">Spatial Data on the Web Working Group</a>, building upon previous work.
         </p>
         <p>
-            A recommended mapping from the revised DCAT (this document) to [[?SCHEMA-ORG]] version 3.4 is <a href="https://raw.githubusercontent.com/w3c/dxwg/gh-pages/dcat/rdf/dcat-schema.ttl">available in an RDF file</a>.
+            A recommended mapping from the revised DCAT (this document) to [[?SCHEMA-ORG]] version 3.4 is <a href="https://w3c.github.io/dxwg/dcat/rdf/dcat-schema.ttl">available in an RDF file</a>.
             This mapping is axiomatized using the predicates <code>rdfs:subClassOf</code>, <code>rdfs:subPropertyOf</code>, <code>owl:equivalentClass</code>, <code>owl:equivalentProperty</code>, <code>skos:closeMatch</code>,
             and also using the annotation properties <code>sdo:domainIncludes</code> and <code>sdo:rangeIncludes</code> to match [[?SCHEMA-ORG]] semantics. The alignment is summarized in the table below, considering the prefix <code>sdo</code> as <code>http://schema.org/</code>.
         </p>
@@ -3604,7 +3608,7 @@ ex:Test543L
     <section id="dcat-prov-o" class="informative">
         <h3>PROV-O</h3>
             An alignment of DCAT with PROV-O [[?PROV-O]] is being prepared, and has been discussed in <a href="https://github.com/w3c/dxwg/issues/128">Issue #128</a>.
-	    A <a href="https://raw.githubusercontent.com/w3c/dxwg/gh-pages/dcat/rdf/dcat-prov.ttl">provisional version</a> is available.
+	    A <a href="https://w3c.github.io/dxwg/dcat/rdf/dcat-prov.ttl">provisional version</a> is available.
 
     </section>
 -->
@@ -3752,7 +3756,7 @@ ex:Test543L
 </pre>
 
       <p>
-          This example is available from the <a href="https://github.com/w3c/dxwg/tree/gh-pages/dcat/examples">DXWG code repository</a> at <a href="https://raw.githubusercontent.com/w3c/dxwg/gh-pages/dcat/examples/csiro-dap-examples.ttl">csiro-dap-examples.ttl</a>
+          This example is available from the <a href="https://github.com/w3c/dxwg/tree/gh-pages/dcat/examples">DXWG code repository</a> at <a href="https://w3c.github.io/dxwg/dcat/examples/csiro-dap-examples.ttl">csiro-dap-examples.ttl</a>
       </p>
 
       <p>
@@ -3858,7 +3862,7 @@ dap:d33937
 .
       </pre>
       <p>
-          This example is available from the <a href="https://github.com/w3c/dxwg/tree/gh-pages/dcat/examples">DXWG code repository</a> at <a href="https://raw.githubusercontent.com/w3c/dxwg/gh-pages/dcat/examples/csiro-stratchart.ttl">csiro-stratchart.ttl</a>
+          This example is available from the <a href="https://github.com/w3c/dxwg/tree/gh-pages/dcat/examples">DXWG code repository</a> at <a href="https://w3c.github.io/dxwg/dcat/examples/csiro-stratchart.ttl">csiro-stratchart.ttl</a>
       </p>
 
   </section>
@@ -3891,7 +3895,7 @@ rdfs:seeAlso &lt;https://doi.org/10.1111/j.1365-2966.2006.10100.x&gt; ;
 .
 </pre>
       <p>
-          This example is available from the <a href="https://github.com/w3c/dxwg/tree/gh-pages/dcat/examples">DXWG code repository</a> at <a href="https://raw.githubusercontent.com/w3c/dxwg/gh-pages/dcat/examples/csiro-dap-examples.ttl">csiro-dap-examples.ttl</a>
+          This example is available from the <a href="https://github.com/w3c/dxwg/tree/gh-pages/dcat/examples">DXWG code repository</a> at <a href="https://w3c.github.io/dxwg/dcat/examples/csiro-dap-examples.ttl">csiro-dap-examples.ttl</a>
       </p>
       <p>
           Several properties capture provenance information, including within the citation and title, but the primary link to a formal description of the project is through <a href="#Property:dataset_wasgeneratedby"><code>prov:wasGeneratedBy</code></a>.
@@ -3926,29 +3930,36 @@ rdfs:seeAlso &lt;https://doi.org/10.1111/j.1365-2966.2006.10100.x&gt; ;
           This is classified as a <a href="#Class:Data_Service"><code>dcat:DataService</code></a> and has the <code>dct:type</code> set to <a href="http://inspire.ec.europa.eu/metadata-codelist/SpatialDataServiceType/discovery">discovery</a> from the <a href="http://inspire.ec.europa.eu/metadata-codelist/SpatialDataServiceType/">INSPIRE classification of spatial data service types</a>.
       </p>
       <p>
-          This example is available from the <a href="https://github.com/w3c/dxwg/tree/gh-pages/dcat/examples">DXWG code repository</a> at <a href="https://raw.githubusercontent.com/w3c/dxwg/gh-pages/dcat/examples/eea-csw.ttl">eea-csw.ttl</a>
+          This example is available from the <a href="https://github.com/w3c/dxwg/tree/gh-pages/dcat/examples">DXWG code repository</a> at <a href="https://w3c.github.io/dxwg/dcat/examples/eea-csw.ttl"><code>eea-csw.ttl</code></a>
       </p>
 <pre id="ex-service-eea" class="example nohighlight turtle">
 a:EEA-CSW-Endpoint
-rdf:type dcat:DataService ;
-dc:subject "infoCatalogueService"@en ;
-dct:accessRights &lt;http://publications.europa.eu/resource/authority/access-right/PUBLIC&gt; ;
-dct:conformsTo &lt;http://www.opengis.net/def/serviceType/ogc/csw&gt; ;
-dct:description "The EEA public catalogue of spatial datasets references the spatial datasets used by the European Environment Agency as well as the spatial datasets produced by or for the EEA. In the latter case, when datasets are publicly available, a link to the location from where they can be downloaded is included in the dataset's metadata. The catalogue has been initially populated with the most important spatial datasets already available on the data&maps section of the EEA website and is currently updated with any newly published spatial dataset."@en ;
-dct:identifier "eea-sdi-public-catalogue" ;
-dct:issued "2012-01-01"^^xsd:date ;
-dct:license &lt;https://creativecommons.org/licenses/by/2.5/dk/&gt; ;
-dct:spatial [
+  rdf:type dcat:DataService ;
+  dct:type &lt;http://inspire.ec.europa.eu/metadata-codelist/SpatialDataServiceCategory/infoCatalogueService&gt; ;
+  dct:accessRights &lt;http://publications.europa.eu/resource/authority/access-right/PUBLIC&gt; ;
+  dct:conformsTo &lt;http://www.opengis.net/def/serviceType/ogc/csw&gt; ;
+  dct:description "The EEA public catalogue of spatial datasets references 
+    the spatial datasets used by the European Environment Agency as well as 
+    the spatial datasets produced by or for the EEA. In the latter case, 
+    when datasets are publicly available, a link to the location from where 
+    they can be downloaded is included in the dataset's metadata. The 
+    catalogue has been initially populated with the most important spatial 
+    datasets already available on the data&maps section of the EEA website 
+    and is currently updated with any newly published spatial dataset."@en ;
+  dct:identifier "eea-sdi-public-catalogue" ;
+  dct:issued "2012-01-01"^^xsd:date ;
+  dct:license &lt;https://creativecommons.org/licenses/by/2.5/dk/&gt; ;
+  dct:spatial [
     rdf:type dct:Location ;
     locn:geometry "&lt;gml:Envelope srsName=\"http://www.opengis.net/def/crs/OGC/1.3/CRS84\"&gt;&lt;gml:lowerCorner&gt;-180 -90&lt;/gml:lowerCorner&gt;&lt;gml:upperCorner&gt;180 90&lt;/gml:upperCorner&gt;&lt;/gml:Envelope&gt;"^^gsp:gmlLiteral ;
     locn:geometry "POLYGON((-180 90,180 90,180 -90,-180 -90,-180 90))"^^gsp:wktLiteral ;
   ] ;
-dct:title "European Environment Agency's public catalogue of spatial datasets."@en ;
-dct:type &lt;http://inspire.ec.europa.eu/metadata-codelist/ResourceType/service&gt; ;
-dct:type &lt;http://inspire.ec.europa.eu/metadata-codelist/SpatialDataServiceType/discovery&gt; ;
-dcat:contactPoint a:EEA ;
-dcat:endpointDescription &lt;https://sdi.eea.europa.eu/catalogue/srv/eng/csw?service=CSW&request=GetCapabilities&gt; ;
-dcat:endpointURL &lt;http://sdi.eea.europa.eu/catalogue/srv/eng/csw&gt; ;
+  dct:title "European Environment Agency's public catalogue of spatial datasets."@en ;
+  dct:type &lt;http://inspire.ec.europa.eu/metadata-codelist/ResourceType/service&gt; ;
+  dct:type &lt;http://inspire.ec.europa.eu/metadata-codelist/SpatialDataServiceType/discovery&gt; ;
+  dcat:contactPoint a:EEA ;
+  dcat:endpointDescription &lt;https://sdi.eea.europa.eu/catalogue/srv/eng/csw?service=CSW&request=GetCapabilities&gt; ;
+  dcat:endpointURL &lt;http://sdi.eea.europa.eu/catalogue/srv/eng/csw&gt; ;
 .
 </pre>
       <p>
@@ -3956,7 +3967,7 @@ dcat:endpointURL &lt;http://sdi.eea.europa.eu/catalogue/srv/eng/csw&gt; ;
           These are classified as a <a href="#Class:Data_Service"><code>dcat:DataService</code></a> and also have the <code>dct:type</code> set to <a href="http://inspire.ec.europa.eu/metadata-codelist/SpatialDataServiceType/download">download</a> and <a href="http://inspire.ec.europa.eu/metadata-codelist/SpatialDataServiceType/view">view</a> from the <a href="http://inspire.ec.europa.eu/metadata-codelist/SpatialDataServiceType/">INSPIRE classification of spatial data service types</a>.
       </p>
       <p>
-          This example is available from the <a href="https://github.com/w3c/dxwg/tree/gh-pages/dcat/examples">DXWG code repository</a> at <a href="https://raw.githubusercontent.com/w3c/dxwg/gh-pages/dcat/examples/ga-courts.ttl">ga-courts.ttl</a>
+          This example is available from the <a href="https://github.com/w3c/dxwg/tree/gh-pages/dcat/examples">DXWG code repository</a> at <a href="https://w3c.github.io/dxwg/dcat/examples/ga-courts.ttl">ga-courts.ttl</a>
       </p>
 
 <pre id="ex-service-gsa" class="example nohighlight turtle">
@@ -4077,7 +4088,7 @@ dcat:servesDataset ga-courts:jc ;
 
         </pre>
         <p>
-            These examples are available from the <a href="https://github.com/w3c/dxwg/tree/gh-pages/dcat/examples">DXWG code repository</a> at <a href="https://raw.githubusercontent.com/w3c/dxwg/gh-pages/dcat/examples/compress-and-package.ttl"><code>compress-and-package.ttl</code></a>
+            These examples are available from the <a href="https://github.com/w3c/dxwg/tree/gh-pages/dcat/examples">DXWG code repository</a> at <a href="https://w3c.github.io/dxwg/dcat/examples/compress-and-package.ttl"><code>compress-and-package.ttl</code></a>
         </p>
 
   </section>

--- a/dcat/index.html
+++ b/dcat/index.html
@@ -70,7 +70,7 @@ $(document).ready( function() {
     </p>
     <h3 id="dcat_history">DCAT history</h3>
     <p>The original DCAT vocabulary was developed and <a href="http://vocab.deri.ie/dcat">hosted</a> at the Digital Enterprise Research Institute (DERI), then refined by the <a href="http://www.w3.org/egov/">eGov Interest Group</a>, and finally standardized in 2014 [[?VOCAB-DCAT-20140116]] by the <a href="http://www.w3.org/2011/gld/">Government Linked Data (GLD)</a> Working Group.</p>
-    <p>This revised version of DCAT was developed by the <a href="https://www.w3.org/2017/dxwg/">Dataset Exchange Working Group</a> in response to a new set of Use Cases and Requirements [[?DCAT-UCR]] gathered from peoples' experience with the DCAT vocabulary from the time of the original version, and new applications that were not considered in the first version. A summary of the changes from  [[?VOCAB-DCAT-20140116]] can be found at <a href="#changes"></a></p>
+    <p>This revised version of DCAT was developed by the <a href="https://www.w3.org/2017/dxwg/">Dataset Exchange Working Group</a> in response to a new set of Use Cases and Requirements [[?DCAT-UCR]] gathered from peoples' experience with the DCAT vocabulary from the time of the original version, and new applications that were not considered in the first version. A summary of the changes from  [[?VOCAB-DCAT-20140116]] <a href="#changes">is provided</a>. </p>
 
     <h3 id="external_terms">External terms</h3>
     <p>DCAT incorporates terms from pre-existing vocabularies where stable terms with appropriate meanings could be found, such as <a href="http://xmlns.com/foaf/0.1/homepage"><code>foaf:homepage</code></a> and <a href="http://purl.org/dc/terms/title"><code>dct:title</code></a>.


### PR DESCRIPTION
As per https://github.com/w3c/dxwg/issues/890

Preview:

https://raw.githack.com/w3c/dxwg/andrea-perego-dcat-ed-rev/dcat/index.html

Diff:

https://services.w3.org/htmldiff?doc1=https%3A%2F%2Fw3c.github.io%2Fdxwg%2Fdcat%2Findex.html&doc2=https%3A%2F%2Fraw.githack.com%2Fw3c%2Fdxwg%2Fandrea-perego-dcat-ed-rev%2Fdcat%2Findex.html

Summary of changes:

- Fixed inconsistent labels for dcat:xyzURL properties - sometimes "* URL" sometimes "* address"). Now always sometimes "* URL" ("access URL", "download URL", "endpoint URL")
- Fixed wrong camel case in labels
- Fixed & cleaned markup and added link to classes and properties
- Fixed cross-refs and citation keys
- Indented code in examples
- Validated HTML markup
