### PR TITLE
Removed script to cross-ref examples

### DIFF
--- a/dcat/index.html
+++ b/dcat/index.html
@@ -6,28 +6,6 @@
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
     <script class="remove" src="https://www.w3.org/Tools/respec/respec-w3c-common"></script>
     <script class="remove" src="config.js"></script>
-
-    <script>
-// @andrea-perego
-function popCrossRefs() {
-  $('a[href^="#"]').each( function () {
-    var href = $(this).attr('href');
-    var id = href.trim().replace('#','');
-    var text = $(this).text();
-    if (text.trim().length == 0 && id.length > 0 && ( $(href).hasClass('example') || $(href).hasClass('practicelab') )) {
-      var label = $('.example:has(#' + id + ') > .example-title, *[id="' + id + '"].example > .example-title, *[id="' + id + '"].illegal-example > .example-title, *[id="' + id + '"].practicelab').text();
-      if (label.trim().length > 0) {
-        $(this).text(label);
-      }
-    }
-  } );
-}
-$(document).ready( function() {
-  popCrossRefs();
-});
-// @andrea-perego
-    </script>
-
     <link rel="stylesheet" type="text/css" href="style.css">
     <link rel="stylesheet" type="text/css" href="small.css" media="only all and (max-width: 649px)">
 </head>


### PR DESCRIPTION
Reverting https://github.com/w3c/dxwg/pull/699 (related issue: https://github.com/w3c/dxwg/issues/673)

The script is no longer needed, as this feature is now supported in ReSpec - see https://github.com/w3c/respec/issues/1124 and related PR https://github.com/w3c/respec/pull/2303