### PR TITLE
adding cataloged resources explicitly ( for issue #967)

### DIFF
--- a/dcat/index.html
+++ b/dcat/index.html
@@ -178,7 +178,7 @@
     <p>A data catalog conforms to DCAT if:</p>
     <ul>
         <li> Access to data is organized into datasets, distributions, and data-services. </li>
-        <li> An RDF description of the catalog itself and its datasets, distributions, data-services, and other cataloged resources (if any) is available (but the choice of
+        <li> An RDF description of the catalog itself, the corresponding cataloged resources, and distributions is available (but the choice of
             RDF syntax, access protocol, and access policy are not mandated by this specification).</li>
         <li> The contents of all metadata fields that are held in the catalog and that contain data about the catalog itself and its datasets, distributions, data-services, and other cataloged resources (if any) are included in this RDF description and are expressed using the appropriate classes and properties from DCAT, except where no such class or property exists.</li>
         <li> All classes and properties defined in DCAT are used in a way consistent with the semantics declared in this specification.</li>

--- a/dcat/index.html
+++ b/dcat/index.html
@@ -180,7 +180,7 @@
         <li> Access to data is organized into datasets, distributions, and data-services. </li>
         <li> An RDF description of the catalog itself, the corresponding cataloged resources, and distributions is available (but the choice of
             RDF syntax, access protocol, and access policy are not mandated by this specification).</li>
-        <li> The contents of all metadata fields that are held in the catalog and that contain data about the catalog itself and its datasets, distributions, data-services, and other cataloged resources (if any) are included in this RDF description and are expressed using the appropriate classes and properties from DCAT, except where no such class or property exists.</li>
+        <li> The contents of all metadata fields that are held in the catalog and that contain data about the catalog itself, the corresponding cataloged resources,  and distributions are included in this RDF description and are expressed using the appropriate classes and properties from DCAT, except where no such class or property exists.</li>
         <li> All classes and properties defined in DCAT are used in a way consistent with the semantics declared in this specification.</li>
         <li>DCAT-compliant catalogs MAY include additional non-DCAT metadata fields and additional RDF data in the catalog's RDF description.</li>
     </ul>

--- a/dcat/index.html
+++ b/dcat/index.html
@@ -178,9 +178,9 @@
     <p>A data catalog conforms to DCAT if:</p>
     <ul>
         <li> Access to data is organized into datasets, distributions, and data-services. </li>
-        <li> An RDF description of the catalog itself and its datasets, distributions, and data-services is available (but the choice of
+        <li> An RDF description of the catalog itself and its datasets, distributions, data-services, and other cataloged resources (if any) is available (but the choice of
             RDF syntax, access protocol, and access policy are not mandated by this specification).</li>
-        <li> The contents of all metadata fields that are held in the catalog and that contain data about the catalog itself and its datasets, distributions, and data-services, are included in this RDF description and are expressed using the appropriate classes and properties from DCAT, except where no such class or property exists.</li>
+        <li> The contents of all metadata fields that are held in the catalog and that contain data about the catalog itself and its datasets, distributions, data-services, and other cataloged resources (if any) are included in this RDF description and are expressed using the appropriate classes and properties from DCAT, except where no such class or property exists.</li>
         <li> All classes and properties defined in DCAT are used in a way consistent with the semantics declared in this specification.</li>
         <li>DCAT-compliant catalogs MAY include additional non-DCAT metadata fields and additional RDF data in the catalog's RDF description.</li>
     </ul>


### PR DESCRIPTION
This PR addresses the issue #967 by explicitly mentioning the cataloged resources in the conformance section.

In this way, we convey the idea that a catalog of resources other than datasets and services is conformant.