### PR TITLE
PR for  issue #966 

### DIFF
--- a/dcat/index.html
+++ b/dcat/index.html
@@ -225,10 +225,10 @@
           <a href="#Class:Resource"><code>dcat:Resource</code></a> represents a dataset, a data service or any other resource that may be described by a metadata record in a catalog.
           This class is not intended to be used directly, but is the parent class of <a href="#Class:Dataset"><code>dcat:Dataset</code></a>, <a href="#Class:Data_Service"><code>dcat:DataService</code></a> and <a href="#Class:Catalog"><code>dcat:Catalog</code></a>.
           Member items in a catalog should be members of one of the sub-classes, or of a sub-class of these, or of a sub-class of <a href="#Class:Resource"><code>dcat:Resource</code></a> defined in a DCAT profile or other DCAT application.
-          <a href="#Class:Resource"><code>dcat:Resource</code></a> is effectively an extension point for defining a catalog of any kind of resource. <a href="#Class:Dataset"><code>dcat:Dataset</code></a> and <a href="#Class:Data_Service"><code>dcat:DataService</code></a>  can be used for datasets and services which are not documented in any catalog.
+          <a href="#Class:Resource"><code>dcat:Resource</code></a> is effectively an extension point for defining a catalog of any kind of resource. <a href="#Class:Dataset"><code>dcat:Dataset</code></a> and <a href="#Class:Data_Service"><code>dcat:DataService</code></a> can be used for datasets and services which are not documented in any catalog.
         </li>
         <li>
-          <a href="#Class:Dataset"><code>dcat:Dataset</code></a> represents a dataset in a catalog.
+          <a href="#Class:Dataset"><code>dcat:Dataset</code></a> represents a dataset.
           A dataset is a collection of data, published or curated by a single agent.
           Data comes in many forms including numbers, words, pixels, imagery, sound and other multi-media, and potentially other types, any of which might be collected into a dataset.
         </li>
@@ -236,7 +236,7 @@
           <a href="#Class:Distribution"><code>dcat:Distribution</code></a> represents an accessible form of a dataset such as a downloadable file.
         </li>
         <li>
-          <a href="#Class:Data_Service"><code>dcat:DataService</code></a> represents a data service in a catalog.
+          <a href="#Class:Data_Service"><code>dcat:DataService</code></a> represents a data service.
           A data service is a collection of operations accessible through an interface (<abbr title="Application Programming Interface">API</abbr>) that provide access to one or more datasets or data processing functions.
         </li>
         <!--

--- a/dcat/index.html
+++ b/dcat/index.html
@@ -222,7 +222,7 @@
           <a href="#Class:Catalog"><code>dcat:Catalog</code></a> represents a catalog, which is a dataset in which each individual item is a metadata record describing some resource; the scope of <code>dcat:Catalog</code> is collections of metadata about <b>datasets</b> or <b>data services</b>.
         </li>
         <li>
-          <a href="#Class:Resource"><code>dcat:Resource</code></a> represents an individual item in a catalog.
+          <a href="#Class:Resource"><code>dcat:Resource</code></a> represents a dataset, a data service or any other resource that may be described by a metadata record in a catalog.
           This class is not intended to be used directly, but is the parent class of <a href="#Class:Dataset"><code>dcat:Dataset</code></a>, <a href="#Class:Data_Service"><code>dcat:DataService</code></a> and <a href="#Class:Catalog"><code>dcat:Catalog</code></a>.
           Member items in a catalog should be members of one of the sub-classes, or of a sub-class of these, or of a sub-class of <a href="#Class:Resource"><code>dcat:Resource</code></a> defined in a DCAT profile or other DCAT application.
           <a href="#Class:Resource"><code>dcat:Resource</code></a> is effectively an extension point for defining a catalog of any kind of resource.

--- a/dcat/index.html
+++ b/dcat/index.html
@@ -225,7 +225,7 @@
           <a href="#Class:Resource"><code>dcat:Resource</code></a> represents a dataset, a data service or any other resource that may be described by a metadata record in a catalog.
           This class is not intended to be used directly, but is the parent class of <a href="#Class:Dataset"><code>dcat:Dataset</code></a>, <a href="#Class:Data_Service"><code>dcat:DataService</code></a> and <a href="#Class:Catalog"><code>dcat:Catalog</code></a>.
           Member items in a catalog should be members of one of the sub-classes, or of a sub-class of these, or of a sub-class of <a href="#Class:Resource"><code>dcat:Resource</code></a> defined in a DCAT profile or other DCAT application.
-          <a href="#Class:Resource"><code>dcat:Resource</code></a> is effectively an extension point for defining a catalog of any kind of resource.
+          <a href="#Class:Resource"><code>dcat:Resource</code></a> is effectively an extension point for defining a catalog of any kind of resource. <a href="#Class:Dataset"><code>dcat:Dataset</code></a> and <a href="#Class:Data_Service"><code>dcat:DataService</code></a>  can be used for datasets and services which are not documented in any catalog.
         </li>
         <li>
           <a href="#Class:Dataset"><code>dcat:Dataset</code></a> represents a dataset in a catalog.


### PR DESCRIPTION
Implementing changes discussed in issue #966 in response to @smrgeoinfo feedbacks.
-  It provides  an updated definition of dcat:Resource in section 5.1, it makes also explicit that dataset and data service can be used for not yet cataloged resources
- it deletes the explicit mention that dataset and data service are 'in a catalog' 