### PR TITLE
Addressing feedback (in issue #935)

### DIFF
--- a/dcat/index.html
+++ b/dcat/index.html
@@ -2251,7 +2251,7 @@
             <table class="definition">
                 <thead><tr><th>RDF Property:</th><th><a href="http://www.w3.org/ns/dcat#compressFormat">dcat:compressFormat</a></th></tr></thead>
                 <tbody>
-                <tr><td class="prop">Definition:</td><td>The format of the file in which the data is contained in a compressed form, e.g. to reduce the size of the downloadable file.</td></tr>
+                <tr><td class="prop">Definition:</td><td>The compression format of the distribution in which the data is contained in a compressed form, e.g. to reduce the size of the downloadable file.</td></tr>
                 <tr><td class="prop">Range:</td><td><a href="http://purl.org/dc/terms/MediaType"><code>dct:MediaType</code></a></td></tr>
                 <tr><td class="prop">Usage note:</td><td>This property to be used when the files in the distribution are compressed, e.g. in a ZIP file. The format SHOULD be expressed using a media type as defined by IANA [[!IANA-MEDIA-TYPES]], if available.</td></tr>
                 <tr><td class="prop">See also:</td><td><a href="#Property:distribution_packaging_format"></a>.</td></tr>
@@ -2274,7 +2274,7 @@
             <table class="definition">
                 <thead><tr><th>RDF Property:</th><th><a href="http://www.w3.org/ns/dcat#packageFormat">dcat:packageFormat</a></th></tr></thead>
                 <tbody>
-                <tr><td class="prop">Definition:</td><td>The format of the file in which one or more data files are grouped together, e.g. to enable a set of related files to be downloaded together.</td></tr>
+                <tr><td class="prop">Definition:</td><td>The package format of the distribution in which one or more data files are grouped together, e.g. to enable a set of related files to be downloaded together.</td></tr>
                 <tr><td class="prop">Range:</td><td><a href="http://purl.org/dc/terms/MediaType"><code>dct:MediaType</code></a></td></tr>
                 <tr><td class="prop">Usage note:</td><td>This property to be used when the files in the distribution are packaged, e.g. in a TAR file. The format SHOULD be expressed using a media type as defined by IANA [[!IANA-MEDIA-TYPES]], if available.</td></tr>
                 <tr><td class="prop">See also:</td><td><a href="#Property:distribution_compression_format"></a>.</td></tr>

--- a/dcat/rdf/dcat.ttl
+++ b/dcat/rdf/dcat.ttl
@@ -849,9 +849,9 @@ dcat:mediaType
 dcat:compressFormat
   rdf:type rdf:Property ;
   rdf:type owl:ObjectProperty ;
-  rdfs:comment "The format of the file in which the data is contained in a compressed form, e.g. to reduce the size of the downloadable file."@en ;
+  rdfs:comment "The compression format of the distribution in which the data is contained in a compressed form, e.g. to reduce the size of the downloadable file."@en ;
   rdfs:comment "El formato de la distribución en el que los datos están en forma comprimida, e.g. para reducir el tamaño del archivo a bajar."@es ;
-rdfs:comment "Il formato del file nella quale i dati sono in forma compressa, ad es. per ridurre le dimensioni del file da scaricare."@it ;
+  rdfs:comment "Il formato di compressione della distribuzione nel quale i dati sono in forma compressa, ad es. per ridurre le dimensioni del file da scaricare."@it ;
   rdfs:domain dcat:Distribution ;
   rdfs:isDefinedBy <https://www.w3.org/TR/vocab-dcat-2/> ;
   rdfs:label "compression format"@en ;
@@ -867,9 +867,9 @@ rdfs:comment "Il formato del file nella quale i dati sono in forma compressa, ad
 dcat:packageFormat
   rdf:type rdf:Property ;
   rdf:type owl:ObjectProperty ;
-  rdfs:comment "The format of the file in which one or more data files are grouped together, e.g. to enable a set of related files to be downloaded together."@en ;
+  rdfs:comment "The package format of the distribution in which one or more data files are grouped together, e.g. to enable a set of related files to be downloaded together."@en ;
   rdfs:comment "El formato del archivo en que se agrupan uno o más archivos de datos, e.g. para permitir que un conjunto de archivos relacionados se bajen juntos."@es ;
- rdfs:comment "Il formato del file in cui uno o più file di dati sono raggruppati insieme, ad es. per abilitare un insieme di file correlati da scaricare insieme."@it ;
+ rdfs:comment "Il formato di impacchettamento della distribuzione in cui uno o più file di dati sono raggruppati insieme, ad es. per abilitare un insieme di file correlati da scaricare insieme."@it ;
   rdfs:domain dcat:Distribution ;
   rdfs:isDefinedBy <https://www.w3.org/TR/vocab-dcat-2/> ;
   rdfs:label "packaging format"@en ;

--- a/dcat/rdf/dcat.ttl
+++ b/dcat/rdf/dcat.ttl
@@ -849,9 +849,9 @@ dcat:mediaType
 dcat:compressFormat
   rdf:type rdf:Property ;
   rdf:type owl:ObjectProperty ;
-  rdfs:comment "The format of the distribution in which the data is contained in a compressed form, e.g. to reduce the size of the downloadable file."@en ;
+  rdfs:comment "The format of the file in which the data is contained in a compressed form, e.g. to reduce the size of the downloadable file."@en ;
   rdfs:comment "El formato de la distribución en el que los datos están en forma comprimida, e.g. para reducir el tamaño del archivo a bajar."@es ;
-rdfs:comment "Il formato della distribuzione nella quale i dati sono in forma compressa, ad es. per ridurre le dimensioni del file da scaricare."@it ;
+rdfs:comment "Il formato del file nella quale i dati sono in forma compressa, ad es. per ridurre le dimensioni del file da scaricare."@it ;
   rdfs:domain dcat:Distribution ;
   rdfs:isDefinedBy <https://www.w3.org/TR/vocab-dcat-2/> ;
   rdfs:label "compression format"@en ;


### PR DESCRIPTION
Addressing issue #935 in the dcat.ttl: 
-replacing  "distribution" with "file" in  rdfs:comment of dcat:compressFormat 
The DCAT WD  has not changed as "file" was already used in the correspondent definition. 