### PR TITLE
Adding missing definitions issue #983 

### DIFF
--- a/dcat/rdf/dcat.ttl
+++ b/dcat/rdf/dcat.ttl
@@ -34,6 +34,7 @@ dct:language
   skos:scopeNote "If representations of a dataset are available for each language separately, define an instance of dcat:Distribution for each language and describe the specific language of each distribution using dct:language (i.e. the dataset will have multiple dct:language values and each distribution will have just one as the value of its dct:language property)."@en;
 .
 dct:relation
+  skos:definition "A resource with an unspecified relationship to the cataloged item."@en ;
   skos:scopeNote "In the context of a dcat:Relationship this is expected to point to another dcat:Dataset or other catalogued resource"@en ;
   skos:scopeNote "See also: Sub-properties of dct:relation in particular dcat:distribution, dct:hasPart, dct:isPartOf, dct:conformsTo, dct:isFormatOf, dct:hasFormat, dct:isVersionOf, dct:hasVersion, dct:replaces, dct:isReplacedBy, dct:references, dct:isReferencedBy, dct:requires, dct:isRequiredBy"@en ;
   skos:scopeNote "dct:relation SHOULD be used where the nature of the relationship between a catalogued item and related resources is not known. A more specific sub-property SHOULD be used if the nature of the relationship of the link is known. The property dcat:distribution SHOULD be used to link from a dcat:Dataset to a representation of the dataset, described as a dcat:Distribution"@en ;

--- a/dcat/rdf/dcat.ttl
+++ b/dcat/rdf/dcat.ttl
@@ -22,12 +22,13 @@
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
 dct:hasPart
-  skos:definition "An item that is listed in the catalog."@en
+  skos:definition "An item that is listed in the catalog."@en ;
   skos:scopeNote "See also: Sub-properties of dct:hasPart in particular dcat:dataset, dcat:catalog, dcat:service."@en ;
   skos:scopeNote "This is the most general predicate for membership of a catalog. Use of a more specific sub-property is recommended when available."@en ;
   skos:changeNote "Property added in this context in this revision of DCAT"@en ;
 .
 dct:language
+  skos:definition "A language of the item. This refers to the natural language used for textual metadata (i.e. titles, descriptions, etc) of a cataloged resource (i.e. dataset or service) or the textual values of a dataset distribution"@en ;
   skos:scopeNote "Repeat this property if the resource is available in multiple languages."@en ;
   skos:scopeNote "The value(s) provided for members of a catalog (i.e. dataset or service) override the value(s) provided for the catalog if they conflict."@en ;
   skos:scopeNote "If representations of a dataset are available for each language separately, define an instance of dcat:Distribution for each language and describe the specific language of each distribution using dct:language (i.e. the dataset will have multiple dct:language values and each distribution will have just one as the value of its dct:language property)."@en;

--- a/dcat/rdf/dcat.ttl
+++ b/dcat/rdf/dcat.ttl
@@ -41,6 +41,7 @@ dct:relation
   skos:changeNote "Property added in this context in this revision of DCAT"@en ;
 .
 dct:type
+  skos:definition "The nature or genre of the resource."@en ;
   skos:scopeNote """The value SHOULD be taken from a well governed and broadly recognised controlled vocabulary, such as:
 1. DCMI Type vocabulary [DCTERMS]
 2. ISO 19115 scope codes [ISO-19115-1]

--- a/dcat/rdf/dcat.ttl
+++ b/dcat/rdf/dcat.ttl
@@ -22,6 +22,7 @@
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
 dct:hasPart
+  skos:definition "An item that is listed in the catalog."@en
   skos:scopeNote "See also: Sub-properties of dct:hasPart in particular dcat:dataset, dcat:catalog, dcat:service."@en ;
   skos:scopeNote "This is the most general predicate for membership of a catalog. Use of a more specific sub-property is recommended when available."@en ;
   skos:changeNote "Property added in this context in this revision of DCAT"@en ;


### PR DESCRIPTION
Addressing issue #983 :
- added skos:definition for missing dct term definitions.

