### PR TITLE
Correct title for dcat-ap.de link

### DIFF
--- a/dcat/config.js
+++ b/dcat/config.js
@@ -122,7 +122,7 @@ var respecConfig = {
             href: "http://difi.github.io/dcat-ap-no/"
         },
         "DCAT-AP.de": {
-            title: "DCAT-AP.de als formaler Metadatenstandard für offene Verwaltungsdaten bestätigt",
+            title: "Vokabulare und Dokumente für DCAT-AP.de",
             href: "https://dcat-ap.de/def/"
         },
         "DDI" : {


### PR DESCRIPTION
@andrea-perego - would it be possible to merge this into your ACK branch?  Lars pointed [out](https://github.com/w3c/dxwg/issues/1020#issuecomment-529351294) that the title of dcat-ap.de was no longer correct (and I'd like to keep the number outstanding mrs down.....

(Assuming I've done it correctly, of course)