### PR TITLE
Indicate tokens through separate Link header

### DIFF
--- a/conneg-by-ap/index.html
+++ b/conneg-by-ap/index.html
@@ -1137,11 +1137,14 @@ Accept: text/turtle
 HTTP/1.1 200 OK
 Content-Type: text/turtle
 Content-Location: http://example.org/resource/a.profx.ttl
-Content-Profile: &lt;urn:example:profile:x;token=px>
-Link: &lt;http://example.org/resource/a.profx.ttl&gt;; rel="self"; type="text/turtle"; profile="urn:example:profile:x;token=px",
-  &lt;http://example.org/resource/a.profy.ttl&gt;; rel="alternate"; type="text/turtle"; profile="http://example.org/profile/2;token=py",
-  &lt;http://example.org/resource/a.profx.xml&gt;; rel="alternate"; type="application/xml"; profile="urn:example:profile:x;token=px",
-  &lt;http://example.org/resource/a.profy.xml&gt;; rel="alternate"; type="application/xml"; profile="http://example.org/profile/2;token=py",
+Content-Profile: &lt;urn:example:profile:x&gt;
+Link:
+  &lt;http://www.w3.org/ns/dx/prof/Profile&gt;; rel="type"; token="px"; anchor=&lt;urn:example:profile:x&gt;,
+  &lt;http://www.w3.org/ns/dx/prof/Profile&gt;; rel="type"; token="py"; anchor=&lt;http://example.org/profile/2&gt;,
+  &lt;http://example.org/resource/a.profx.ttl&gt;; rel="self"; type="text/turtle"; profile="urn:example:profile:x",
+  &lt;http://example.org/resource/a.profy.ttl&gt;; rel="alternate"; type="text/turtle"; profile="http://example.org/profile/2",
+  &lt;http://example.org/resource/a.profx.xml&gt;; rel="alternate"; type="application/xml"; profile="urn:example:profile:x",
+  &lt;http://example.org/resource/a.profy.xml&gt;; rel="alternate"; type="application/xml"; profile="http://example.org/profile/2",
   &lt;http://example.org/resource/a.html&gt;; rel="alternate"; type="text/html"
 [more response headers]
           </pre>


### PR DESCRIPTION
This pull request implements a suggestion [discussed](https://github.com/w3c/dxwg/issues/501#issuecomment-528813489) in #501.

Rather than requiring an extension to the `profile` link relation in order to support tokens, we introduce a new `token` attribute.

Pros:
- orthogonal separation of the token mechanism from other mechanisms
- does not require modifications to existing IETF RFCs and drafts
- avoids repeated indications of the _token_

Cons:
- requires an extra `Link` as opposed to more compactly piggybacking on an existing one