### PR TITLE
Added back specification of attribute "token"

### DIFF
--- a/conneg-by-ap/index.html
+++ b/conneg-by-ap/index.html
@@ -1743,7 +1743,7 @@ Link:
 	<p>
 	  When used in a <code>Link</code> header field,
 	  the attribute <code>token</code> is used to specify
-	  a <a>token</<a> that a client MAY use
+	  a <a>token</a> that a client MAY use
 	  as an alternative to the full profile URI
 	  given in the <code>anchor</code> attribute.
 	</p>

--- a/conneg-by-ap/index.html
+++ b/conneg-by-ap/index.html
@@ -1125,11 +1125,11 @@ Link:
           <h3>Token mappings</h3>
           <p>
             If an HTTP <a>server</a> wishes to allow a <a>client</a> to identify a <a>profile</a> via a <a>token</a>,
-            in addition to the the mandatory identification of <a>profile</a>s via via URI, the <a>server</a>s MAY
-            provide a <a>token</a> / URI mapping via the <strong>list profiles</strong> function.
+            in addition to the the mandatory identification of <a>profile</a>s via via URI, the <a>server</a>s SHOULD
+            indicate for every supported token to which profile URI it corresponds.
             When implementing the HTTP functional profile of this specification,
             a server MUST include a <code>Link</code> header ([[RFC8288]])
-            for each <code>profile</code>/<code>token</code> pair in its response.
+            for each <code>profile URI</code>/<code>token</code> pair in its response.
             Each <code>Link</code> header MUST use the <code>Link Target</code>
             "<code>http://www.w3.org/ns/dx/prof/Profile</code>"
             and MUST contain the following <code>Target Attribute</code>s:

--- a/conneg-by-ap/index.html
+++ b/conneg-by-ap/index.html
@@ -1156,9 +1156,6 @@ Link:
             </tr>
             </tbody>
           </table>
-	    The rules for <code>link-param</code> values defined in
-            <a href="https://tools.ietf.org/html/rfc8288#section-3">section 3</a> of [[RFC8288]] apply.
-          </p>
           <p>
             An example <code>Link</code> header used to communicate a token/URI mapping is given in <a href="#eg-uri-token"></a>.
           </p>

--- a/conneg-by-ap/index.html
+++ b/conneg-by-ap/index.html
@@ -1156,11 +1156,7 @@ Link:
             </tr>
             </tbody>
           </table>
-          <p>
-            The ABNF for the profile attribute's value is <code>(token / quoted-string)</code>,
-            where "token"and "quoted-string" are defined as in
-            <a href="https://tools.ietf.org/html/rfc7230#section-3.2.6">section 3.2.6</a>
-            of [[RFC7230]]. The rules for <code>link-param</code> values defined in
+	    The rules for <code>link-param</code> values defined in
             <a href="https://tools.ietf.org/html/rfc8288#section-3">section 3</a> of [[RFC8288]] apply.
           </p>
           <p>
@@ -1177,16 +1173,7 @@ Link: &lt;http://www.w3.org/ns/dx/prof/Profile&gt;;
   rel="type";
   token="igsn-r1";
   anchor=&lt;http://schema.igsn.org/description/1.0&gt;
-	      </pre>
-
-          <p>
-            It should be noted that the use of the token as an alternative to the profile URI
-            is, by default, limited to the current resource
-            (i. e. the resource identified by the current request URI).
-            Servers MAY use a larger scope for this
-            but clients should not depend on that
-            unless the server documentation explicitly gives other instructions through some other means.
-          </p>
+          </pre>
           <p>
             Servers MAY add more attributes to a <code>Link</code> header alongside token/URI mappings, for example
             Alternate Representations data model content. <a href="#eg-uri-token-multi"></a> shows tokens a
@@ -1748,6 +1735,46 @@ Link:
         </p>
       </section>
     </section>
+  </section>
+  <section id="link-attributes">
+    <h2>Link Attributes</h2>
+      <section id="link-attributes-token">
+	<h3>Token</h3>
+	<p>
+	  When used in a <code>Link</code> header field,
+	  the attribute <code>token</code> is used to specify
+	  a <a>token</<a> that a client MAY use
+	  as an alternative to the full profile URI
+	  given in the <code>anchor</code> attribute.
+	</p>
+	<p>
+	  It should be noted that the use of the token as an alternative to the profile URI
+	  is per default limited to the current resource
+	  (i. e. the resource identified by the current request URI).
+	  Servers MAY use a larger scope for their this
+	  but clients should not depend on that
+	  unless the server documentation explicitly gives other instructions through some other means.
+	</p>
+	<p>
+	  The ABNF for the profile attribute's value is <code>token / quoted-string</code>,
+	  where "token" and "quoted-string" are defined as in 
+		<a href="https://tools.ietf.org/html/rfc7230#section-3.2.6">section 3.2.6</a>
+	  of [[RFC7230]]. The rules for <code>link-param</code> values defined in
+		<a href="https://tools.ietf.org/html/rfc8288#section-3">section 3</a> of [[RFC8288]] apply.
+	</p>
+	<pre id="eg-link-attribute-token" class="example nohighlight" aria-busy="false" aria-live="polite"
+           title="Using the Link attribute &quot;token&quot; to link a profile URI to a token">
+# The profile URI in the "anchor" element is linked to the token "igsn-r1"
+
+# Further, the relation "type" is used to inform
+# that the anchor resource is of type "prof:Profile"
+
+Link: &lt;http://www.w3.org/ns/dx/prof/Profile&gt;;
+  rel="type";
+  token="igsn-r1";
+  anchor=&lt;http://schema.igsn.org/description/1.0&gt;
+	</pre>
+      </section>
   </section>
   <section id="testsuites">
     <h2>Test Suites</h2>


### PR DESCRIPTION
The specification of the attribute token (done in #1066 and #1067) somehow got lost in the commit storm last week, so I'm adding that back again.
Since the decisions had been taken already, I mark this PR as editorial.

Text changes at https://raw.githack.com/w3c/dxwg/larsgsvensson-token-registration/conneg-by-ap/index.html#link-attributes and https://raw.githack.com/w3c/dxwg/larsgsvensson-token-registration/conneg-by-ap/index.html#http-tokens