### PR TITLE
Added definition for functional specification

### DIFF
--- a/conneg-by-ap/index.html
+++ b/conneg-by-ap/index.html
@@ -125,7 +125,14 @@
         </p>
         <p><em>Source: deliberations of the DXWG.</em></p>
       </dd>
-      <dt><dfn data-lt="profile">profile</dfn></dt>
+      <dt><dfn data-lt="functional specification">functional specification</dfn></dt>
+      <dd>
+        <p>
+          A <a>specification</a>, with human- and/or machine-processable representations,
+		that defines the behaviour of an application in a given context.
+        </p>
+        <p><em>Source: deliberations of the DXWG.</em></p>
+      </dd><dt><dfn data-lt="profile">profile</dfn></dt>
       <dd>
         <p>
           A <a>specification</a> that constrains, extends, combines, or provides guidance or explanation about the usage of other specifications.


### PR DESCRIPTION
This definition was lost in transition in a previous PR...
Preview in https://raw.githack.com/w3c/dxwg/larsgsvensson-functional-specification/conneg-by-ap/index.html#definitions