### PR TITLE
Add ref to #505 - order or precedence and remove MUST

### DIFF
--- a/connegp/config.js
+++ b/connegp/config.js
@@ -5,7 +5,7 @@ var respecConfig = {
     previousPublishDate: "2019-04-30",
     previousMaturity: "PWD",
     prevRecURI: "https://www.w3.org/TR/2019/WD-dx-prof-conneg-20190430/",
-    testSuiteURI: "https://github.com/w3c/conneg-prof-testing",
+    testSuiteURI: "https://github.com/w3c/prof-conneg-testing",
     implementationReportURI: "https://w3c.github.io/dxwg/connegp-implementation-report/",
     canonicalURI: "TR",
     editors: [{

--- a/connegp/config.js
+++ b/connegp/config.js
@@ -6,7 +6,7 @@ var respecConfig = {
     previousMaturity: "PWD",
     prevRecURI: "https://www.w3.org/TR/2019/WD-dx-prof-conneg-20190430/",
     testSuiteURI: "https://github.com/w3c/conneg-prof-testing",
-    implementationReportURI: "https://github.com/w3c/conneg-prof-testing",
+    implementationReportURI: "https://w3c.github.io/dxwg/connegp-implementation-report/",
     canonicalURI: "TR",
     editors: [{
         name:       "Lars G. Svensson",

--- a/connegp/index.html
+++ b/connegp/index.html
@@ -759,7 +759,8 @@ Content-Profile: http://example.org/profile/x, \
         the more likely it is that the agent intends to request that precise resource
         irrespective of which HTTP headers are sent with that request.
       </p>
-      <p>If other functional profiles of the abstract model are defined each MUST specify order of precedence.</p>
+      <p>If other functional profiles of the abstract model are defined then order of precedence will need to be established.</p>
+      <div class="issue" data-number="505"></div>
     </section>
   </section>
   <section id="functional-profiles">

--- a/connegp/index.html
+++ b/connegp/index.html
@@ -697,7 +697,8 @@ Content-Profile: http://example.org/profile/x, \
         </pre>
         <p>
           When a resource is returned that conforms to two or more profiles that are not within the same profile hierarchy
-          (i.e. the resource conforms to a set of profiles, but some of these are independent, not being specialised profiles of others in the set), the server SHOULD indicate indicate conformance to each independent profile.
+          (i.e. the resource conforms to a set of profiles, but some of these are independent, not being specialised
+          profiles of others in the set), the server SHOULD indicate indicate conformance to each independent profile.
         </p>
         <p>
           For example, using the HTTP Functional Profile,  a response from a server that conforms to both [[?GeoDCAT-AP]] and also [[?STATDCAT-AP]], given
@@ -744,16 +745,20 @@ Content-Profile: http://example.org/profile/x, \
       <h3>Order of Precedence for Implementation Profiles</h3>
       <p>
         A service MAY implement multiple <a>functional profile</a>s, including HTTP, QSA and possibly other approaches.
-        In such cases a client may specify conflicting choices via different mechanisms, for example the common case of client sending default headers but asking for a specific representation.
+        In such cases a client may specify conflicting choices via different mechanisms, for example the common case of
+        client sending default headers but asking for a specific representation.
         The order of precedence defined here determines which mechanism MUST be used.
       </p>
       <p>
-        The order of precedence is QSA over HTTP. 
+        The order of precedence is QSA over HTTP.
         This is on the basis that the more precisely a URI points to a resource,
         the more likely it is that the agent intends to request that precise resource
         irrespective of which HTTP headers are sent with that request.
       </p>
-      <p>If other functional profiles of the abstract model are defined then order of precedence will need to be established. No specific mechanism is proposed for how this may be declared.</p>
+      <p>
+        If other potentially conflicting functional profiles of the abstract model are defined, then order of precedence
+        will need to be established. No specific mechanism is proposed for how this may be declared.
+      </p>
       <div class="issue" data-number="505"></div>
     </section>
   </section>

--- a/connegp/index.html
+++ b/connegp/index.html
@@ -750,16 +750,16 @@ Content-Profile: http://example.org/profile/x, \
       <h3>Order of Precedence for Implementation Profiles</h3>
       <p>
         A service MAY implement multiple <a>functional profile</a>s, including HTTP, QSA and possibly other approaches.
-        In such cases a client MAY specify conflicting choices via different mechanisms.
-        The order of precedence determines which mechanism MUST be used.
+        In such cases a client may specify conflicting choices via different mechanisms, for example the common case of client sending default headers but asking for a specific representation.
+        The order of precedence defined here determines which mechanism MUST be used.
       </p>
       <p>
-        The order of precedence is QSA over HTTP
-        on the basis that the more precisely a URI points to a resource,
+        The order of precedence is QSA over HTTP. 
+        This is on the basis that the more precisely a URI points to a resource,
         the more likely it is that the agent intends to request that precise resource
         irrespective of which HTTP headers are sent with that request.
       </p>
-      <p>If other functional profiles of the abstract model are defined then order of precedence will need to be established.</p>
+      <p>If other functional profiles of the abstract model are defined then order of precedence will need to be established. No specific mechanism is proposed for how this may be declared.</p>
       <div class="issue" data-number="505"></div>
     </section>
   </section>

--- a/connegp/index.html
+++ b/connegp/index.html
@@ -1797,16 +1797,10 @@ Link: &lt;http://www.w3.org/ns/dx/prof/Profile&gt;;
   <section id="implementations" class="informative">
     <h2>Implementations</h2>
     <p>
-      This section includes implementations of the functional profiles given in this document and their conformance
-      test results. The tools used for conformance testing are listed in the section above.
+      Implementations of the functional profiles given in this document and their conformance
+      test results are given in the <a href="https://w3c.github.io/dxwg/conneg-implementation-report">Content Negotiation by Profile Implementation Report</a>.
+      That report also contains a description of, and gives access to the code for, conformance testing tools.
     </p>
-    <ul>
-      <li>
-        <a href="https://github.com/CSIRO-enviro-informatics/prof-conneg-conf-test-results">
-          https://github.com/CSIRO-enviro-informatics/prof-conneg-conf-test-results
-        </a>
-      </li>
-    </ul>
   </section>
   <section id="acknowledgements" class="informative">
     <h2>Acknowledgements</h2>


### PR DESCRIPTION
no mechanism is available - tweaked #505 to make question clearer. 
Removed overspecification using MAY and MUST as per discussions in issue
Hopefully this also clarifies and addresses @agreiner concerns here. 