### PR TITLE
DCAT License cc-by 4.0 for vocabulary files

### DIFF
--- a/dcat/rdf/dcat-external.jsonld
+++ b/dcat/rdf/dcat-external.jsonld
@@ -1584,7 +1584,7 @@
     "@id" : "_:genid20"
   } ],
   "http://purl.org/dc/terms/license" : [ {
-    "@id" : "https://www.w3.org/Consortium/Legal/2015/copyright-software-and-document"
+    "@id" : "https://creativecommons.org/licenses/by/4.0/"
   } ],
   "http://purl.org/dc/terms/modified" : [ {
     "@type" : "http://www.w3.org/2001/XMLSchema#date",

--- a/dcat/rdf/dcat-external.rdf
+++ b/dcat/rdf/dcat-external.rdf
@@ -150,7 +150,7 @@
             </rdf:Description>
         </dct:creator>
         <dct:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2013-09-20</dct:modified>
-        <dct:license rdf:resource="https://www.w3.org/Consortium/Legal/2015/copyright-software-and-document"/>
+        <dct:license rdf:resource="https://creativecommons.org/licenses/by/4.0/"/>
         <dct:contributor>
             <rdf:Description>
                 <foaf:homepage rdf:resource="http://www.asahi-net.or.jp/~ax2s-kmtn/"/>

--- a/dcat/rdf/dcat-external.ttl
+++ b/dcat/rdf/dcat-external.ttl
@@ -507,7 +507,7 @@ time:hasEnd
   dct:creator [
       foaf:name "John Erickson" ;
     ] ;
-  dct:license <https://www.w3.org/Consortium/Legal/2015/copyright-software-and-document> ;
+  dct:license <https://creativecommons.org/licenses/by/4.0/> ;
   dct:modified "2012-04-24"^^xsd:date ;
   dct:modified "2013-09-20"^^xsd:date ;
   dct:modified "2013-11-28"^^xsd:date ;

--- a/dcat/rdf/dcat2.jsonld
+++ b/dcat/rdf/dcat2.jsonld
@@ -137,7 +137,7 @@
     "@type" : "owl:Ontology",
     "contributor" : [ "_:b16", "_:b20", "_:b15", "_:b5", "_:b21", "_:b22", "_:b23", "_:b9", "_:b24", "_:b1", "_:b25", "_:b26", "_:b17", "_:b14", "_:b27", "_:b0" ],
     "creator" : [ "_:b19", "_:b13" ],
-    "license" : "https://www.w3.org/Consortium/Legal/2015/copyright-software-and-document",
+    "license" : "https://creativecommons.org/licenses/by/4.0/",
     "modified" : [ "2013-09-20", "2012-04-24", "2013-11-28", "2017-12-19" ],
     "dct:modified" : "2019",
     "comment" : [ {

--- a/dcat/rdf/dcat2.rdf
+++ b/dcat/rdf/dcat2.rdf
@@ -94,7 +94,7 @@
       <rdfs:seeAlso rdf:resource="http://fadmaa.me/foaf.ttl"/>
     </dct:creator>
     <rdfs:comment xml:lang="en">DCAT is an RDF vocabulary designed to facilitate interoperability between data catalogs published on the Web. By using DCAT to describe datasets in data catalogs, publishers increase discoverability and enable applications easily to consume metadata from multiple catalogs. It further enables decentralized publishing of catalogs and facilitates federated dataset search across sites. Aggregated DCAT metadata can serve as a manifest file to facilitate digital preservation. DCAT is defined at http://www.w3.org/TR/vocab-dcat/. Any variance between that normative document and this schema is an error in this schema.</rdfs:comment>
-    <dct:license rdf:resource="https://www.w3.org/Consortium/Legal/2015/copyright-software-and-document"/>
+    <dct:license rdf:resource="https://creativecommons.org/licenses/by/4.0/"/>
     <dct:contributor rdf:parseType="Resource">
       <foaf:name>Vassilios Peristeras</foaf:name>
       <sdo:affiliation rdf:parseType="Resource">

--- a/dcat/rdf/dcat2.ttl
+++ b/dcat/rdf/dcat2.ttl
@@ -113,7 +113,7 @@
   dct:creator [
       foaf:name "John Erickson" ;
     ] ;
-  dct:license <https://www.w3.org/Consortium/Legal/2015/copyright-software-and-document> ;
+  dct:license <https://creativecommons.org/licenses/by/4.0/> ;
   dct:modified "2012-04-24"^^xsd:date ;
   dct:modified "2013-09-20"^^xsd:date ;
   dct:modified "2013-11-28"^^xsd:date ;


### PR DESCRIPTION
This PR replaces the license https://www.w3.org/Consortium/Legal/2015/copyright-software-and-document with CC-BY 4.0 in the DCAT vocabulary files, as proposed in the [discussion](https://lists.w3.org/Archives/Public/public-dxwg-wg/2020Jan/0062.html) on the  DXWG mailing list. 
