### PR TITLE
schema:url equivalent to foaf:page

### DIFF
--- a/dcat/rdf/dcat-schema.ttl
+++ b/dcat/rdf/dcat-schema.ttl
@@ -220,7 +220,7 @@ foaf:Organization
 foaf:Person
   owl:equivalentClass schema:Person ;
 .
-foaf:homepage
+foaf:page
   owl:equivalentProperty schema:url ;
 .
 foaf:mbox


### PR DESCRIPTION
foaf:page is a closer match to schema:url, than foaf:homepage. Every foaf:homepage is a URL, but not the reverse. This fixes that, as foaf:homepage is a sub property of foaf:page. https://github.com/w3c/dxwg/issues/1231#issuecomment-613778775