### PR TITLE
correct WKT datatype

### DIFF
--- a/dcat/examples/spatial-properties.jsonld
+++ b/dcat/examples/spatial-properties.jsonld
@@ -64,7 +64,7 @@
   "@context" : {
     "centroid" : {
       "@id" : "http://www.w3.org/ns/dcat#centroid",
-      "@type" : "http://www.opengis.net/ont/geosparql#asWKT"
+      "@type" : "http://www.opengis.net/ont/geosparql#wktLiteral"
     },
     "long" : {
       "@id" : "http://www.w3.org/2003/01/geo/wgs84_pos#long",
@@ -94,11 +94,11 @@
     },
     "geometry" : {
       "@id" : "http://www.w3.org/ns/locn#geometry",
-      "@type" : "http://www.opengis.net/ont/geosparql#asWKT"
+      "@type" : "http://www.opengis.net/ont/geosparql#wktLiteral"
     },
     "bbox" : {
       "@id" : "http://www.w3.org/ns/dcat#bbox",
-      "@type" : "http://www.opengis.net/ont/geosparql#asWKT"
+      "@type" : "http://www.opengis.net/ont/geosparql#wktLiteral"
     },
     "geosparql" : "http://www.opengis.net/ont/geosparql#",
     "ex" : "https://dcat.example.org/",

--- a/dcat/examples/spatial-properties.ttl
+++ b/dcat/examples/spatial-properties.ttl
@@ -17,21 +17,21 @@ ex:AnneFrank_0
   a dcat:Dataset ;
   dct:spatial [
       a dct:Location ;
-      locn:geometry "POLYGON (( 4.8842353 52.375108 , 4.884276 52.375153 , 4.8842567 52.375159 , 4.883981 52.375254 , 4.8838502 52.375109 , 4.883819 52.375075 , 4.8841037 52.374979 , 4.884143 52.374965 , 4.8842069 52.375035 , 4.884263 52.375016 , 4.8843200 52.374996 , 4.884255 52.374926 , 4.8843289 52.374901 , 4.884451 52.375034 , 4.8842353 52.375108 ))"^^geosparql:asWKT ;
+      locn:geometry "POLYGON (( 4.8842353 52.375108 , 4.884276 52.375153 , 4.8842567 52.375159 , 4.883981 52.375254 , 4.8838502 52.375109 , 4.883819 52.375075 , 4.8841037 52.374979 , 4.884143 52.374965 , 4.8842069 52.375035 , 4.884263 52.375016 , 4.8843200 52.374996 , 4.884255 52.374926 , 4.8843289 52.374901 , 4.884451 52.375034 , 4.8842353 52.375108 ))"^^geosparql:wktLiteral ;
     ] ;
 .
 ex:AnneFrank_1
   a dcat:Dataset ;
   dct:spatial [
       a dct:Location ;
-      locn:geometry "<http://www.opengis.net/def/crs/EPSG/0/28992> POLYGON (( 120749.725 487589.422 , 120752.55 487594.375  , 120751.227 487595.129 , 120732.539 487605.788 , 120723.505 487589.745 , 120721.387 487585.939 , 120740.668 487575.07  , 120743.316 487573.589 , 120747.735 487581.337 , 120751.564 487579.154 , 120755.411 487576.96  , 120750.935 487569.172 , 120755.941 487566.288 , 120764.369 487581.066 , 120749.725 487589.422 ))"^^geosparql:asWKT ;
+      locn:geometry "<http://www.opengis.net/def/crs/EPSG/0/28992> POLYGON (( 120749.725 487589.422 , 120752.55 487594.375  , 120751.227 487595.129 , 120732.539 487605.788 , 120723.505 487589.745 , 120721.387 487585.939 , 120740.668 487575.07  , 120743.316 487573.589 , 120747.735 487581.337 , 120751.564 487579.154 , 120755.411 487576.96  , 120750.935 487569.172 , 120755.941 487566.288 , 120764.369 487581.066 , 120749.725 487589.422 ))"^^geosparql:wktLiteral ;
     ] ;
 .
 ex:AnneFrank_2
   a dcat:Dataset ;
   dct:spatial [
       a dct:Location ;
-      dcat:centroid "POINT(4.88412 52.37509)"^^geosparql:asWKT ;
+      dcat:centroid "POINT(4.88412 52.37509)"^^geosparql:wktLiteral ;
     ] ;
 .
 ex:AnneFrank_3
@@ -40,7 +40,7 @@ ex:AnneFrank_3
       a dct:Location ;
       w3cgeo:lat 52.37509 ;
       w3cgeo:long 4.88412 ;
-      dcat:centroid "POINT(4.88412 52.37509)"^^geosparql:asWKT ;
+      dcat:centroid "POINT(4.88412 52.37509)"^^geosparql:wktLiteral ;
     ] ;
 .
 ex:Dutch-postal
@@ -49,7 +49,7 @@ ex:Dutch-postal
   dct:description "INSPIRE addresses derived from the Addresses base registry, available for the Netherlands"@en ;
   dct:spatial [
       a dct:Location ;
-      dcat:bbox "POLYGON(( 3.053 47.975 , 7.24  47.975 , 7.24  53.504 , 3.053 53.504 , 3.053 47.975 ))"^^geosparql:asWKT ;
+      dcat:bbox "POLYGON(( 3.053 47.975 , 7.24  47.975 , 7.24  53.504 , 3.053 53.504 , 3.053 47.975 ))"^^geosparql:wktLiteral ;
     ] ;
   dct:title "Addresses"@en ;
   dct:title "Adressen"@nl ;

--- a/dcat/index.html
+++ b/dcat/index.html
@@ -2750,7 +2750,7 @@
               <tbody>
               <tr><td class="prop">Definition:</td><td>Associates any resource with the corresponding geometry. [[LOCN]]</td></tr>
               <tr><td class="prop">Range:</td><td><a data-cite="RDF-SCHEMA#ch_literal"><code title="http://www.w3.org/2000/01/rdf-schema#Literal">rdfs:Literal</code></a></td></tr>
-              <tr><td class="prop">Usage note:</td><td>The range of this property is intentionally generic, with the purpose of allowing different geometry encodings. E.g., the geometry could be encoded as <abbr title="Well-known Text">WKT</abbr> (<a href="http://www.opengis.net/ont/geosparql#asWKT"><code title="http://www.opengis.net/ont/geosparql#asWKT">geosparql:asWKT</code></a> [[GeoSPARQL]]).</td></tr>
+              <tr><td class="prop">Usage note:</td><td>The range of this property is intentionally generic, with the purpose of allowing different geometry encodings. E.g., the geometry could be encoded as <abbr title="Well-known Text">WKT</abbr> (<a href="http://www.opengis.net/ont/geosparql#wktLiteral"><code title="http://www.opengis.net/ont/geosparql#wktLiteral">geosparql:wktLiteral</code></a> [[GeoSPARQL]]).</td></tr>
               </tbody>
             </table>
 
@@ -2776,7 +2776,7 @@
               <tbody>
               <tr><td class="prop">Definition:</td><td>The geographic bounding box of a resource.</td></tr>
               <tr><td class="prop">Range:</td><td><a data-cite="RDF-SCHEMA#ch_literal"><code title="http://www.w3.org/2000/01/rdf-schema#Literal">rdfs:Literal</code></a></td></tr>
-              <tr><td class="prop">Usage note:</td><td>The range of this property is intentionally generic, with the purpose of allowing different geometry encodings. E.g., the geometry could be encoded as <abbr title="Well-known Text">WKT</abbr> (<a href="http://www.opengis.net/ont/geosparql#asWKT"><code title="http://www.opengis.net/ont/geosparql#asWKT">geosparql:asWKT</code></a> [[GeoSPARQL]]).</td></tr>
+              <tr><td class="prop">Usage note:</td><td>The range of this property is intentionally generic, with the purpose of allowing different geometry encodings. E.g., the geometry could be encoded as <abbr title="Well-known Text">WKT</abbr> (<a href="http://www.opengis.net/ont/geosparql#wktLiteral"><code title="http://www.opengis.net/ont/geosparql#wktLiteral">geosparql:wktLiteral</code></a> [[GeoSPARQL]]).</td></tr>
               </tbody>
             </table>
 
@@ -2802,7 +2802,7 @@
               <tbody>
               <tr><td class="prop">Definition:</td><td>The geographic center (centroid) of a resource.</td></tr>
               <tr><td class="prop">Range:</td><td><a data-cite="RDF-SCHEMA#ch_literal"><code title="http://www.w3.org/2000/01/rdf-schema#Literal">rdfs:Literal</code></a></td></tr>
-              <tr><td class="prop">Usage note:</td><td>The range of this property is intentionally generic, with the purpose of allowing different geometry encodings. E.g., the geometry could be encoded as <abbr title="Well-known Text">WKT</abbr> (<a href="http://www.opengis.net/ont/geosparql#asWKT"><code title="http://www.opengis.net/ont/geosparql#asWKT">geosparql:asWKT</code></a> [[GeoSPARQL]]).</td></tr>
+              <tr><td class="prop">Usage note:</td><td>The range of this property is intentionally generic, with the purpose of allowing different geometry encodings. E.g., the geometry could be encoded as <abbr title="Well-known Text">WKT</abbr> (<a href="http://www.opengis.net/ont/geosparql#wktLiteral"><code title="http://www.opengis.net/ont/geosparql#wktLiteral">geosparql:wktLiteral</code></a> [[GeoSPARQL]]).</td></tr>
               </tbody>
             </table>
 
@@ -3181,7 +3181,7 @@ ex:InternationalDOIFundation a foaf:Organization ;
       4.8843200 52.374996 , 4.884255 52.374926 ,
       4.8843289 52.374901 , 4.884451 52.375034 ,
       4.8842353 52.375108
-    ))"""^^geosparql:asWKT ;
+    ))"""^^geosparql:wktLiteral ;
   ] .
 </pre>
 <figure id="fig-spatial-coverage-geometry">
@@ -3205,7 +3205,7 @@ ex:InternationalDOIFundation a foaf:Organization ;
       120755.411 487576.96  , 120750.935 487569.172 ,
       120755.941 487566.288 , 120764.369 487581.066 ,
       120749.725 487589.422
-    ))"""^^geosparql:asWKT ;
+    ))"""^^geosparql:wktLiteral ;
   ] .
 </pre>
 </aside>
@@ -3216,7 +3216,7 @@ ex:InternationalDOIFundation a foaf:Organization ;
 &lt;AnneFrank_2&gt; a dcat:Dataset ;
   dct:spatial [
     a dct:Location ;
-    dcat:centroid "POINT(4.88412 52.37509)"^^geosparql:asWKT ;
+    dcat:centroid "POINT(4.88412 52.37509)"^^geosparql:wktLiteral ;
   ] .
 </pre>
 <figure id="fig-spatial-coverage-centroid">
@@ -3225,14 +3225,14 @@ ex:InternationalDOIFundation a foaf:Organization ;
 </figure>
 <div class="note">
 <p>This point location could be expressed using the [[W3C-BASIC-GEO]] vocabulary. 
-If it is required to provide the <code>w3cgeo:Point</code> formulation, then it should be in addition to, not in place of, a <code>dcat:centroid</code> containing a <abbr title="Well-known Text">WKT</abbr> literal (<a href="http://www.opengis.net/ont/geosparql#asWKT"><code title="http://www.opengis.net/ont/geosparql#asWKT">geosparql:asWKT</code></a> [[GeoSPARQL]]). 
+If it is required to provide the <code>w3cgeo:Point</code> formulation, then it should be in addition to, not in place of, a <code>dcat:centroid</code> containing a <abbr title="Well-known Text">WKT</abbr> literal (<a href="http://www.opengis.net/ont/geosparql#wktLiteral"><code title="http://www.opengis.net/ont/geosparql#wktLiteral">geosparql:wktLiteral</code></a> [[GeoSPARQL]]). 
 This ensures interoperability with other DCAT dataset descriptions. 
 For example:
 <pre class="nohighlight turtle">
   &lt;AnneFrank_3&gt; a dcat:Dataset ;
     dct:spatial [
       a dct:Location , w3cgeo:Point ;
-      dcat:centroid "POINT(4.88412 52.37509)"^^geosparql:asWKT ;
+      dcat:centroid "POINT(4.88412 52.37509)"^^geosparql:wktLiteral ;
       w3cgeo:lat  "52.37509"^^xsd:decimal ;
       w3cgeo:long "4.88412"^^xsd:decimal ;
     ] .
@@ -3257,7 +3257,7 @@ For example:
       3.053 47.975 , 7.24  47.975 ,
       7.24  53.504 , 3.053 53.504 ,
       3.053 47.975
-    ))"""^^geosparql:asWKT ;
+    ))"""^^geosparql:wktLiteral ;
   ] .
 </pre>
 <figure id="fig-spatial-coverage-bbox">

--- a/dcat/rdf/dcat-external.jsonld
+++ b/dcat/rdf/dcat-external.jsonld
@@ -1653,16 +1653,16 @@
   } ],
   "http://www.w3.org/2004/02/skos/core#scopeNote" : [ {
     "@language" : "es",
-    "@value" : " el contexto de DCAT 2.0, el rango de esta propiedad es intencionalmente genérico con el propósito de permitir distintas codificaciones de la geometría. Por ejemplo, la geometría puede codificarse como WKT (geosparql:asWKT [GeoSPARQL])."
+    "@value" : " el contexto de DCAT 2.0, el rango de esta propiedad es intencionalmente genérico con el propósito de permitir distintas codificaciones de la geometría. Por ejemplo, la geometría puede codificarse como WKT (geosparql:wktLiteral [GeoSPARQL])."
   }, {
     "@language" : "en",
-    "@value" : "In the context of DCAT 2.0, the range of this property is intentionally generic, with the purpose of allowing different geometry encodings. E.g., the geometry could be encoded as WKT (geosparql:asWKT [GeoSPARQL])."
+    "@value" : "In the context of DCAT 2.0, the range of this property is intentionally generic, with the purpose of allowing different geometry encodings. E.g., the geometry could be encoded as WKT (geosparql:wktLiteral [GeoSPARQL])."
   }, {
     "@language" : "it",
-    "@value" : "Nel contesto del DCAT 2.0, il range di questa proprietà è volutamente generico, con lo scopo di consentire diverse codifiche geometriche. Ad esempio, la geometria potrebbe essere codificata come WKT (geosparql:asWKT [GeoSPARQL])."
+    "@value" : "Nel contesto del DCAT 2.0, il range di questa proprietà è volutamente generico, con lo scopo di consentire diverse codifiche geometriche. Ad esempio, la geometria potrebbe essere codificata come WKT (geosparql:wktLiteral [GeoSPARQL])."
   }, {
     "@language" : "cs",
-    "@value" : "V kontextu DCAT 2.0, obor hodnot této vlastnosti je úmyslně obecný, aby umožnil různé kódování geometrií. Geometrie by kupříkladu mohla být kódována jako WKT (geosparql:asWKT [GeoSPARQL])."
+    "@value" : "V kontextu DCAT 2.0, obor hodnot této vlastnosti je úmyslně obecný, aby umožnil různé kódování geometrií. Geometrie by kupříkladu mohla být kódována jako WKT (geosparql:wktLiteral [GeoSPARQL])."
   } ]
 }, {
   "@id" : "http://www.w3.org/ns/odrl/2/hasPolicy",

--- a/dcat/rdf/dcat-external.rdf
+++ b/dcat/rdf/dcat-external.rdf
@@ -344,10 +344,10 @@
         <skos:definition xml:lang="it">Associa qualsiasi risorsa alla geometria corrispondente.</skos:definition>
         <skos:definition xml:lang="en">Associates any resource with the corresponding geometry.</skos:definition>
         <skos:definition xml:lang="cs">Přiřazuje geometrii jakémukoliv zdroji.</skos:definition>
-        <skos:scopeNote xml:lang="es"> el contexto de DCAT 2.0, el rango de esta propiedad es intencionalmente genérico con el propósito de permitir distintas codificaciones de la geometría. Por ejemplo, la geometría puede codificarse como WKT (geosparql:asWKT [GeoSPARQL]).</skos:scopeNote>
-        <skos:scopeNote xml:lang="en">In the context of DCAT 2.0, the range of this property is intentionally generic, with the purpose of allowing different geometry encodings. E.g., the geometry could be encoded as WKT (geosparql:asWKT [GeoSPARQL]).</skos:scopeNote>
-        <skos:scopeNote xml:lang="it">Nel contesto del DCAT 2.0, il range di questa proprietà è volutamente generico, con lo scopo di consentire diverse codifiche geometriche. Ad esempio, la geometria potrebbe essere codificata come WKT (geosparql:asWKT [GeoSPARQL]).</skos:scopeNote>
-        <skos:scopeNote xml:lang="cs">V kontextu DCAT 2.0, obor hodnot této vlastnosti je úmyslně obecný, aby umožnil různé kódování geometrií. Geometrie by kupříkladu mohla být kódována jako WKT (geosparql:asWKT [GeoSPARQL]).</skos:scopeNote>
+        <skos:scopeNote xml:lang="es"> el contexto de DCAT 2.0, el rango de esta propiedad es intencionalmente genérico con el propósito de permitir distintas codificaciones de la geometría. Por ejemplo, la geometría puede codificarse como WKT (geosparql:wktLiteral [GeoSPARQL]).</skos:scopeNote>
+        <skos:scopeNote xml:lang="en">In the context of DCAT 2.0, the range of this property is intentionally generic, with the purpose of allowing different geometry encodings. E.g., the geometry could be encoded as WKT (geosparql:wktLiteral [GeoSPARQL]).</skos:scopeNote>
+        <skos:scopeNote xml:lang="it">Nel contesto del DCAT 2.0, il range di questa proprietà è volutamente generico, con lo scopo di consentire diverse codifiche geometriche. Ad esempio, la geometria potrebbe essere codificata come WKT (geosparql:wktLiteral [GeoSPARQL]).</skos:scopeNote>
+        <skos:scopeNote xml:lang="cs">V kontextu DCAT 2.0, obor hodnot této vlastnosti je úmyslně obecný, aby umožnil různé kódování geometrií. Geometrie by kupříkladu mohla být kódována jako WKT (geosparql:wktLiteral [GeoSPARQL]).</skos:scopeNote>
     </owl:ObjectProperty>
     
 

--- a/dcat/rdf/dcat-external.ttl
+++ b/dcat/rdf/dcat-external.ttl
@@ -530,10 +530,10 @@ locn:geometry
   skos:definition "Associa qualsiasi risorsa alla geometria corrispondente."@it ;
   skos:definition "Associates any resource with the corresponding geometry."@en ;
   skos:definition "Přiřazuje geometrii jakémukoliv zdroji."@cs ;
-  skos:scopeNote " el contexto de DCAT 2.0, el rango de esta propiedad es intencionalmente genérico con el propósito de permitir distintas codificaciones de la geometría. Por ejemplo, la geometría puede codificarse como WKT (geosparql:asWKT [GeoSPARQL])."@es ;
-  skos:scopeNote "In the context of DCAT 2.0, the range of this property is intentionally generic, with the purpose of allowing different geometry encodings. E.g., the geometry could be encoded as WKT (geosparql:asWKT [GeoSPARQL])."@en ;
-  skos:scopeNote "Nel contesto del DCAT 2.0, il range di questa proprietà è volutamente generico, con lo scopo di consentire diverse codifiche geometriche. Ad esempio, la geometria potrebbe essere codificata come WKT (geosparql:asWKT [GeoSPARQL])."@it ;
-  skos:scopeNote "V kontextu DCAT 2.0, obor hodnot této vlastnosti je úmyslně obecný, aby umožnil různé kódování geometrií. Geometrie by kupříkladu mohla být kódována jako WKT (geosparql:asWKT [GeoSPARQL])."@cs ;
+  skos:scopeNote " el contexto de DCAT 2.0, el rango de esta propiedad es intencionalmente genérico con el propósito de permitir distintas codificaciones de la geometría. Por ejemplo, la geometría puede codificarse como WKT (geosparql:wktLiteral [GeoSPARQL])."@es ;
+  skos:scopeNote "In the context of DCAT 2.0, the range of this property is intentionally generic, with the purpose of allowing different geometry encodings. E.g., the geometry could be encoded as WKT (geosparql:wktLiteral [GeoSPARQL])."@en ;
+  skos:scopeNote "Nel contesto del DCAT 2.0, il range di questa proprietà è volutamente generico, con lo scopo di consentire diverse codifiche geometriche. Ad esempio, la geometria potrebbe essere codificata come WKT (geosparql:wktLiteral [GeoSPARQL])."@it ;
+  skos:scopeNote "V kontextu DCAT 2.0, obor hodnot této vlastnosti je úmyslně obecný, aby umožnil různé kódování geometrií. Geometrie by kupříkladu mohla být kódována jako WKT (geosparql:wktLiteral [GeoSPARQL])."@cs ;
 .
 odrl:hasPolicy
   skos:definition "En el contexto de DCAT 2.0 dcat:Distribution, una reglamentación conforme a ODRL expresando los derechos asociados con la distribución [ODRL-VOCAB]."@es ;

--- a/dcat/rdf/dcat2.jsonld
+++ b/dcat/rdf/dcat2.jsonld
@@ -1171,16 +1171,16 @@
     } ],
     "scopeNote" : [ {
       "@language" : "en",
-      "@value" : "The range of this property is intentionally generic, with the purpose of allowing different geometry encodings. E.g., the geometry could be encoded with as WKT (geosparql:asWKT [GeoSPARQL]) or [GML] (geosparql:asGML [GeoSPARQL])."
+      "@value" : "The range of this property is intentionally generic, with the purpose of allowing different geometry encodings. E.g., the geometry could be encoded with as WKT (geosparql:wktLiteral [GeoSPARQL]) or [GML] (geosparql:asGML [GeoSPARQL])."
     }, {
       "@language" : "cs",
-      "@value" : "Obor hodnot této vlastnosti je úmyslně obecný, aby umožnil různé kódování geometrií. Geometrie by kupříkladu mohla být kódována jako WKT (geosparql:asWKT [GeoSPARQL]) či [GML] (geosparql:asGML [GeoSPARQL])."
+      "@value" : "Obor hodnot této vlastnosti je úmyslně obecný, aby umožnil různé kódování geometrií. Geometrie by kupříkladu mohla být kódována jako WKT (geosparql:wktLiteral [GeoSPARQL]) či [GML] (geosparql:asGML [GeoSPARQL])."
     }, {
       "@language" : "it",
-      "@value" : "Il range di questa proprietà è volutamente generica, con lo scopo di consentire diverse codifiche geometriche. Ad esempio, la geometria potrebbe essere codificata con WKT (geosparql:asWKT [GeoSPARQL]) o [GML] (geosparql:asGML [GeoSPARQL])."
+      "@value" : "Il range di questa proprietà è volutamente generica, con lo scopo di consentire diverse codifiche geometriche. Ad esempio, la geometria potrebbe essere codificata con WKT (geosparql:wktLiteral [GeoSPARQL]) o [GML] (geosparql:asGML [GeoSPARQL])."
     }, {
       "@language" : "es",
-      "@value" : "El rango de esta propiedad es intencionalmente genérico con el propósito de permitir distintas codificaciones geométricas. Por ejemplo, la geometría puede ser codificada como WKT (geosparql:asWKT [GeoSPARQL]) o [GML] (geosparql:asGML [GeoSPARQL])."
+      "@value" : "El rango de esta propiedad es intencionalmente genérico con el propósito de permitir distintas codificaciones geométricas. Por ejemplo, la geometría puede ser codificada como WKT (geosparql:wktLiteral [GeoSPARQL]) o [GML] (geosparql:asGML [GeoSPARQL])."
     } ]
   }, {
     "@id" : "dcat:byteSize",
@@ -1392,16 +1392,16 @@
     } ],
     "scopeNote" : [ {
       "@language" : "it",
-      "@value" : "Il range di questa proprietà è volutamente generica, con lo scopo di consentire diverse codifiche geometriche. Ad esempio, la geometria potrebbe essere codificata con WKT (geosparql:asWKT [GeoSPARQL]) o [GML] (geosparql:asGML [GeoSPARQL])."
+      "@value" : "Il range di questa proprietà è volutamente generica, con lo scopo di consentire diverse codifiche geometriche. Ad esempio, la geometria potrebbe essere codificata con WKT (geosparql:wktLiteral [GeoSPARQL]) o [GML] (geosparql:asGML [GeoSPARQL])."
     }, {
       "@language" : "cs",
-      "@value" : "Obor hodnot této vlastnosti je úmyslně obecný, aby umožnil různé kódování geometrií. Geometrie by kupříkladu mohla být kódována jako WKT (geosparql:asWKT [GeoSPARQL]) či [GML] (geosparql:asGML [GeoSPARQL])."
+      "@value" : "Obor hodnot této vlastnosti je úmyslně obecný, aby umožnil různé kódování geometrií. Geometrie by kupříkladu mohla být kódována jako WKT (geosparql:wktLiteral [GeoSPARQL]) či [GML] (geosparql:asGML [GeoSPARQL])."
     }, {
       "@language" : "es",
-      "@value" : "El rango de esta propiedad es intencionalmente genérico con el objetivo de permitir distintas codificaciones geométricas. Por ejemplo, la geometría puede codificarse como WKT (geosparql:asWKT [GeoSPARQL]) o [GML] (geosparql:asGML [GeoSPARQL])."
+      "@value" : "El rango de esta propiedad es intencionalmente genérico con el objetivo de permitir distintas codificaciones geométricas. Por ejemplo, la geometría puede codificarse como WKT (geosparql:wktLiteral [GeoSPARQL]) o [GML] (geosparql:asGML [GeoSPARQL])."
     }, {
       "@language" : "en",
-      "@value" : "The range of this property is intentionally generic, with the purpose of allowing different geometry encodings. E.g., the geometry could be encoded with as WKT (geosparql:asWKT [GeoSPARQL]) or [GML] (geosparql:asGML [GeoSPARQL])."
+      "@value" : "The range of this property is intentionally generic, with the purpose of allowing different geometry encodings. E.g., the geometry could be encoded with as WKT (geosparql:wktLiteral [GeoSPARQL]) or [GML] (geosparql:asGML [GeoSPARQL])."
     } ]
   }, {
     "@id" : "dcat:compressFormat",

--- a/dcat/rdf/dcat2.rdf
+++ b/dcat/rdf/dcat2.rdf
@@ -1157,8 +1157,8 @@
     <rdfs:comment xml:lang="el">Συνδέει ένα σύνολο δεδομένων με μία από τις διαθέσιμες διανομές του.</rdfs:comment>
   </rdf:Property>
   <rdf:Property rdf:ID="bbox">
-    <skos:scopeNote xml:lang="en">The range of this property is intentionally generic, with the purpose of allowing different geometry encodings. E.g., the geometry could be encoded with as WKT (geosparql:asWKT [GeoSPARQL]) or [GML] (geosparql:asGML [GeoSPARQL]).</skos:scopeNote>
-    <skos:scopeNote xml:lang="cs">Obor hodnot této vlastnosti je úmyslně obecný, aby umožnil různé kódování geometrií. Geometrie by kupříkladu mohla být kódována jako WKT (geosparql:asWKT [GeoSPARQL]) či [GML] (geosparql:asGML [GeoSPARQL]).</skos:scopeNote>
+    <skos:scopeNote xml:lang="en">The range of this property is intentionally generic, with the purpose of allowing different geometry encodings. E.g., the geometry could be encoded with as WKT (geosparql:wktLiteral [GeoSPARQL]) or [GML] (geosparql:asGML [GeoSPARQL]).</skos:scopeNote>
+    <skos:scopeNote xml:lang="cs">Obor hodnot této vlastnosti je úmyslně obecný, aby umožnil různé kódování geometrií. Geometrie by kupříkladu mohla být kódována jako WKT (geosparql:wktLiteral [GeoSPARQL]) či [GML] (geosparql:asGML [GeoSPARQL]).</skos:scopeNote>
     <skos:definition xml:lang="it">Il riquadro di delimitazione geografica di una risorsa.</skos:definition>
     <rdfs:domain rdf:resource="http://purl.org/dc/terms/Location"/>
     <skos:changeNote xml:lang="cs">Nová vlastnost přidaná ve verzi DCAT 2.0.</skos:changeNote>
@@ -1168,10 +1168,10 @@
     <rdfs:label xml:lang="es">cuadro delimitador</rdfs:label>
     <skos:changeNote xml:lang="en">New property added in DCAT 2.0.</skos:changeNote>
     <rdfs:range rdf:resource="http://www.w3.org/2000/01/rdf-schema#Literal"/>
-    <skos:scopeNote xml:lang="it">Il range di questa proprietà è volutamente generica, con lo scopo di consentire diverse codifiche geometriche. Ad esempio, la geometria potrebbe essere codificata con WKT (geosparql:asWKT [GeoSPARQL]) o [GML] (geosparql:asGML [GeoSPARQL]).</skos:scopeNote>
+    <skos:scopeNote xml:lang="it">Il range di questa proprietà è volutamente generica, con lo scopo di consentire diverse codifiche geometriche. Ad esempio, la geometria potrebbe essere codificata con WKT (geosparql:wktLiteral [GeoSPARQL]) o [GML] (geosparql:asGML [GeoSPARQL]).</skos:scopeNote>
     <rdfs:label xml:lang="cs">ohraničení oblasti</rdfs:label>
     <skos:definition xml:lang="cs">Ohraničení geografické oblasti zdroje.</skos:definition>
-    <skos:scopeNote xml:lang="es">El rango de esta propiedad es intencionalmente genérico con el propósito de permitir distintas codificaciones geométricas. Por ejemplo, la geometría puede ser codificada como WKT (geosparql:asWKT [GeoSPARQL]) o [GML] (geosparql:asGML [GeoSPARQL]).</skos:scopeNote>
+    <skos:scopeNote xml:lang="es">El rango de esta propiedad es intencionalmente genérico con el propósito de permitir distintas codificaciones geométricas. Por ejemplo, la geometría puede ser codificada como WKT (geosparql:wktLiteral [GeoSPARQL]) o [GML] (geosparql:asGML [GeoSPARQL]).</skos:scopeNote>
     <skos:definition xml:lang="es">El cuadro delimitador geográfico para un recurso.</skos:definition>
     <skos:changeNote xml:lang="it">Nuova proprietà aggiunta in DCAT 2.0.</skos:changeNote>
     <skos:definition xml:lang="en">The geographic bounding box of a resource.</skos:definition>
@@ -1221,10 +1221,10 @@
     <rdfs:label xml:lang="cs">centroid</rdfs:label>
     <rdfs:domain rdf:resource="http://purl.org/dc/terms/Location"/>
     <skos:definition xml:lang="cs">Geografický střed (centroid) zdroje.</skos:definition>
-    <skos:scopeNote xml:lang="it">Il range di questa proprietà è volutamente generica, con lo scopo di consentire diverse codifiche geometriche. Ad esempio, la geometria potrebbe essere codificata con WKT (geosparql:asWKT [GeoSPARQL]) o [GML] (geosparql:asGML [GeoSPARQL]).</skos:scopeNote>
-    <skos:scopeNote xml:lang="cs">Obor hodnot této vlastnosti je úmyslně obecný, aby umožnil různé kódování geometrií. Geometrie by kupříkladu mohla být kódována jako WKT (geosparql:asWKT [GeoSPARQL]) či [GML] (geosparql:asGML [GeoSPARQL]).</skos:scopeNote>
-    <skos:scopeNote xml:lang="es">El rango de esta propiedad es intencionalmente genérico con el objetivo de permitir distintas codificaciones geométricas. Por ejemplo, la geometría puede codificarse como WKT (geosparql:asWKT [GeoSPARQL]) o [GML] (geosparql:asGML [GeoSPARQL]).</skos:scopeNote>
-    <skos:scopeNote xml:lang="en">The range of this property is intentionally generic, with the purpose of allowing different geometry encodings. E.g., the geometry could be encoded with as WKT (geosparql:asWKT [GeoSPARQL]) or [GML] (geosparql:asGML [GeoSPARQL]).</skos:scopeNote>
+    <skos:scopeNote xml:lang="it">Il range di questa proprietà è volutamente generica, con lo scopo di consentire diverse codifiche geometriche. Ad esempio, la geometria potrebbe essere codificata con WKT (geosparql:wktLiteral [GeoSPARQL]) o [GML] (geosparql:asGML [GeoSPARQL]).</skos:scopeNote>
+    <skos:scopeNote xml:lang="cs">Obor hodnot této vlastnosti je úmyslně obecný, aby umožnil různé kódování geometrií. Geometrie by kupříkladu mohla být kódována jako WKT (geosparql:wktLiteral [GeoSPARQL]) či [GML] (geosparql:asGML [GeoSPARQL]).</skos:scopeNote>
+    <skos:scopeNote xml:lang="es">El rango de esta propiedad es intencionalmente genérico con el objetivo de permitir distintas codificaciones geométricas. Por ejemplo, la geometría puede codificarse como WKT (geosparql:wktLiteral [GeoSPARQL]) o [GML] (geosparql:asGML [GeoSPARQL]).</skos:scopeNote>
+    <skos:scopeNote xml:lang="en">The range of this property is intentionally generic, with the purpose of allowing different geometry encodings. E.g., the geometry could be encoded with as WKT (geosparql:wktLiteral [GeoSPARQL]) or [GML] (geosparql:asGML [GeoSPARQL]).</skos:scopeNote>
     <skos:definition xml:lang="es">El centro geográfico (centroide) de un recurso.</skos:definition>
     <rdfs:range rdf:resource="http://www.w3.org/2000/01/rdf-schema#Literal"/>
     <rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Property"/>

--- a/dcat/rdf/dcat2.ttl
+++ b/dcat/rdf/dcat2.ttl
@@ -516,10 +516,10 @@ dcat:bbox
   skos:definition "Ohraničení geografické oblasti zdroje."@cs ;
   skos:definition "The geographic bounding box of a resource."@en ;
   skos:definition "Il riquadro di delimitazione geografica di una risorsa."@it ;
-  skos:scopeNote "El rango de esta propiedad es intencionalmente genérico con el propósito de permitir distintas codificaciones geométricas. Por ejemplo, la geometría puede ser codificada como WKT (geosparql:asWKT [GeoSPARQL]) o [GML] (geosparql:asGML [GeoSPARQL])."@es ;
-  skos:scopeNote "Obor hodnot této vlastnosti je úmyslně obecný, aby umožnil různé kódování geometrií. Geometrie by kupříkladu mohla být kódována jako WKT (geosparql:asWKT [GeoSPARQL]) či [GML] (geosparql:asGML [GeoSPARQL])."@cs ;
-  skos:scopeNote "The range of this property is intentionally generic, with the purpose of allowing different geometry encodings. E.g., the geometry could be encoded with as WKT (geosparql:asWKT [GeoSPARQL]) or [GML] (geosparql:asGML [GeoSPARQL])."@en ;
-  skos:scopeNote "Il range di questa proprietà è volutamente generica, con lo scopo di consentire diverse codifiche geometriche. Ad esempio, la geometria potrebbe essere codificata con WKT (geosparql:asWKT [GeoSPARQL]) o [GML] (geosparql:asGML [GeoSPARQL])."@it ;
+  skos:scopeNote "El rango de esta propiedad es intencionalmente genérico con el propósito de permitir distintas codificaciones geométricas. Por ejemplo, la geometría puede ser codificada como WKT (geosparql:wktLiteral [GeoSPARQL]) o [GML] (geosparql:asGML [GeoSPARQL])."@es ;
+  skos:scopeNote "Obor hodnot této vlastnosti je úmyslně obecný, aby umožnil různé kódování geometrií. Geometrie by kupříkladu mohla být kódována jako WKT (geosparql:wktLiteral [GeoSPARQL]) či [GML] (geosparql:asGML [GeoSPARQL])."@cs ;
+  skos:scopeNote "The range of this property is intentionally generic, with the purpose of allowing different geometry encodings. E.g., the geometry could be encoded with as WKT (geosparql:wktLiteral [GeoSPARQL]) or [GML] (geosparql:asGML [GeoSPARQL])."@en ;
+  skos:scopeNote "Il range di questa proprietà è volutamente generica, con lo scopo di consentire diverse codifiche geometriche. Ad esempio, la geometria potrebbe essere codificata con WKT (geosparql:wktLiteral [GeoSPARQL]) o [GML] (geosparql:asGML [GeoSPARQL])."@it ;
 .
 dcat:byteSize
   a rdf:Property ;
@@ -600,10 +600,10 @@ dcat:centroid
   skos:definition "Geografický střed (centroid) zdroje."@cs ;
   skos:definition "The geographic center (centroid) of a resource."@en ;
   skos:definition "Il centro geografico (centroide) di una risorsa."@it ;
-  skos:scopeNote "El rango de esta propiedad es intencionalmente genérico con el objetivo de permitir distintas codificaciones geométricas. Por ejemplo, la geometría puede codificarse como WKT (geosparql:asWKT [GeoSPARQL]) o [GML] (geosparql:asGML [GeoSPARQL])."@es ;
-  skos:scopeNote "Obor hodnot této vlastnosti je úmyslně obecný, aby umožnil různé kódování geometrií. Geometrie by kupříkladu mohla být kódována jako WKT (geosparql:asWKT [GeoSPARQL]) či [GML] (geosparql:asGML [GeoSPARQL])."@cs ;
-  skos:scopeNote "The range of this property is intentionally generic, with the purpose of allowing different geometry encodings. E.g., the geometry could be encoded with as WKT (geosparql:asWKT [GeoSPARQL]) or [GML] (geosparql:asGML [GeoSPARQL])."@en ;
-  skos:scopeNote "Il range di questa proprietà è volutamente generica, con lo scopo di consentire diverse codifiche geometriche. Ad esempio, la geometria potrebbe essere codificata con WKT (geosparql:asWKT [GeoSPARQL]) o [GML] (geosparql:asGML [GeoSPARQL])."@it ;
+  skos:scopeNote "El rango de esta propiedad es intencionalmente genérico con el objetivo de permitir distintas codificaciones geométricas. Por ejemplo, la geometría puede codificarse como WKT (geosparql:wktLiteral [GeoSPARQL]) o [GML] (geosparql:asGML [GeoSPARQL])."@es ;
+  skos:scopeNote "Obor hodnot této vlastnosti je úmyslně obecný, aby umožnil různé kódování geometrií. Geometrie by kupříkladu mohla být kódována jako WKT (geosparql:wktLiteral [GeoSPARQL]) či [GML] (geosparql:asGML [GeoSPARQL])."@cs ;
+  skos:scopeNote "The range of this property is intentionally generic, with the purpose of allowing different geometry encodings. E.g., the geometry could be encoded with as WKT (geosparql:wktLiteral [GeoSPARQL]) or [GML] (geosparql:asGML [GeoSPARQL])."@en ;
+  skos:scopeNote "Il range di questa proprietà è volutamente generica, con lo scopo di consentire diverse codifiche geometriche. Ad esempio, la geometria potrebbe essere codificata con WKT (geosparql:wktLiteral [GeoSPARQL]) o [GML] (geosparql:asGML [GeoSPARQL])."@it ;
 .
 dcat:compressFormat
   a rdf:Property ;


### PR DESCRIPTION
change `geosparql:asWKT` (a DatatypeProperty) to `geosparql:wktLiteral` (a Datatype) throughout

All usages are in non-normative examples or comments. 

Fixes #1233 