### PR TITLE
Dcat changing example using dct relation

### DIFF
--- a/dcat/examples/csiro-stratchart.jsonld
+++ b/dcat/examples/csiro-stratchart.jsonld
@@ -81,7 +81,8 @@
       "@value" : "Service that supports queries to obtain RDF representations of subsets of the data"
     },
     "endpointURL" : "http://vocabs.ands.org.au/repository/api/sparql/csiro_international-chronostratigraphic-chart_2017",
-    "landingPage" : "https://vocabs.ands.org.au/viewById/196"
+    "landingPage" : "https://vocabs.ands.org.au/viewById/196",
+    "servesDataset" : "dap:d33937"
   }, {
     "@id" : "dap:d33937.nt",
     "@type" : "dcat:Distribution",
@@ -217,12 +218,16 @@
       "@id" : "http://www.w3.org/ns/dcat#downloadURL",
       "@type" : "@id"
     },
-    "imports" : {
-      "@id" : "http://www.w3.org/2002/07/owl#imports",
+    "servesDataset" : {
+      "@id" : "http://www.w3.org/ns/dcat#servesDataset",
       "@type" : "@id"
     },
     "endpointURL" : {
       "@id" : "http://www.w3.org/ns/dcat#endpointURL",
+      "@type" : "@id"
+    },
+    "imports" : {
+      "@id" : "http://www.w3.org/2002/07/owl#imports",
       "@type" : "@id"
     },
     "owl" : "http://www.w3.org/2002/07/owl#",

--- a/dcat/examples/csiro-stratchart.jsonld
+++ b/dcat/examples/csiro-stratchart.jsonld
@@ -1,125 +1,163 @@
 {
   "@graph" : [ {
-    "@id" : "_:b0",
-    "@type" : "dcat:Distribution",
-    "identifier" : "isc2017.nt",
-    "comment" : "N-Triples serialization of the RDF representation of the entire dataset",
-    "mediaType" : "mime:application/n-triples"
-  }, {
-    "@id" : "_:b1",
-    "@type" : "dcat:Distribution",
-    "identifier" : "isc2017.ttl",
-    "comment" : "TTL serialization of the RDF representation of the entire dataset",
-    "mediaType" : "mime:text/turtle"
-  }, {
-    "@id" : "_:b2",
-    "@type" : "dcat:Distribution",
-    "conformsTo" : "https://www.w3.org/TR/rdf-schema/",
-    "comment" : "RDF representation of the data",
-    "accessService" : "_:b9"
-  }, {
-    "@id" : "_:b3",
-    "@type" : "dcat:Dataset",
-    "conformsTo" : "https://www.w3.org/TR/owl2-overview/",
-    "description" : "This is an RDF/OWL representation of the GeoSciML Geologic Timescale model ...",
-    "issued" : "2011-01-01",
-    "modified" : "2017-04-28",
-    "title" : "Geologic Timescale model",
-    "type" : "http://purl.org/adms/assettype/DomainModel",
-    "comment" : "The ontology used for the data",
-    "distribution" : [ "_:b6", "_:b7", "_:b8" ],
-    "landingPage" : "http://resource.geosciml.org/ontology/timescale/gts"
-  }, {
-    "@id" : "_:b4",
-    "@type" : "dcat:Distribution",
-    "identifier" : "isc2017.jsonld",
-    "comment" : "JSON-LD serialization of the RDF representation of the entire dataset",
-    "mediaType" : "mime:application/ld+json"
-  }, {
-    "@id" : "_:b5",
-    "@type" : "dcat:Distribution",
-    "identifier" : "isc2017.rdf",
-    "comment" : "RDF/XML serialization of the RDF representation of the entire dataset",
-    "mediaType" : "mime:application/rdf+xml"
-  }, {
-    "@id" : "_:b6",
-    "@type" : "dcat:Distribution",
-    "comment" : "RDF/XML representation of the ontology used for the data",
-    "downloadURL" : "http://resource.geosciml.org/ontology/timescale/gts.rdf",
-    "mediaType" : "mime:application/rdf+xml"
-  }, {
-    "@id" : "_:b7",
-    "@type" : "dcat:Distribution",
-    "comment" : "TTL representation of the ontology used for the data",
-    "downloadURL" : "http://resource.geosciml.org/ontology/timescale/gts.ttl",
-    "mediaType" : "mime:text/turtle"
-  }, {
-    "@id" : "_:b8",
-    "@type" : "dcat:Distribution",
-    "comment" : "Webpage describing the ontology used for the data",
-    "downloadURL" : "http://resource.geosciml.org/ontology/timescale/gts.html",
-    "mediaType" : "mime:text/html"
-  }, {
-    "@id" : "_:b9",
-    "@type" : "dcat:DataService",
-    "conformsTo" : "https://www.w3.org/TR/sparql11-query/",
-    "title" : "International Chronostratigraphic Chart hosted at Research Vocabularies Australia",
-    "comment" : "Service that supports queries to obtain RDF representations of subsets of the data",
-    "endpointURL" : "http://vocabs.ands.org.au/repository/api/sparql/csiro_international-chronostratigraphic-chart_2017",
-    "landingPage" : "https://vocabs.ands.org.au/viewById/196"
-  }, {
     "@id" : "http://stratigraphy.org/ICSchart/ChronostratChart2017-02.jpg",
     "@type" : "foaf:Document",
-    "description" : "Coloured image representation of the International Chronostratigraphic Chart",
+    "description" : {
+      "@language" : "en",
+      "@value" : "Coloured image representation of the International Chronostratigraphic Chart"
+    },
     "format" : "mime:img/jpeg",
     "issued" : "2017-02-01",
-    "title" : "International Chronostratigraphic Chart",
+    "title" : {
+      "@language" : "en",
+      "@value" : "International Chronostratigraphic Chart"
+    },
     "type" : "dctype:Image"
   }, {
     "@id" : "http://stratigraphy.org/ICSchart/ChronostratChart2017-02.pdf",
     "@type" : "foaf:Document",
-    "description" : "Coloured image representation of the International Chronostratigraphic Chart",
+    "description" : {
+      "@language" : "en",
+      "@value" : "Coloured image representation of the International Chronostratigraphic Chart"
+    },
     "format" : "mime:application/pdf",
     "issued" : "2017-02-01",
-    "title" : "International Chronostratigraphic Chart",
+    "title" : {
+      "@language" : "en",
+      "@value" : "International Chronostratigraphic Chart"
+    },
     "type" : "dctype:Image"
   }, {
     "@id" : "dap:d33937",
     "@type" : "dcat:Dataset",
     "conformsTo" : "http://resource.geosciml.org/ontology/timescale/gts",
-    "description" : "A set of RDF graphs representing the International [Chrono]stratigraphic Chart, comprising Turtle serializations of data from the 2017-02 version, along with updated ontologies that define the structure of the data. The Geological Timescale Model is aligned with the W3C OWL-Time ontology https://www.w3.org/TR/owl-time/ for the temporal topology, with OGC GeoSPARQL http://www.opengeospatial.org/standards/geosparql for location data, and with the W3C SOSA/SSN ontology for samples. The content of the vocabulary matches the 2017-02 International Chronostratigraphic Chart.",
+    "description" : {
+      "@language" : "en",
+      "@value" : "A set of RDF graphs representing the International [Chrono]stratigraphic Chart, comprising Turtle serializations of data from the 2017-02 version, along with updated ontologies that define the structure of the data. The Geological Timescale Model is aligned with the W3C OWL-Time ontology https://www.w3.org/TR/owl-time/ for the temporal topology, with OGC GeoSPARQL http://www.opengeospatial.org/standards/geosparql for location data, and with the W3C SOSA/SSN ontology for samples. The content of the vocabulary matches the 2017-02 International Chronostratigraphic Chart."
+    },
+    "hasFormat" : [ "http://stratigraphy.org/ICSchart/ChronostratChart2017-02.jpg", "http://stratigraphy.org/ICSchart/ChronostratChart2017-02.pdf" ],
     "identifier" : "https://doi.org/10.25919/5b4d2b83cbf2d",
     "issued" : "2018-07-07",
     "license" : "https://creativecommons.org/licenses/by/4.0/",
     "publisher" : "http://www.csiro.au",
-    "relation" : [ "_:b3", "http://stratigraphy.org/ICSchart/ChronostratChart2017-02.pdf", "http://stratigraphy.org/ICSchart/ChronostratChart2017-02.jpg" ],
-    "comment" : "The data",
-    "distribution" : [ "_:b1", "_:b2", "_:b4", "_:b0", "_:b5" ],
+    "references" : "dap:d33937.owl",
+    "comment" : {
+      "@language" : "en",
+      "@value" : "The data"
+    },
+    "distribution" : [ "dap:d33937.jsonld", "dap:d33937.rdf", "dap:d33937.ttl", "dap:d33937.nt" ],
     "landingPage" : "https://data.csiro.au/dap/landingpage?pid=csiro:33937"
   }, {
-    "@id" : "dap:d33937/",
+    "@id" : "dap:d33937#",
     "@type" : "owl:Ontology",
     "conformsTo" : "http://www.w3.org/ns/dcat#",
-    "comment" : "This graph provides a DCAT-conformant representation of a catalog entry together with some related resource descriptions",
+    "modified" : "2020-07-07",
+    "comment" : {
+      "@language" : "en",
+      "@value" : "This graph provides a DCAT-conformant representation of a catalog entry together with some related resource descriptions"
+    },
     "imports" : "http://www.w3.org/ns/dcat"
+  }, {
+    "@id" : "dap:d33937.jsonld",
+    "@type" : "dcat:Distribution",
+    "conformsTo" : "https://www.w3.org/TR/rdf-schema/",
+    "identifier" : "isc2017.jsonld",
+    "comment" : {
+      "@language" : "en",
+      "@value" : "JSON-LD serialization of the RDF representation of the entire dataset"
+    },
+    "accessService" : "dap:d33937.ld",
+    "mediaType" : "mime:application/ld+json"
+  }, {
+    "@id" : "dap:d33937.ld",
+    "@type" : "dcat:DataService",
+    "conformsTo" : "https://www.w3.org/TR/sparql11-query/",
+    "title" : {
+      "@language" : "en",
+      "@value" : "International Chronostratigraphic Chart hosted at Research Vocabularies Australia"
+    },
+    "comment" : {
+      "@language" : "en",
+      "@value" : "Service that supports queries to obtain RDF representations of subsets of the data"
+    },
+    "endpointURL" : "http://vocabs.ands.org.au/repository/api/sparql/csiro_international-chronostratigraphic-chart_2017",
+    "landingPage" : "https://vocabs.ands.org.au/viewById/196"
+  }, {
+    "@id" : "dap:d33937.nt",
+    "@type" : "dcat:Distribution",
+    "conformsTo" : "https://www.w3.org/TR/rdf-schema/",
+    "identifier" : "isc2017.nt",
+    "comment" : {
+      "@language" : "en",
+      "@value" : "N-Triples serialization of the RDF representation of the entire dataset"
+    },
+    "accessService" : "dap:d33937.ld",
+    "mediaType" : "mime:application/n-triples"
+  }, {
+    "@id" : "dap:d33937.owl",
+    "@type" : "dcat:Dataset",
+    "conformsTo" : "https://www.w3.org/TR/owl2-overview/",
+    "description" : {
+      "@language" : "en",
+      "@value" : "This is an RDF/OWL representation of the GeoSciML Geologic Timescale model ..."
+    },
+    "identifier" : "http://resource.geosciml.org/ontology/timescale/gts",
+    "issued" : "2011-01-01",
+    "modified" : "2017-04-28",
+    "title" : {
+      "@language" : "en",
+      "@value" : "Geologic Timescale model"
+    },
+    "type" : "http://purl.org/adms/assettype/DomainModel",
+    "comment" : {
+      "@language" : "en",
+      "@value" : "The ontology used for the data"
+    },
+    "distribution" : "dap:d33937.owl.ttl",
+    "landingPage" : "https://raw.githack.com/CGI-IUGS/timescale-ont/master/html/gts.html"
+  }, {
+    "@id" : "dap:d33937.owl.ttl",
+    "@type" : "dcat:Distribution",
+    "conformsTo" : "https://www.w3.org/TR/rdf-schema/",
+    "comment" : {
+      "@language" : "en",
+      "@value" : "TTL representation of the ontology used for the data"
+    },
+    "downloadURL" : "https://raw.githack.com/CGI-IUGS/timescale-ont/master/rdf/gts.ttl",
+    "mediaType" : "mime:text/turtle"
+  }, {
+    "@id" : "dap:d33937.rdf",
+    "@type" : "dcat:Distribution",
+    "conformsTo" : "https://www.w3.org/TR/rdf-schema/",
+    "identifier" : "isc2017.rdf",
+    "comment" : {
+      "@language" : "en",
+      "@value" : "RDF/XML serialization of the RDF representation of the entire dataset"
+    },
+    "accessService" : "dap:d33937.ld",
+    "mediaType" : "mime:application/rdf+xml"
+  }, {
+    "@id" : "dap:d33937.ttl",
+    "@type" : "dcat:Distribution",
+    "conformsTo" : "https://www.w3.org/TR/rdf-schema/",
+    "identifier" : "isc2017.ttl",
+    "comment" : {
+      "@language" : "en",
+      "@value" : "TTL serialization of the RDF representation of the entire dataset"
+    },
+    "accessService" : "dap:d33937.ld",
+    "mediaType" : "mime:text/turtle"
   } ],
   "@context" : {
-    "mediaType" : {
-      "@id" : "http://www.w3.org/ns/dcat#mediaType",
+    "distribution" : {
+      "@id" : "http://www.w3.org/ns/dcat#distribution",
       "@type" : "@id"
     },
     "comment" : {
       "@id" : "http://www.w3.org/2000/01/rdf-schema#comment"
     },
-    "identifier" : {
-      "@id" : "http://purl.org/dc/terms/identifier"
-    },
-    "distribution" : {
-      "@id" : "http://www.w3.org/ns/dcat#distribution",
-      "@type" : "@id"
-    },
-    "relation" : {
-      "@id" : "http://purl.org/dc/terms/relation",
+    "references" : {
+      "@id" : "http://purl.org/dc/terms/references",
       "@type" : "@id"
     },
     "issued" : {
@@ -134,6 +172,10 @@
       "@id" : "http://purl.org/dc/terms/publisher",
       "@type" : "@id"
     },
+    "hasFormat" : {
+      "@id" : "http://purl.org/dc/terms/hasFormat",
+      "@type" : "@id"
+    },
     "license" : {
       "@id" : "http://purl.org/dc/terms/license",
       "@type" : "@id"
@@ -145,35 +187,42 @@
     "description" : {
       "@id" : "http://purl.org/dc/terms/description"
     },
-    "type" : {
-      "@id" : "http://purl.org/dc/terms/type",
-      "@type" : "@id"
+    "identifier" : {
+      "@id" : "http://purl.org/dc/terms/identifier"
     },
     "title" : {
       "@id" : "http://purl.org/dc/terms/title"
     },
-    "format" : {
-      "@id" : "http://purl.org/dc/terms/format",
+    "type" : {
+      "@id" : "http://purl.org/dc/terms/type",
       "@type" : "@id"
     },
     "modified" : {
       "@id" : "http://purl.org/dc/terms/modified",
       "@type" : "http://www.w3.org/2001/XMLSchema#date"
     },
-    "imports" : {
-      "@id" : "http://www.w3.org/2002/07/owl#imports",
+    "format" : {
+      "@id" : "http://purl.org/dc/terms/format",
+      "@type" : "@id"
+    },
+    "mediaType" : {
+      "@id" : "http://www.w3.org/ns/dcat#mediaType",
+      "@type" : "@id"
+    },
+    "accessService" : {
+      "@id" : "http://www.w3.org/ns/dcat#accessService",
       "@type" : "@id"
     },
     "downloadURL" : {
       "@id" : "http://www.w3.org/ns/dcat#downloadURL",
       "@type" : "@id"
     },
-    "endpointURL" : {
-      "@id" : "http://www.w3.org/ns/dcat#endpointURL",
+    "imports" : {
+      "@id" : "http://www.w3.org/2002/07/owl#imports",
       "@type" : "@id"
     },
-    "accessService" : {
-      "@id" : "http://www.w3.org/ns/dcat#accessService",
+    "endpointURL" : {
+      "@id" : "http://www.w3.org/ns/dcat#endpointURL",
       "@type" : "@id"
     },
     "owl" : "http://www.w3.org/2002/07/owl#",

--- a/dcat/examples/csiro-stratchart.ttl
+++ b/dcat/examples/csiro-stratchart.ttl
@@ -72,6 +72,7 @@ dap:d33937
   rdfs:comment "Service that supports queries to obtain RDF representations of subsets of the data"@en ;
   dcat:endpointURL <http://vocabs.ands.org.au/repository/api/sparql/csiro_international-chronostratigraphic-chart_2017> ;
   dcat:landingPage <https://vocabs.ands.org.au/viewById/196> ;
+  dcat:servesDataset dap:d33937 ;
 .
 <https://data.csiro.au/dataset/d33937.nt>
   a dcat:Distribution ;

--- a/dcat/examples/csiro-stratchart.ttl
+++ b/dcat/examples/csiro-stratchart.ttl
@@ -1,5 +1,4 @@
-# baseURI: https://data.csiro.au/dataset/d33937/
-# imports: http://www.w3.org/ns/dcat
+# baseURI: https://data.csiro.au/dataset/d33937
 
 @prefix dap: <https://data.csiro.au/dataset/> .
 @prefix dcat: <http://www.w3.org/ns/dcat#> .
@@ -22,99 +21,99 @@
   dct:description "Coloured image representation of the International Chronostratigraphic Chart"@en ;
   dct:format <https://www.iana.org/assignments/media-types/img/jpeg> ;
   dct:issued "2017-02-01"^^xsd:date ;
-  dct:title "International Chronostratigraphic Chart"@en;
+  dct:title "International Chronostratigraphic Chart"@en ;
   dct:type dctype:Image ;
 .
 <http://stratigraphy.org/ICSchart/ChronostratChart2017-02.pdf>
   a foaf:Document ;
-  dct:description "Coloured image representation of the International Chronostratigraphic Chart"@en;
+  dct:description "Coloured image representation of the International Chronostratigraphic Chart"@en ;
   dct:format <https://www.iana.org/assignments/media-types/application/pdf> ;
   dct:issued "2017-02-01"^^xsd:date ;
-  dct:title "International Chronostratigraphic Chart"@en;
+  dct:title "International Chronostratigraphic Chart"@en ;
   dct:type dctype:Image ;
 .
 dap:d33937
   a dcat:Dataset ;
   dct:conformsTo <http://resource.geosciml.org/ontology/timescale/gts> ;
-  dct:description "A set of RDF graphs representing the International [Chrono]stratigraphic Chart, comprising Turtle serializations of data from the 2017-02 version, along with updated ontologies that define the structure of the data. The Geological Timescale Model is aligned with the W3C OWL-Time ontology https://www.w3.org/TR/owl-time/ for the temporal topology, with OGC GeoSPARQL http://www.opengeospatial.org/standards/geosparql for location data, and with the W3C SOSA/SSN ontology for samples. The content of the vocabulary matches the 2017-02 International Chronostratigraphic Chart."@en;
+  dct:description "A set of RDF graphs representing the International [Chrono]stratigraphic Chart, comprising Turtle serializations of data from the 2017-02 version, along with updated ontologies that define the structure of the data. The Geological Timescale Model is aligned with the W3C OWL-Time ontology https://www.w3.org/TR/owl-time/ for the temporal topology, with OGC GeoSPARQL http://www.opengeospatial.org/standards/geosparql for location data, and with the W3C SOSA/SSN ontology for samples. The content of the vocabulary matches the 2017-02 International Chronostratigraphic Chart."@en ;
+  dct:hasFormat <http://stratigraphy.org/ICSchart/ChronostratChart2017-02.jpg> ;
+  dct:hasFormat <http://stratigraphy.org/ICSchart/ChronostratChart2017-02.pdf> ;
   dct:identifier "https://doi.org/10.25919/5b4d2b83cbf2d" ;
   dct:issued "2018-07-07"^^xsd:date ;
   dct:license <https://creativecommons.org/licenses/by/4.0/> ;
   dct:publisher <http://www.csiro.au> ;
-  dct:hasPart <http://stratigraphy.org/ICSchart/ChronostratChart2017-02.jpg> ;
-  dct:hasPart <http://stratigraphy.org/ICSchart/ChronostratChart2017-02.pdf> ;
-  dct:hasPart [
-      a dcat:Dataset ;
-      dct:conformsTo <https://www.w3.org/TR/owl2-overview/> ;
-      dct:description "This is an RDF/OWL representation of the GeoSciML Geologic Timescale model ..."@en;
-      dct:issued "2011-01-01"^^xsd:date ;
-      dct:modified "2017-04-28"^^xsd:date ;
-      dct:title "Geologic Timescale model"@en;
-      dct:type <http://purl.org/adms/assettype/DomainModel> ;
-      rdfs:comment "The ontology used for the data"@en;
-      dcat:distribution [
-          a dcat:Distribution ;
-          rdfs:comment "RDF/XML representation of the ontology used for the data"@en;
-          dcat:downloadURL <http://resource.geosciml.org/ontology/timescale/gts.rdf> ;
-          dcat:mediaType <https://www.iana.org/assignments/media-types/application/rdf+xml> ;
-        ] ;
-      dcat:distribution [
-          a dcat:Distribution ;
-          rdfs:comment "TTL representation of the ontology used for the data"@en;
-          dcat:downloadURL <http://resource.geosciml.org/ontology/timescale/gts.ttl> ;
-          dcat:mediaType <https://www.iana.org/assignments/media-types/text/turtle> ;
-        ] ;
-      dcat:distribution [
-          a dcat:Distribution ;
-          rdfs:comment "Webpage describing the ontology used for the data"@en;
-          dcat:downloadURL <http://resource.geosciml.org/ontology/timescale/gts.html> ;
-          dcat:mediaType <https://www.iana.org/assignments/media-types/text/html> ;
-        ] ;
-      dcat:landingPage <http://resource.geosciml.org/ontology/timescale/gts> ;
-    ] ;
-  rdfs:comment "The data"@en;
-  dcat:distribution [
-      a dcat:Distribution ;
-      dct:conformsTo <https://www.w3.org/TR/rdf-schema/> ;
-      rdfs:comment "RDF representation of the data"@en;
-      dcat:accessService [
-          a dcat:DataService ;
-          dct:conformsTo <https://www.w3.org/TR/sparql11-query/> ;
-          dct:title "International Chronostratigraphic Chart hosted at Research Vocabularies Australia"@en;
-          rdfs:comment "Service that supports queries to obtain RDF representations of subsets of the data"@en;
-          dcat:endpointURL <http://vocabs.ands.org.au/repository/api/sparql/csiro_international-chronostratigraphic-chart_2017> ;
-          dcat:landingPage <https://vocabs.ands.org.au/viewById/196> ;
-        ] ;
-    ] ;
-  dcat:distribution [
-      a dcat:Distribution ;
-      dct:identifier "isc2017.jsonld" ;
-      rdfs:comment "JSON-LD serialization of the RDF representation of the entire dataset"@en;
-      dcat:mediaType <https://www.iana.org/assignments/media-types/application/ld+json> ;
-    ] ;
-  dcat:distribution [
-      a dcat:Distribution ;
-      dct:identifier "isc2017.nt" ;
-      rdfs:comment "N-Triples serialization of the RDF representation of the entire dataset"@en;
-      dcat:mediaType <https://www.iana.org/assignments/media-types/application/n-triples> ;
-    ] ;
-  dcat:distribution [
-      a dcat:Distribution ;
-      dct:identifier "isc2017.rdf" ;
-      rdfs:comment "RDF/XML serialization of the RDF representation of the entire dataset"@en;
-      dcat:mediaType <https://www.iana.org/assignments/media-types/application/rdf+xml> ;
-    ] ;
-  dcat:distribution [
-      a dcat:Distribution ;
-      dct:identifier "isc2017.ttl" ;
-      rdfs:comment "TTL serialization of the RDF representation of the entire dataset"@en;
-      dcat:mediaType <https://www.iana.org/assignments/media-types/text/turtle> ;
-    ] ;
+  dct:references <https://data.csiro.au/dataset/d33937.owl> ;
+  rdfs:comment "The data"@en ;
+  dcat:distribution <https://data.csiro.au/dataset/d33937.jsonld> ;
+  dcat:distribution <https://data.csiro.au/dataset/d33937.nt> ;
+  dcat:distribution <https://data.csiro.au/dataset/d33937.rdf> ;
+  dcat:distribution <https://data.csiro.au/dataset/d33937.ttl> ;
   dcat:landingPage <https://data.csiro.au/dap/landingpage?pid=csiro:33937> ;
 .
-<https://data.csiro.au/dataset/d33937/>
+<https://data.csiro.au/dataset/d33937#>
   a owl:Ontology ;
   dct:conformsTo dcat: ;
-  rdfs:comment "This graph provides a DCAT-conformant representation of a catalog entry together with some related resource descriptions"@en;
+  dct:modified "2020-07-07"^^xsd:date ;
+  rdfs:comment "This graph provides a DCAT-conformant representation of a catalog entry together with some related resource descriptions"@en ;
   owl:imports <http://www.w3.org/ns/dcat> ;
+.
+<https://data.csiro.au/dataset/d33937.jsonld>
+  a dcat:Distribution ;
+  dct:conformsTo <https://www.w3.org/TR/rdf-schema/> ;
+  dct:identifier "isc2017.jsonld" ;
+  rdfs:comment "JSON-LD serialization of the RDF representation of the entire dataset"@en ;
+  dcat:accessService <https://data.csiro.au/dataset/d33937.ld> ;
+  dcat:mediaType <https://www.iana.org/assignments/media-types/application/ld+json> ;
+.
+<https://data.csiro.au/dataset/d33937.ld>
+  a dcat:DataService ;
+  dct:conformsTo <https://www.w3.org/TR/sparql11-query/> ;
+  dct:title "International Chronostratigraphic Chart hosted at Research Vocabularies Australia"@en ;
+  rdfs:comment "Service that supports queries to obtain RDF representations of subsets of the data"@en ;
+  dcat:endpointURL <http://vocabs.ands.org.au/repository/api/sparql/csiro_international-chronostratigraphic-chart_2017> ;
+  dcat:landingPage <https://vocabs.ands.org.au/viewById/196> ;
+.
+<https://data.csiro.au/dataset/d33937.nt>
+  a dcat:Distribution ;
+  dct:conformsTo <https://www.w3.org/TR/rdf-schema/> ;
+  dct:identifier "isc2017.nt" ;
+  rdfs:comment "N-Triples serialization of the RDF representation of the entire dataset"@en ;
+  dcat:accessService <https://data.csiro.au/dataset/d33937.ld> ;
+  dcat:mediaType <https://www.iana.org/assignments/media-types/application/n-triples> ;
+.
+<https://data.csiro.au/dataset/d33937.owl>
+  a dcat:Dataset ;
+  dct:conformsTo <https://www.w3.org/TR/owl2-overview/> ;
+  dct:description "This is an RDF/OWL representation of the GeoSciML Geologic Timescale model ..."@en ;
+  dct:identifier "http://resource.geosciml.org/ontology/timescale/gts" ;
+  dct:issued "2011-01-01"^^xsd:date ;
+  dct:modified "2017-04-28"^^xsd:date ;
+  dct:title "Geologic Timescale model"@en ;
+  dct:type <http://purl.org/adms/assettype/DomainModel> ;
+  rdfs:comment "The ontology used for the data"@en ;
+  dcat:distribution <https://data.csiro.au/dataset/d33937.owl.ttl> ;
+  dcat:landingPage <https://raw.githack.com/CGI-IUGS/timescale-ont/master/html/gts.html> ;
+.
+<https://data.csiro.au/dataset/d33937.owl.ttl>
+  a dcat:Distribution ;
+  dct:conformsTo <https://www.w3.org/TR/rdf-schema/> ;
+  rdfs:comment "TTL representation of the ontology used for the data"@en ;
+  dcat:downloadURL <https://raw.githack.com/CGI-IUGS/timescale-ont/master/rdf/gts.ttl> ;
+  dcat:mediaType <https://www.iana.org/assignments/media-types/text/turtle> ;
+.
+<https://data.csiro.au/dataset/d33937.rdf>
+  a dcat:Distribution ;
+  dct:conformsTo <https://www.w3.org/TR/rdf-schema/> ;
+  dct:identifier "isc2017.rdf" ;
+  rdfs:comment "RDF/XML serialization of the RDF representation of the entire dataset"@en ;
+  dcat:accessService <https://data.csiro.au/dataset/d33937.ld> ;
+  dcat:mediaType <https://www.iana.org/assignments/media-types/application/rdf+xml> ;
+.
+<https://data.csiro.au/dataset/d33937.ttl>
+  a dcat:Distribution ;
+  dct:conformsTo <https://www.w3.org/TR/rdf-schema/> ;
+  dct:identifier "isc2017.ttl" ;
+  rdfs:comment "TTL serialization of the RDF representation of the entire dataset"@en ;
+  dcat:accessService <https://data.csiro.au/dataset/d33937.ld> ;
+  dcat:mediaType <https://www.iana.org/assignments/media-types/text/turtle> ;
 .

--- a/dcat/examples/csiro-stratchart.ttl
+++ b/dcat/examples/csiro-stratchart.ttl
@@ -41,9 +41,9 @@ dap:d33937
   dct:issued "2018-07-07"^^xsd:date ;
   dct:license <https://creativecommons.org/licenses/by/4.0/> ;
   dct:publisher <http://www.csiro.au> ;
-  dct:relation <http://stratigraphy.org/ICSchart/ChronostratChart2017-02.jpg> ;
-  dct:relation <http://stratigraphy.org/ICSchart/ChronostratChart2017-02.pdf> ;
-  dct:relation [
+  dct:hasPart <http://stratigraphy.org/ICSchart/ChronostratChart2017-02.jpg> ;
+  dct:hasPart <http://stratigraphy.org/ICSchart/ChronostratChart2017-02.pdf> ;
+  dct:hasPart [
       a dcat:Dataset ;
       dct:conformsTo <https://www.w3.org/TR/owl2-overview/> ;
       dct:description "This is an RDF/OWL representation of the GeoSciML Geologic Timescale model ..."@en;

--- a/dcat/index.html
+++ b/dcat/index.html
@@ -4084,10 +4084,10 @@ ex:Test543L
       </aside>
 
       <p>
-          In many legacy catalogs and repositories (e.g. CKAN), ‘datasets’ are ‘just a bag of files’. There is no distinction made between part/whole, distribution (representation), and other kinds of relationship (e.g. documentation, schema, supporting documents) from the dataset to each of the files.
+          In many legacy catalogs and repositories (e.g. CKAN), ‘datasets’ are ‘just a bag of files’. There is no distinction made between distribution (representation), and other kinds of relationship (e.g. documentation, schema, supporting documents) from the dataset to each of the files.
       </p>
       <p>
-          If the nature of the relationships between a dataset and component resources in a catalog, repository, or elsewhere are not known, <code>dct:relation</code> can be used:
+          If the nature of the relationships between a dataset and component resources in a catalog, repository, or elsewhere are not known, <code>dct:hasPart</code> can be used:
       </p>
 
 <aside id="ex-dataset-as-bag-of-files" class="example">
@@ -4096,14 +4096,14 @@ ex:Test543L
   dct:description "A set of RDF graphs representing the International [Chrono]stratigraphic Chart, ..."@en ;
   dct:identifier "https://doi.org/10.25919/5b4d2b83cbf2d"^^xsd:anyURI ;
   dct:creator &lt;https://orcid.org/0000-0002-3884-3420&gt;;
-  dct:relation &lt;https://vocabs.ands.org.au/viewById/196&gt; ;
-  dct:relation :ChronostratChart2017-02.pdf  ;
-  dct:relation :ChronostratChart2017-02.jpg ;
-  dct:relation :timescale.zip ;
-  dct:relation :isc2017.jsonld ;
-  dct:relation :isc2017.nt ;
-  dct:relation :isc2017.rdf ;
-  dct:relation :isc2017.ttl ;
+  dct:hasPart &lt;https://vocabs.ands.org.au/viewById/196&gt; ;
+  dct:hasPart :ChronostratChart2017-02.pdf  ;
+  dct:hasPart :ChronostratChart2017-02.jpg ;
+  dct:hasPart :timescale.zip ;
+  dct:hasPart :isc2017.jsonld ;
+  dct:hasPart :isc2017.nt ;
+  dct:hasPart :isc2017.rdf ;
+  dct:hasPart :isc2017.ttl ;
 .
 </pre>
 </aside>
@@ -4118,10 +4118,10 @@ ex:Test543L
   rdf:type dcat:Dataset ;
   dct:description "A set of RDF graphs representing the International [Chrono]stratigraphic Chart, ..."@en ;
   dct:identifier "https://doi.org/10.25919/5b4d2b83cbf2d"^^xsd:anyURI ;
-  dct:relation &lt;https://vocabs.ands.org.au/viewById/196&gt; ;
-  dct:relation :ChronostratChart2017-02.pdf  ;
-  dct:relation :ChronostratChart2017-02.jpg ;
-  dct:relation :timescale.zip ;
+  dct:hasPart &lt;https://vocabs.ands.org.au/viewById/196&gt; ;
+  dct:hasPart :ChronostratChart2017-02.pdf  ;
+  dct:hasPart :ChronostratChart2017-02.jpg ;
+  dct:hasPart :timescale.zip ;
   dcat:distribution :d33937-jsonld ;
   dcat:distribution :d33937-nt ;
   dcat:distribution :d33937-rdf ;
@@ -4169,9 +4169,9 @@ dap:d33937
   dct:issued "2018-07-07"^^xsd:date ;
   dct:license &lt;https://creativecommons.org/licenses/by/4.0/&gt; ;
   dct:publisher &lt;http://www.csiro.au&gt; ;
-  dct:relation &lt;http://stratigraphy.org/ICSchart/ChronostratChart2017-02.jpg&gt; ;
-  dct:relation &lt;http://stratigraphy.org/ICSchart/ChronostratChart2017-02.pdf&gt; ;
-  dct:relation [
+  dct:hasPart &lt;http://stratigraphy.org/ICSchart/ChronostratChart2017-02.jpg&gt; ;
+  dct:hasPart &lt;http://stratigraphy.org/ICSchart/ChronostratChart2017-02.pdf&gt; ;
+  dct:hasPart [
     rdf:type dcat:Dataset ;
     dct:conformsTo &lt;https://www.w3.org/TR/owl2-overview/&gt; ;
     dct:title "The ontology used for the data"@en ;

--- a/dcat/index.html
+++ b/dcat/index.html
@@ -4087,7 +4087,7 @@ ex:Test543L
           In many legacy catalogs and repositories (e.g. CKAN), ‘datasets’ are ‘just a bag of files’. There is no distinction made between distribution (representation), and other kinds of relationship (e.g. documentation, schema, supporting documents) from the dataset to each of the files.
       </p>
       <p>
-          If the nature of the relationships between a dataset and component resources in a catalog, repository, or elsewhere are not known, <code>dct:hasPart</code> can be used:
+          If the nature of the relationships between a dataset and component resources in a catalog, repository, or elsewhere are not known, <code>dct:relation</code> or its sub-property <code>dct:hasPart</code> can be used:
       </p>
 
 <aside id="ex-dataset-as-bag-of-files" class="example">
@@ -4095,21 +4095,21 @@ ex:Test543L
 :d33937
   dct:description "A set of RDF graphs representing the International [Chrono]stratigraphic Chart, ..."@en ;
   dct:identifier "https://doi.org/10.25919/5b4d2b83cbf2d"^^xsd:anyURI ;
-  dct:creator &lt;https://orcid.org/0000-0002-3884-3420&gt;;
-  dct:hasPart &lt;https://vocabs.ands.org.au/viewById/196&gt; ;
-  dct:hasPart :ChronostratChart2017-02.pdf  ;
-  dct:hasPart :ChronostratChart2017-02.jpg ;
+  dct:creator &lt;https://orcid.org/0000-0002-3884-3420&gt; ;
+  dct:relation :ChronostratChart2017-02.pdf  ;
+  dct:relation :ChronostratChart2017-02.jpg ;
+  dct:relation :d33937.owl ;
   dct:hasPart :timescale.zip ;
-  dct:hasPart :isc2017.jsonld ;
-  dct:hasPart :isc2017.nt ;
-  dct:hasPart :isc2017.rdf ;
-  dct:hasPart :isc2017.ttl ;
+  dct:hasPart :d33937-jsonld ;
+  dct:hasPart :d33937-nt ;
+  dct:hasPart :d33937-rdf ;
+  dct:hasPart :d33937-ttl ;
 .
 </pre>
 </aside>
 
       <p>
-          If it is clear that any of these related resources is a proper <i>representation</i> of the dataset, <code>dcat:distribution</code> should be used.
+          If the nature of the relationship is known, then other <a href="#Property:resource_relation">sub-properties of <code>dct:relation</code> should be used</a> to convey this. In particular, if it is clear that any of these related resources is a proper <i>representation</i> of the dataset, then <code>dcat:distribution</code> should be used.
       </p>
 
 <aside id="ex-when-using-distribution" class="example">
@@ -4118,10 +4118,10 @@ ex:Test543L
   rdf:type dcat:Dataset ;
   dct:description "A set of RDF graphs representing the International [Chrono]stratigraphic Chart, ..."@en ;
   dct:identifier "https://doi.org/10.25919/5b4d2b83cbf2d"^^xsd:anyURI ;
-  dct:hasPart &lt;https://vocabs.ands.org.au/viewById/196&gt; ;
-  dct:hasPart :ChronostratChart2017-02.pdf  ;
-  dct:hasPart :ChronostratChart2017-02.jpg ;
-  dct:hasPart :timescale.zip ;
+  dct:hasFormat :ChronostratChart2017-02.pdf  ;
+  dct:hasFormat :ChronostratChart2017-02.jpg ;
+  dct:references :d33937.owl ;
+  dcat:distribution :timescale.zip ;
   dcat:distribution :d33937-jsonld ;
   dcat:distribution :d33937-nt ;
   dcat:distribution :d33937-rdf ;
@@ -4147,11 +4147,24 @@ ex:Test543L
   dcat:byteSize "531703"^^xsd:decimal ;
   dcat:mediaType &lt;https://www.iana.org/assignments/media-types/text/turtle&gt; ;
 .
+:d33937.owl
+  a dcat:Dataset ;
+  dct:conformsTo <https://www.w3.org/TR/owl2-overview/> ;
+  dct:description "This is an RDF/OWL representation of the GeoSciML Geologic Timescale model ..."@en ;
+  dct:identifier "http://resource.geosciml.org/ontology/timescale/gts" ;
+  dct:issued "2011-01-01"^^xsd:date ;
+  dct:modified "2020-05-31"^^xsd:date ;
+  dct:title "Geologic Timescale model"@en ;
+  dct:type <http://purl.org/adms/assettype/DomainModel> ;
+  rdfs:comment "The ontology used for the data"@en ;
+  dcat:distribution <https://data.csiro.au/dataset/d33937.owl.ttl> ;
+  dcat:landingPage <https://raw.githack.com/CGI-IUGS/timescale-ont/master/html/gts.html> ;
+.
 </pre>
 </aside>
 
       <p>
-          This example is available from the <a href="https://github.com/w3c/dxwg/tree/gh-pages/dcat/examples">DXWG code repository</a> at <a href="https://w3c.github.io/dxwg/dcat/examples/csiro-dap-examples.ttl"><code>csiro-dap-examples.ttl</code></a>.
+          This example is available from the <a href="https://github.com/w3c/dxwg/tree/gh-pages/dcat/examples">DXWG code repository</a> at <a href="https://w3c.github.io/dxwg/dcat/examples/csiro-dap-examples.ttl"><code>csiro-dap-examples.ttl</code></a> and <a href="https://w3c.github.io/dxwg/dcat/examples/csiro-stratchart.ttl"><code>csiro-stratchart.ttl</code></a>.
       </p>
 
       <p>

--- a/dcat/index.html
+++ b/dcat/index.html
@@ -4553,6 +4553,16 @@ ga-courts:jc-wms
 <section id="changes" class="appendix">
     <h2>Change history</h2>
     <p>A full change-log is available on <a href="https://github.com/w3c/dxwg/commits/gh-pages/dcat">GitHub</a></p>
+    
+    <section id="changes-since-20200204">
+        <h3>Changes since the W3C Recommendation of 04 February 2020</h3>
+        <p>The document has undergone the following changes since the W3C Recommendation of 04 February 2020 [[?VOCAB-DCAT-2-20200204]]:</p>
+
+        <ul>
+            <li> Examples about <a href="examples-bag-of-files">loosely structured catalog</a> were updated replacing <code>dct:relation</code> with more specific subrelations and emphatizing the use of <code>dct:hasPart</code>.</li>
+        </ul>
+    </section>
+            
     <section id="changes-since-20140116">
         <h3>Changes since the W3C Recommendation of 16 January 2014</h3>
         <p>The document has undergone the following changes since the W3C Recommendation of 16 January 2014 [[?VOCAB-DCAT-20140116]]:</p>


### PR DESCRIPTION
This PR is in-progress. It aims at capturing the replacement of dct:relation by dct:hasPart as discussed in the last [DCAT meeting 2020/07/01]( https://www.w3.org/2020/07/01-dxwgdcat-minutes#t02). It also relates to issue #1243.

So far, I have changed the examples referred to in the DCAT spec with numbers 43, 44, 45.
DCAT made the above examples also available as TTL, JSON-LD, and XML/RDF, see files csiro-stratchart.\*,  csiro-dap-examples.\*.

I've changed the TTL for csiro-stratchart, but not for csiro-dap-examples, as the latter seems to differ slightly from what is written in the spec.

Before changing the remaining JSON-LDs, and RDF/XMLs, I have a couple of questions for @dr-shorthair,
- are my changes made on example 43, 44, 45  coherent with your original intent?
- in the csiro-dap-examples, can I simply replace all the dct:relation with dct:hasPart, or that should be decided on a case by case bases?

Thanks, 


