### PR TITLE
Updated dcat2.ttl - typo in dcat:Dataset scopeNote

### DIFF
--- a/dcat/rdf/dcat2.ttl
+++ b/dcat/rdf/dcat2.ttl
@@ -272,7 +272,7 @@ dcat:Dataset
   a rdfs:Class ;
   a owl:Class ;
   rdfs:comment "1つのエージェントによって公開またはキュレートされ、1つ以上の形式でアクセスまたはダウンロードできるデータの集合。"@ja ;
-  rdfs:comment "A collection of data, published or curated by a single source, and available for access or download in one or more represenations."@en ;
+  rdfs:comment "A collection of data, published or curated by a single source, and available for access or download in one or more representations."@en ;
   rdfs:comment "Kolekce dat poskytovaná či řízená jedním zdrojem, která je k dispozici pro přístup či stažení v jednom či více formátech."@cs ;
   rdfs:comment "Raccolta di dati, pubblicati o curati da un'unica fonte, disponibili per l'accesso o il download in uno o più formati."@it ;
   rdfs:comment "Una colección de datos, publicados o conservados por una única fuente, y disponibles para ser accedidos o descargados en uno o más formatos."@es ;


### PR DESCRIPTION
Typo in scopeNote (@en) of dcat:Dataset corrected: *represenations -> representations.