### PR TITLE
Add SPARQL endpoint into service example

### DIFF
--- a/dcat/index.html
+++ b/dcat/index.html
@@ -442,6 +442,7 @@
   rdf:type dcat:Dataset ;
   dcat:distribution :dataset-004-csv ;
   dcat:distribution :dataset-004-png ;
+  dcat:distribution :dataset-004-rdf ;
 .
 :dataset-004-csv
   rdf:type dcat:Distribution ;
@@ -455,6 +456,14 @@
   dcat:accessURL &lt;http://example.org/api/figure-006&gt; ;
   dcat:mediaType &lt;https://www.iana.org/assignments/media-types/image/png&gt; ;
 .
+:dataset-004-rdf
+  rdf:type dcat:Distribution ;
+  dcat:accessService :sparql-service-007 ;
+  dcat:accessURL &lt;http://example.org/api/sparql-007&gt; ;
+  dcat:mediaType &lt;https://www.iana.org/assignments/media-types/application/rdf+xml&gt; ;
+  dcat:mediaType &lt;https://www.iana.org/assignments/media-types/application/ld+json&gt;; ;
+  dcat:mediaType &lt;https://www.iana.org/assignments/media-types/text/turtle&gt; ;
+.
 :figure-service-006
   rdf:type dcat:DataDistributionService ;
   dct:conformsTo &lt;http://example.org/apidef/figure/v1.0&gt; ;
@@ -462,6 +471,14 @@
   dcat:endpointDescription &lt;http://example.org/api/figure-006/params&gt; ;
   dcat:endpointURL &lt;http://example.org/api/figure-006&gt; ;
   dcat:servesDataset :dataset-004 ;
+.
+:sparql-service-007
+  rdf:type dcat:DataDistributionService ;
+  dct:conformsTo &lt;https://www.w3.org/TR/sparql11-protocol/&gt; ;
+  dct:type &lt;https://inspire.ec.europa.eu/metadata-codelist/SpatialDataServiceType/download&gt; ;
+  dcat:endpointDescription &lt;http://example.org/api/sparql-007?query=SELECT%20DISTINCT%20?c%20WHERE%20{%20?S%20a%20?c%20.%20}&gt; ;
+  dcat:endpointURL &lt;http://example.org/api/sparql-007&gt; ;
+  dcat:servesDataset :dataset-004 , :graph-009 , :graph-010 ;
 .
 :table-service-005
   rdf:type dcat:DataDistributionService ;


### PR DESCRIPTION
<!DOCTYPE html>
<html lang="en" dir="ltr">
<head>
    <title>Data Catalog Vocabulary (DCAT) - revised edition</title>
    <meta content="text/html; charset=utf-8" http-equiv="content-type" />
    <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
    <script class="remove" src="https://www.w3.org/Tools/respec/respec-w3c-common"></script>
    <script class="remove" src="config.js"></script>
    <link rel="stylesheet" type="text/css" href="style.css">
    <link rel="stylesheet" type="text/css" href="small.css" media="only all and (max-width: 649px)">
</head>
<body>
<section  id="abstract">
    <p>DCAT is an RDF vocabulary designed to facilitate interoperability between data catalogs published on the Web. This document defines the schema and provides examples for its use.</p>
    <p>By using DCAT to describe datasets in data catalogs, publishers are using a standard model and vocabulary that facilitates the consumption and aggregation of metadata from multiple catalogs,
        and in doing so can increase the discoverability of datasets. It also makes it possible to have a decentralized approach to publishing data catalogs and makes federated search for datasets across catalogs in multiple sites possible using the same query mechanism and structure. Aggregated DCAT metadata can serve as a manifest file as part of the digital preservation process.</p>
    <p style="text-align: center;">The namespace for DCAT terms is <code>http://www.w3.org/ns/dcat#</code></p>
    <p style="text-align: center;">The suggested prefix for the DCAT namespace is <code>dcat</code></p>
    <p style="text-align: center;">The (revised) DCAT vocabulary is available <a href="https://raw.githubusercontent.com/w3c/dxwg/gh-pages/dcat/rdf/dcat.ttl">here</a>.</p>
</section>

<section id="sotd">

    <p>
        Since the <a href="">First Public Working Draft</a>, the main changes to the DCAT vocabulary have been:
    <ul>
        <li>addition of a <code><a href="#Class:Resource">dcat:Resource</a></code> class for representing any resource than can be included in the catalog, this is
            now the super-class of <code><a href="#Class:Dataset">dcat:Dataset</a></code></li>
        <li>addition of <code><a href="#Class:Data_Service">dcat:DataService</a></code>, as a sub-class of <code><a href="#Class:Resource">dcat:Resource</a></code>, to support cataloguing service end-points providing access to resources</li>
        <li>addition of <code><a href="#Class:Data_Distribution_Service">dcat:DataDistributionService</a></code>, as a sub-class of <code><a href="#Class:Data_Service">dcat:DataService</a></code>,
            representing service end-points providing access to datasets through their distributions, respectively </li>
        <li>addition of ways to representing <a href="#bag-of-files">loosely structured catalogs</a>, where there is no distinction between a dataset and its distributions</li>
        <li>more details for the ways of representing <a href="#examples-dataset-provenance">dataset provenance</a> and <a href="#quality-information">dataset quality</a></li>
        <li>an <a href="#dcat-sdo">alignment</a> between the DCAT vocabulary and the schema.org vocabulary</li>
    </ul>
    </p>

    <p>
        The detailed differences between the two documents can be seen <a href="https://services.w3.org/htmldiff?doc1=https%3A%2F%2Fwww.w3.org%2FTR%2F2018%2FWD-vocab-dcat-2-20180508%2F&doc2=https%3A%2F%2Fwww.w3.org%2FTR%2F2018%2FWD-vocab-dcat-2-20181011%2F">here</a>
        and the list of all the changes since the previous version of DCAT in the <a href="#changes">Change History</a> section.
    </p>


    <h3 id="dxwg_family_of_documents">DXWG Family of Documents</h3>

    <p>
        This document is part of the output of the Dataset Exchange Working Group (DXWG).
        All documents from the group are listed here.
    </p>

    <h4 id="dcat_documents">DCAT documents</h4>
    <p>
        The DCAT documents are about the revised Data Catalog Vocabulary.
    </p>
    <ul>
        <li>[VOCAB-DCAT] (Recommendation) - this document, description of the DCAT RDF vocabulary</li>
    </ul>

    <h4 id="profiling_documents">Profiling documents</h4>
    <p>
        These documents give guidance on profiling. Some of the documents are general while some are technology-specific.
        Please consult the Profile Guidance [[PROF-GUIDE]] document for an overview of all profiling documents. It is the
        recommended starting point.
    </p>
    <ul>
        <li>[[PROF-GUIDE]] (Recommendation) - the top-level general profiling guidance document giving an overview of all other documents</li>
        <li>[[PROF-CONNEG]] (Recommendation) - Specific guidance on how to negotiate for Internet resource content using profiles</li>
        <li>[[PROF-IETF]] (<a href="http://www.ietf.org">IETF</a> <a href="http://www.ietf.org/standards/ids/">Internet-Draft</a>) - HTTP Headers for HTTP content negotiation by profile</li>
    </ul>

    <h3 id="dcat_history">DCAT history</h3>
    <p>The original DCAT vocabulary (originally hosted at http://vocab.deri.ie/dcat) was developed at the Digital Enterprise Research Institute (DERI), refined by the <a href="http://www.w3.org/egov/">eGov Interest Group</a>, and then finally standardized in 2014 [[VOCAB-DCAT-20140116]] by the <a href="http://www.w3.org/2011/gld/">Government Linked Data (GLD)</a> Working Group.</p>
    <p>This revised version of DCAT was developed by the <a href="https://www.w3.org/2017/dxwg/">Dataset Exchange Working Group</a> in response to a new set of Use Cases and Requirements [[DCAT-UCR]] submitted on the basis of experience with the DCAT vocabulary from the time of the original version, and new applications not originally considered. A summary of the changes from  [[VOCAB-DCAT-20140116]] can be found at <a href="#changes">Change History</a></p>

    <h3 id="external_terms">External terms</h3>
    <p>DCAT incorporates terms from pre-existing vocabularies where stable terms with appropriate meanings could be found, such as foaf:homepage and dct:title.  Informal summary definitions of the externally-defined terms are included here for convenience, while authoritative definitions are available in the normative references.  Changes to definitions in the references, if any, supersede the summaries given in this specification.  Note that conformance to DCAT (Section 4) concerns usage of only the terms in the DCAT namespace itself, so possible changes to the external definitions will not affect the conformance of DCAT implementations.</p>

    <h3 id="please_send_comments">Please send comments</h3>

</section>

<section id="introduction" class="informative">

    <h2>Introduction</h2>

    <p class="note">From DCAT 2014 [[VOCAB-DCAT-20140116]]</p>

    <p>Data can come in many formats, ranging from spreadsheets, through XML and RDF, to various specialty formats. DCAT does not make any assumptions about the serialization format of the datasets described in a catalog. Other, complementary vocabularies <em title="MAY" class="rfc2119">MAY</em> be used together with DCAT to provide more detailed format-specific information. For example, properties from the VoID vocabulary [[VOID]] can be used to express various statistics about a DCAT-described dataset if that dataset is in RDF format.</p>
    <p>This document does not prescribe any particular method of deploying data expressed in DCAT. DCAT is applicable in many contexts including RDF accessible via SPARQL endpoints, embedded in HTML pages as RDFa, or serialized as e.g. RDF/XML or Turtle. The examples in this document use Turtle simply because of Turtle's readability.</p>
</section>

<section id="motivation" class="informative"><h2>Motivation for change</h2>
    <p>The original Recommendation [[VOCAB-DCAT-20140116]], published in January 2014, provided the basic framework for describing datasets. Importantly, it made the distinction between a dataset as an abstract idea and a distribution as a manifestation of the dataset. Although DCAT has been widely adopted, it has become clear that the original specification lacked a number of essential features that were added either through application profiles, such as the European Commission's DCAT-AP [[DCAT-AP]], or the development of larger vocabularies that, to a greater or lesser extent, built upon the base standard, such as the Healthcare and Life Sciences Community Profile [[HCLS-Dataset]], the Data Tag Suite [[DATS]] and more. This version of DCAT has been developed to address the specific shortcomings that have come to light through the experiences of different communities, the aim being, of course, to improve interoperability between the outputs of these larger vocabularies.</p>
    <p>This draft includes re-writing of the specification throughout. Significant changes from the 2014 Recommendation are marked within the text using "Note" sections, as well as being described in the <a href="#changes">Change History</a>.</p>

</section>

<section id="namespaces-1">

    <h2 >Namespaces</h2>

    <p>The namespace for DCAT is <code>http://www.w3.org/ns/dcat#</code>.
        However, note that DCAT makes extensive use of terms from other vocabularies, in particular Dublin Core [[DCTERMS]].
        DCAT defines a minimal set of classes and properties of its own.
        A full set of namespaces and prefixes used in this document is shown in the table below.</p>

    <table id="namespaces">
        <thead><tr><th>Prefix</th><th>Namespace</th></tr></thead>
        <tbody>
        <tr><td>dcat</td><td>http://www.w3.org/ns/dcat#</td></tr>
        <tr><td>dct</td><td>http://purl.org/dc/terms/</td></tr>
        <tr><td>dctype</td><td>http://purl.org/dc/dcmitype/</td></tr>
        <tr><td>dqv</td><td>http://www.w3.org/ns/dqv#</td></tr>
        <tr><td>foaf</td><td>http://xmlns.com/foaf/0.1/</td></tr>
        <tr><td>owl</td><td>http://www.w3.org/2002/07/owl#</td></tr>
        <tr><td>prov</td><td>http://www.w3.org/ns/prov#</td></tr>
        <tr><td>rdf</td><td>http://www.w3.org/1999/02/22-rdf-syntax-ns#</td></tr>
        <tr><td>rdfs</td><td>http://www.w3.org/2000/01/rdf-schema#</td></tr>
        <tr><td>schema</td><td>https://schema.org/</td></tr>
        <tr><td>skos</td><td>http://www.w3.org/2004/02/skos/core#</td></tr>
        <tr><td>vcard</td><td>http://www.w3.org/2006/vcard/ns#</td></tr>
        <tr><td>xsd</td><td>http://www.w3.org/2001/XMLSchema#</td></tr>
        </tbody>
    </table>
</section>

<section id="conformance">

    <p class="note">Modified from DCAT 2014 [[VOCAB-DCAT-20140116]]</p>

    <p>A data catalog conforms to DCAT if:</p>
    <ul>
        <li> Access to data is organized into datasets, distributions, and data-services. </li>
        <li> An RDF description of the catalog itself and its datasets, distributions, and data-services is available (but the choice of
            RDF syntaxes, access protocols, and access policies is not mandated by this specification).</li>
        <li> The contents of all metadata fields that are held in the catalog, and that contain data about the catalog itself and its datasets, distributions, and data-services, are included in this RDF description, expressed using the appropriate classes and properties from DCAT, except where no such class or property exists.</li>
        <li> All classes and properties defined in DCAT are used in a way consistent with the semantics declared in this specification.</li>
        <li>DCAT-compliant catalogs <em title="MAY" class="rfc2119">MAY</em> include additional non-DCAT metadata fields and additional RDF data in the catalog's RDF description.</li>
    </ul>

    <p>
        A <strong>DCAT profile</strong> is a specification for data catalogs that adds additional constraints to DCAT. A data catalog that conforms to the profile also conforms to DCAT. Additional constraints in a profile <em title="MAY" class="rfc2119">MAY</em> include:
    </p>
    <ul>
        <li> Cardinality constraints, including a minimum set of required metadata fields </li>
        <li> Sub-classes and sub-properties of the standard DCAT classes and properties</li>
        <li> Classes and properties for additional metadata fields not covered in DCAT</li>
        <li> Controlled vocabularies or URI sets as acceptable values for properties</li>
        <li> Requirements for specific access mechanisms (RDF syntaxes, protocols) to the catalog's RDF description</li>
    </ul>
    <p class="issue" data-number="430">
        The requirement for a DCAT profile to conform to all of DCAT is under discussion.
    </p>

</section>

<section id="vocabulary-overview" class="informative">

    <h2>Vocabulary overview</h2>

    <p class="note">Significantly extended from DCAT 2014 [[VOCAB-DCAT-20140116]]</p>

    <p>DCAT is an RDF vocabulary well-suited to representing data catalogs such as <a href="https://www.data.gov/">data.gov</a> and <a href="https://data.gov.uk">data.gov.uk</a>. DCAT defines eight main classes:</p>
    <ul>
        <li> <code><a href="#Class:Catalog">dcat:Catalog</a></code> represents the catalog</li>
        <li> <code><a href="#Class:Resource">dcat:Resource</a></code> represents an item described by an entry in a catalog.</li>
        <li> <code><a href="#Class:Dataset">dcat:Dataset</a></code> represents a dataset in a catalog.</li>
        <li> <code><a href="#Class:Distribution">dcat:Distribution</a></code> represents an accessible form or representation of a dataset as for example a downloadable file.</li>
        <li> <code><a href="#Class:Data_Service">dcat:DataService</a></code> represents a data service in a catalog. Example data services include data distribution services and data discovery services.</li>
        <li> <code><a href="#Class:Data_Distribution_Service">dcat:DataDistributionService</a></code> represents a data service that provides access to distributions of datasets and extracts of datasets, such as an API.</li>
        <!--	<li> (<code><a href="#Class:DataTransformationService">dcat:DataTransformationService</a></code> represents a service that can transform a dataset, e.g. spatial coordinate transformation; interpolation or resampling of a dataset).</li> -->
        <li> <code><a href="#Class:Discovery_Service">dcat:DiscoveryService</a></code> represents a data service that supports discovery functions.</li>
        <li> <code><a href="#Class:Catalog_Record">dcat:CatalogRecord</a></code> describes a dataset entry in the catalog, primarily concerning the registration information such as who added the item and when</li>
    </ul>

    <figure id="fig1"><img alt="UML model of DCAT classes and properties" src="UML/DCAT-summary-all-attributes.png">
        <figcaption>
            Overview of DCAT model, showing the classes of resources that can be members of a Catalog, and the relationships between them.
        </figcaption>
    </figure>
    <p class="note">
        Along with the rest of the <a href="#vocabulary-overview">Vocabulary overview</a>, this diagram is <b>non-normative</b>.
        Furthermore, while the diagram uses UML-style class notation, it should be interpreted following the usual RDF open-world assumptions around the presence/absence of properties, relationships, and their cardinality.
        The properties shown in each class reflect those recommended in the descriptions of classes in the <a href="#vocabulary-specification">Vocabulary specification</a>.
        To assist in understanding the full scope of each class, properties are copied down from each '::super-class'.
        Cardinalities are shown in a few places to reinforce expectations, but these are not axiomatized or enforced in any way by this recommendation.
    </p>

    <p>
        A <b>dataset</b> in DCAT is defined as a "collection of data, published or curated by a single agent, and available for access or download in one or more formats".
        A dataset is a conceptual entity, and can be represented by one or more <b>distributions</b> that serialize the dataset for transfer.
        Distributions of a dataset can be provided via <b>data distribution services</b>.
        Detailed properties for a data distribution service API are out of the scope of this version of DCAT. </p>

    <p>Datasets and <b>data services</b>, and potentially other types of thing, can be included in a <b>catalog</b>.
        Types of data service that might be found in a catalog include data distribution services, <b>discovery services</b> such as portals and catalog services, <b>data transformation services</b> such as coordinate transformation services, re-sampling and interpolation services, and various <b>data processing services</b>.
    </p>

    <div class="note">
        <p>
            The scope of DCAT 2014 [[VOCAB-DCAT-20140116]] was limited to catalogs of datasets.
            A number of use cases for the revision involve also having <b>data distribution services</b> as members of a catalog - see <a href="https://www.w3.org/TR/dcat-ucr/#ID6">DCAT Distribution to describe web services - ID6</a> and
            <a href="https://www.w3.org/TR/dcat-ucr/#ID18">Modeling service-based data access - ID18</a>.
            It has been decided to add an explicit class for Data Distribution Services in this revision of DCAT, and to enable these to be part of a Catalog.
            Provision for other data services to also be part of a Catalog is also made, as well as for Catalogs to be composed of other Catalogs.
            See <a href="https://github.com/w3c/dxwg/issues/172">Issue #172</a>. </p>
    </div>

    <p>A <b>CatalogRecord</b> describes an entry in the catalog. Notice that while <code>dcat:Resource</code> represents the dataset or service itself, <code>dcat:CatalogRecord</code> is the record that describes the registration of an item in the catalog. The use of <code>dcat:CatalogRecord</code> is considered optional. It is used to capture provenance information about entries in a catalog. If this distinction is not necessary then <code>dcat:CatalogRecord</code> can be safely ignored.</p>

    <p class="issue" data-number="431">
        There is ongoing discussion about whether a DCAT Resource represents only a dataset or also a distribution.
    </p>
    <p id="blankNodes">RDF allows resources to have global identifiers (IRIs) or to be blank nodes.  Blank nodes can be used to denote resources without explicitly naming them with an IRI. They can appear in the subject and object position of a triple [[RDF11-PRIMER]].
        While blank nodes may offer flexibility for some use cases, in a Linked Data context, blank nodes limit our ability to collaboratively annotate data. A  blank node resource cannot be the target of a link and it can't be annotated with new information from new sources. As one of the biggest benefits of the Linked Data approach is that "anyone can say anything anywhere", use of blank nodes undermines some of the advantages we can gain from wide adoption of the RDF model. Even within the closed world of a single application dataset, use of blank nodes can quickly become limiting when integrating new data [[LinkedDataPatterns]].
        For these reasons, it is recommended that instances of the DCAT main classes have a global identifier, and use of blank nodes is generally discouraged when encoding DCAT in RDF.</p>

    <p class="note">All RDF examples in this document are written in Turtle syntax [[Turtle]] and many are available from the <a href="https://github.com/w3c/dxwg/tree/gh-pages/dcat/examples">DXWG code repository</a>. </p>
    <p class="note">Each RDF example in this document is intended to demonstrate specific capabilities of DCAT, and therefore only shows a subset of all the potential properties and links which might appear in a complete DCAT resource. </p>

    <section id="basic-example">
        <h3>Basic Example</h3>
        <p>This example provides a quick overview of how DCAT might be used to represent a government catalog and its datasets. </p>

        <p>First, the catalog description:
        </p>
        <div class="example">
  <pre class="nohighlight turtle" aria-busy="false" aria-live="polite">
:catalog
  a dcat:Catalog&nbsp;;
  dct:title "Imaginary Catalog"&nbsp;;
  rdfs:label "Imaginary Catalog"&nbsp;;
  foaf:homepage &lt;http://example.org/catalog&gt;&nbsp;;
  dct:publisher&nbsp;:transparency-office&nbsp;;
  dct:language &lt;http://id.loc.gov/vocabulary/iso639-1/en&gt; &nbsp;;
  dcat:dataset&nbsp;:dataset-001&nbsp; , :dataset-002 , :dataset-003 ;
  .
</pre></div>
        <p>The publisher of the catalog has the relative URI&nbsp;:transparency-office. Further description of the publisher can be provided as in the following example:
        </p>
        <div class="example">
  <pre class="nohighlight turtle" aria-busy="false" aria-live="polite">
:transparency-office
  a foaf:Organization&nbsp;;
  rdfs:label "Transparency Office"&nbsp;;
  .
</pre></div>
        <p>The catalog lists each of its datasets via the dcat:dataset property. In the example above, an example dataset was mentioned with the relative URI&nbsp;:dataset-001. A possible description of it using DCAT is shown below:
        </p>
        <div class="example">
  <pre class="nohighlight turtle" aria-busy="false" aria-live="polite">
:dataset-001
  a dcat:Dataset&nbsp;;
  dct:title "Imaginary dataset"&nbsp;;
  dcat:keyword "accountability","transparency" ,"payments"&nbsp;;
  dct:creator&nbsp;:finance-employee-001&nbsp;;
  dct:issued "2011-12-05"^^xsd:date&nbsp;;
  dct:modified "2011-12-05"^^xsd:date&nbsp;;
  dcat:contactPoint &lt;http://example.org/transparency-office/contact&gt; ;
  dct:temporal &lt;http://reference.data.gov.uk/id/quarter/2006-Q1&gt; ;
  dct:spatial &lt;http://www.geonames.org/6695072&gt; ;
  dct:publisher&nbsp;:finance-ministry&nbsp;;
  dct:language &lt;http://id.loc.gov/vocabulary/iso639-1/en&gt; &nbsp;;
  dct:accrualPeriodicity &lt;http://purl.org/linked-data/sdmx/2009/code#freq-W&gt; &nbsp;;
  dcat:distribution&nbsp;:dataset-001-csv&nbsp;;
  .
</pre></div>

        <p>In order to express the frequency of update in the example above, we chose to use an instance from the <a href="http://www.w3.org/TR/vocab-data-cube/#dsd-cog">Content-Oriented Guidelines</a> developed as part
            of the <abbr title="World Wide Web Consortium">W3C</abbr> Data Cube Vocabulary [[VOCAB-DATA-CUBE]] efforts. Additionally, we chose to describe the spatial and temporal coverage of the example dataset using URIs from <a href="http://www.geonames.org/">Geonames</a> and the Interval dataset (originally available from http://reference.data.gov.uk/id/interval) from data.gov.uk, respectively. A contact point is also provided where comments and feedback about the dataset can be sent. Further details about the contact point, such as email address or telephone number, can be provided using vCard [[VCARD-RDF]].</p>

        <p>The dataset distribution :dataset-001-csv can be downloaded as a 5Kb CSV file. This information is
            represented via an RDF resource of type dcat:Distribution.
        </p>
        <div class="example">
  <pre class="nohighlight turtle" aria-busy="false" aria-live="polite">
:dataset-001-csv
  a dcat:Distribution&nbsp;;
  dcat:downloadURL &lt;http://www.example.org/files/001.csv&gt; ;
  dct:title "CSV distribution of imaginary dataset 001" ;
  dcat:mediaType &lt;https://www.iana.org/assignments/media-types/text/csv&gt; ;
  dcat:byteSize "5120"^^xsd:decimal ;
  .
</pre></div>
    </section>

    <section id="classifying-datasets">
        <h3>Classifying datasets thematically</h3>
        <p>The catalog classifies its datasets according to a set of domains represented by the relative URI&nbsp;:themes. SKOS can be used to describe the domains used:
        </p>
        <div class="example">
  <pre class="nohighlight turtle" aria-busy="false" aria-live="polite">
:catalog&nbsp;dcat:themeTaxonomy&nbsp;:themes&nbsp;.

:themes
  a skos:ConceptScheme&nbsp;;
  skos:prefLabel "A set of domains to classify documents"&nbsp;;
  .

:dataset-001 dcat:theme&nbsp;:accountability&nbsp; .
</pre></div>
        <p>Notice that this dataset is classified under the domain represented by the relative URI&nbsp;:accountability.
            It is recommended to define the concept as part of the concepts scheme identified by the URI&nbsp;:themes that was used to describe the catalog domains. An example SKOS description:
        </p>
        <div class="example">
  <pre class="nohighlight turtle" aria-busy="false" aria-live="polite">
:accountability
  a skos:Concept&nbsp;;
  skos:inScheme&nbsp;:themes&nbsp;;
  skos:prefLabel "Accountability"&nbsp;;
  .
</pre></div>
    </section>

    <section id="classifying-dataset-types">
        <h3>Classifying dataset types</h3>

        <p>
            The type or genre of a dataset can be indicated using the <a href="http://purl.org/dc/terms/type">dct:type</a> property.
            It is recommended that the value of the property is be taken from a well governed and broadly recognised set of resource types,
            such as the <a href="http://dublincore.org/documents/dcmi-terms/#section-7">DCMI Type Vocabulary</a>,
            the <a href="https://id.loc.gov/vocabulary/marcgt.html">MARC Genre/Terms Scheme</a>,
            the <a href="https://geo-ide.noaa.gov/wiki/index.php?title=ISO_19115_and_19115-2_CodeList_Dictionaries#MD_ScopeCode">ISO 19115 MD_Scope codes</a>,
            the <a href="https://schema.datacite.org/meta/kernel-4.1/include/datacite-resourceType-v4.1.xsd">DataCite resource types</a>,
            or the PARSE.Insight content-types from Re3data [[RE3DATA-SCHEMA]].
        </p>
        <p>
            In the following examples, a (notional) dataset is classified separately using values from different vocabularies.
        </p>
        <div class="example">
  <pre class="nohighlight turtle" aria-busy="false" aria-live="polite">
:dataset-001
  rdf:type  dcat:Dataset ;
  dct:type  &lt;http://purl.org/dc/dcmitype/Text&gt; ;
  .

:dataset-001
  rdf:type  dcat:Dataset ;
  dct:type  &lt;http://id.loc.gov/vocabulary/marcgt/man&gt; ;
  .
</pre></div>
        <p>
            It is also possible for multiple classifications to be present in a single description.
        </p>
        <div class="example">
  <pre class="nohighlight turtle" aria-busy="false" aria-live="polite">
:dataset-001
  rdf:type  dcat:Dataset ;
  dct:type  &lt;http://purl.org/dc/dcmitype/Text&gt; ;
  dct:type  &lt;http://id.loc.gov/vocabulary/marcgt/man&gt; ;
  dct:type  &lt;http://registry.it.csiro.au/def/datacite/resourceType/Text&gt; ;
  dct:type  &lt;http://registry.it.csiro.au/def/re3data/contentType/doc&gt; ;
.

&lt;http://registry.it.csiro.au/def/datacite/resourceType/Text&gt;
  rdfs:label "Text" ;
  dct:source "DataCite resource types" ;
  .

&lt;http://registry.it.csiro.au/def/re3data/contentType/doc&gt;
  rdfs:label "Standard office documents" ;
  dct:source "Re3data content types" ;
  .
</pre></div>

    </section>

    <section id="describing-catalog-records-metadata">
        <h3>Describing catalog records metadata</h3>
        <p>If the catalog publisher decides to keep metadata
            describing its records (i.e. the records containing metadata
            describing the datasets), dcat:CatalogRecord can be used. For example,
            while &nbsp;:dataset-001 was issued on 2011-12-05, its description on Imaginary Catalog was added on 2011-12-11. This can be represented by DCAT as in the following:
        </p>
        <div class="example">
  <pre class="nohighlight turtle" aria-busy="false" aria-live="polite">
:catalog  dcat:record&nbsp;:record-001&nbsp; .

:record-001
  a dcat:CatalogRecord&nbsp;;
  foaf:primaryTopic&nbsp;:dataset-001&nbsp;;
  dct:issued "2011-12-11"^^xsd:date&nbsp;;
  .
</pre></div>
    </section>

    <section id="example-landing-page">
        <h3>Dataset available only behind some Web page</h3>
        <p>:dataset-002 is available as a CSV file. However :dataset-002 can only be obtained through some Web page
            where the user needs to follow some links, provide some information and check some boxes
            before accessing the data</p>

        <div class="example">
  <pre class="nohighlight turtle" aria-busy="false" aria-live="polite">
:dataset-002
  a dcat:Dataset ;
  dcat:landingPage &lt;http://example.org/dataset-002.html&gt; ;
  dcat:distribution :dataset-002-csv ;
  .
:dataset-002-csv
  a dcat:Distribution ;
  dcat:accessURL &lt;http://example.org/dataset-002.html&gt; ;
  dcat:mediaType &lt;https://www.iana.org/assignments/media-types/text/csv&gt; ;
  .
</pre></div>

        Notice the use of a dcat:landingPage and the definition of the dcat:Distribution instance.
    </section>

    <section id="a-dataset-available-as-download-and-behind-some-web-page">
        <h3>A dataset available as a download and behind some Web page</h3>
        <p>On the other hand, :dataset-003 can be obtained through some landing page but also can be downloaded from a known URL.
        </p>
        <div class="example">
  <pre class="nohighlight turtle" aria-busy="false" aria-live="polite">
:dataset-003
  a dcat:Dataset ;
  dcat:landingPage &lt;http://example.org/dataset-003.html&gt; ;
  dcat:distribution :dataset-003-csv ;
  .
:dataset-003-csv
  a dcat:Distribution ;
  dcat:downloadURL &lt;http://example.org/dataset-003.csv&gt; ;
  dcat:mediaType &lt;https://www.iana.org/assignments/media-types/text/csv&gt; ;
  .
</pre></div>
        Notice that we used dcat:downloadURL with the downloadable distribution and that the other distribution accessible through the landing page
        does not have to be defined as a separate dcat:Distribution instance.
    </section>

    <section id="a-dataset-available-from a service">
        <h3>A dataset available through a service</h3>
        <p>:dataset-004 is distributed in different representations from different services.
          The <code>accessURL</code> for each <code>Distribution</code> corresponds with the <code>endpointURL</code> of the service.
          Each service is characterized by its general type using <code>dct:type</code> (here using values from the INSPIRE spatial data service type vocabulary),
          its specific API definition using <code>dct:conformsTo</code>,
          with the detailed description of the individual endpoint parameters and options linked using <code>dcat:endpointDescription</code>.
        </p>
<div class="example">
  <pre class="nohighlight turtle" aria-busy="false" aria-live="polite">
:dataset-004
  rdf:type dcat:Dataset ;
  dcat:distribution :dataset-004-csv ;
  dcat:distribution :dataset-004-png ;
  dcat:distribution :dataset-004-rdf ;
.
:dataset-004-csv
  rdf:type dcat:Distribution ;
  dcat:accessService :table-service-005 ;
  dcat:accessURL &lt;http://example.org/api/table-005&gt; ;
  dcat:mediaType &lt;https://www.iana.org/assignments/media-types/text/csv&gt; ;
.
:dataset-004-png
  rdf:type dcat:Distribution ;
  dcat:accessService :figure-service-006 ;
  dcat:accessURL &lt;http://example.org/api/figure-006&gt; ;
  dcat:mediaType &lt;https://www.iana.org/assignments/media-types/image/png&gt; ;
.
:dataset-004-rdf
  rdf:type dcat:Distribution ;
  dcat:accessService :sparql-service-007 ;
  dcat:accessURL &lt;http://example.org/api/sparql-007&gt; ;
  dcat:mediaType &lt;https://www.iana.org/assignments/media-types/application/rdf+xml&gt; ;
  dcat:mediaType &lt;https://www.iana.org/assignments/media-types/application/ld+json&gt;; ;
  dcat:mediaType &lt;https://www.iana.org/assignments/media-types/text/turtle&gt; ;
.
:figure-service-006
  rdf:type dcat:DataDistributionService ;
  dct:conformsTo &lt;http://example.org/apidef/figure/v1.0&gt; ;
  dct:type &lt;https://inspire.ec.europa.eu/metadata-codelist/SpatialDataServiceType/view&gt; ;
  dcat:endpointDescription &lt;http://example.org/api/figure-006/params&gt; ;
  dcat:endpointURL &lt;http://example.org/api/figure-006&gt; ;
  dcat:servesDataset :dataset-004 ;
.
:sparql-service-007
  rdf:type dcat:DataDistributionService ;
  dct:conformsTo &lt;https://www.w3.org/TR/sparql11-protocol/&gt; ;
  dct:type &lt;https://inspire.ec.europa.eu/metadata-codelist/SpatialDataServiceType/download&gt; ;
  dcat:endpointDescription &lt;http://example.org/api/sparql-007?query=SELECT%20DISTINCT%20?c%20WHERE%20{%20?S%20a%20?c%20.%20}&gt; ;
  dcat:endpointURL &lt;http://example.org/api/sparql-007&gt; ;
  dcat:servesDataset :dataset-004 , :graph-009 , :graph-010 ;
.
:table-service-005
  rdf:type dcat:DataDistributionService ;
  dct:conformsTo &lt;http://example.org/apidef/table/v2.2&gt; ;
  dct:type &lt;https://inspire.ec.europa.eu/metadata-codelist/SpatialDataServiceType/download&gt; ;
  dcat:endpointDescription &lt;http://example.org/api/table-005/capability&gt; ;
  dcat:endpointURL &lt;http://example.org/api/table-005&gt; ;
  dcat:servesDataset :dataset-003, :dataset-004 ;
.  </pre>
</div>



    </section>

</section>

<section id="vocabulary-specification">

    <h2>Vocabulary specification</h2>

    <section id="RDF-representation">
        <h3>RDF representation</h3>

        <p class="note">
            The DCAT RDF representation is modularized into several files or graphs to help users access a version of DCAT with just the alignments that they need. This mechanism can also be used to capture different levels of axiomatization, though the status of such proposals has not been finalized. See <a href="https://github.com/w3c/dxwg/issues/134">Issue #134</a> and the issues enumerated below.
        </p>

        <div class="issue" data-number="65">
            <p>
                Guidance on the use DCAT in a weakly-axiomatized environment, such as schema.org, has been identified as a requirement to be satisfied in this revision of DCAT.
            </p>
            <p>
                An <a href="https://raw.githubusercontent.com/w3c/dxwg/gh-pages/dcat/rdf/dcat-schema.ttl">RDF graph containing a proposed alignment of DCAT with schema.org</a> is available. Comments on this alignment are invited.
            </p>
        </div>

        <p class="issue" data-number="105">
            The use of guarded constraints (existence, cardinality, range-type) to control the use of the recommended properties in the context of a class is being considered as part of the revision of DCAT.
        </p>

        <p class="issue" data-number="110">
            The axiomatization of DCAT 2014 used global domain and range constraints for many of the properties defined in the DCAT namespace [[VOCAB-DCAT-20140116]]. This makes quite strong ontological commitments, some of which are now being reconsidered - see individual issues noted inline below.
        </p>

        <p>The (revised) DCAT vocabulary is <a href="https://github.com/w3c/dxwg/tree/gh-pages/dcat/rdf/">available in RDF</a>.
            The primary artefact <a href="https://raw.githubusercontent.com/w3c/dxwg/gh-pages/dcat/rdf/dcat.ttl">dcat.ttl</a> is a serialization of the core DCAT vocabulary.
            Alongside it are a set of other RDF files that provide additional information, including:</p>
        <ol>
            <li>
                alignments to other vocabularies, some of which are normative and some of which are only for guidance
            </li>
            <li>
                additional axioms, which can be useful in some contexts
            </li>
            <li>
                some profiles of DCAT, including a profile that corresponds to the 2014 version of DCAT [[VOCAB-DCAT-20140116]]
            </li>
        </ol>

        <p class="issue" data-number="144">
            The implementation of a DCAT 2014 profile of the revised DCAT is being considered.
        </p>



    </section>

    <section id="dependencies">
        <h3>Dependencies</h3>

        <p>
            The definitions (including domain and range) of terms outside the DCAT namespace are provided here only for convenience and <em title="MUST NOT" class="rfc2119">MUST NOT</em> be considered normative. The authoritative definitions of these terms are in the corresponding specifications: [[!DC11]], [[!DCTERMS]], [[!FOAF]], [[!RDF-SCHEMA]], [[!SKOS-REFERENCE]], [[!XMLSCHEMA11-2]] and [[!VCARD-RDF]].
        </p>
    </section>

    <section id="Class:Catalog">
        <h3>Class: Catalog</h3>
        <p>The following properties are recommended for use on this class:
            <a href="#Property:catalog_catalog_record">catalog record</a>,
            <a href="#Property:catalog_hasPart">hasPart</a>,
            <a href="#Property:catalog_dataset">dataset</a>,
            <a href="#Property:catalog_service">service</a>,
            <a href="#Property:catalog_catalog">catalog</a>,
            <a href="#Property:catalog_description">description</a>,
            <a href="#Property:catalog_homepage">homepage</a>,
            <a href="#Property:catalog_language">language</a>,
            <a href="#Property:catalog_license">license</a>,
            <a href="#Property:catalog_publisher">publisher</a>,
            <a href="#Property:catalog_release_date">release date</a>,
            <a href="#Property:catalog_rights">rights</a>,
            <a href="#Property:catalog_spatial">spatial/geographical</a>,
            <a href="#Property:catalog_themes">themes</a>,
            <a href="#Property:catalog_title">title</a>,
            <a href="#Property:catalog_update_date">update/modification date</a>
        </p>

        <div class="note">
            <p>
                The scope of DCAT 2014 was limited to catalogs of datasets [[VOCAB-DCAT-20140116]].
                A number of use cases for the revision involve also having <b>data distribution services</b> as members of a catalog - see <a href="https://www.w3.org/TR/dcat-ucr/#ID6">DCAT Distribution to describe web services - ID6</a> and
                <a href="https://www.w3.org/TR/dcat-ucr/#ID18">Modeling service-based data access - ID18</a>.
                It has been decided to add an explicit class for Data Distribution Services in this revision of DCAT, and to enable these to be part of a Catalog.
                Provision for other services to also be part of a Catalog will also be made, as well as for Catalogs to be composed of other Catalogs.
                See <a href="https://github.com/w3c/dxwg/issues/172">Issue #172</a> and <a href="https://github.com/w3c/dxwg/issues/116">Issue #116</a>. </p>
        </div>

        <table class="definition">
            <thead><tr><th>RDF Class:</th><th><a href="http://www.w3.org/ns/dcat#Catalog">dcat:Catalog</a></th></tr></thead>
            <tbody>
            <tr><td class="prop">Sub-class of:</td><td><a href="#Class:Dataset">Dataset</a></td></tr>
            <tr><td class="prop">Definition:</td><td>A curated collection of metadata about datasets and data services</td></tr>
            <tr><td class="prop">Usage note:</td><td>A web-based data catalog is typically represented as a single instance of this class.</td></tr>
            <tr><td class="prop">See also:</td><td> <a href="#Class:Catalog_Record">Catalog record</a>, <a href="#Class:Dataset">Dataset</a></td></tr>
            </tbody>
        </table>

        <section id="Property:catalog_title">
            <h4>Property: title</h4>
            <table class="definition">
                <thead><tr><th>RDF Property:</th><th><a href="http://purl.org/dc/terms/title">dct:title</a></th></tr></thead>
                <tbody>
                <tr><td class="prop">Definition:</td><td>A name given to the catalog.</td></tr>
                <tr><td class="prop">Range:</td><td><a href="http://www.w3.org/2000/01/rdf-schema#Literal">rdfs:Literal</a></td></tr>
                </tbody>
            </table>
        </section>

        <section id="Property:catalog_description">
            <h4>Property: description</h4>
            <table class="definition">
                <thead><tr><th>RDF Property:</th><th><a href="http://purl.org/dc/terms/description">dct:description</a></th></tr></thead>
                <tbody>
                <tr><td class="prop">Definition:</td><td>A free-text account of the catalog.</td></tr>
                <tr><td class="prop">Range:</td><td><a href="http://www.w3.org/2000/01/rdf-schema#Literal">rdfs:Literal</a></td></tr>
                </tbody>
            </table>
        </section>

        <section id="Property:catalog_release_date">
            <h4>Property: release date</h4>
            <table class="definition">
                <thead><tr><th>RDF Property:</th><th><a href="http://purl.org/dc/terms/issued">dct:issued</a></th></tr></thead>
                <tbody>
                <tr><td class="prop">Definition:</td><td>Date of formal issuance (e.g., publication) of the catalog.</td></tr>
                <tr><td class="prop">Range:</td><td><a href="http://www.w3.org/2000/01/rdf-schema#Literal">rdfs:Literal</a>
                    encoded using the relevant ISO 8601 Date and Time compliant string [[!DATETIME]] and typed using the appropriate XML Schema datatype [[XMLSCHEMA11-2]]
                </td></tr>
                <tr><td class="prop">See also:</td><td><a href="#Property:resource_release_date" title=""> resource release date</a>, <a href="#Property:record_listing_date" title=""> catalog record listing date</a> and <a href="#Property:distribution_release_date" title=""> distribution release date</a></td></tr>
                </tbody>
            </table>
        </section>

        <section id="Property:catalog_update_date">
            <h4>Property: update/modification date</h4>
            <table class="definition">
                <thead><tr><th>RDF Property:</th><th><a href="http://purl.org/dc/terms/modified">dct:modified</a></th></tr></thead>
                <tbody>
                <tr><td class="prop">Definition:</td><td>Most recent date on which the catalog was changed, updated or modified.</td></tr>
                <tr><td class="prop">Range:</td><td><a href="http://www.w3.org/2000/01/rdf-schema#Literal">rdfs:Literal</a>
                    encoded using the relevant ISO 8601 Date and Time compliant string [[!DATETIME]] and typed using the appropriate XML Schema datatype [[XMLSCHEMA11-2]]
                </td></tr>
                <tr><td class="prop">See also:</td><td><a href="#Property:resource_update_date" title=""> resource modification date</a>, <a href="#Property:record_update_date" title=""> catalog record modification date</a> and <a href="#Property:distribution_update_date" title=""> distribution modification date</a></td></tr>
                </tbody>
            </table>
        </section>

        <section id="Property:catalog_language">
            <h4>Property: language</h4>
            <table class="definition">
                <thead><tr><th>RDF Property:</th><th><a href="http://purl.org/dc/terms/language">dct:language</a></th></tr></thead>
                <tbody>
                <tr><td class="prop">Definition:</td><td>A language of the catalog. This refers to the language used in the textual metadata describing titles, descriptions, etc. of the resources (i.e. datasets and services) in the catalog.</td></tr>
                <tr><td class="prop">Range:</td><td>
                    <a href="http://purl.org/dc/terms/LinguisticSystem">dct:LinguisticSystem</a>
                    <br>
                    Resources defined by the Library of Congress (<a href="http://id.loc.gov/vocabulary/iso639-1.html">1</a>,
                    <a href="http://id.loc.gov/vocabulary/iso639-2.html">2</a>) <em title="SHOULD" class="rfc2119">SHOULD</em> be used.
                    <br>
                    If a ISO 639-1 (two-letter) code is defined for language, then its corresponding IRI <em title="SHOULD" class="rfc2119">SHOULD</em> be used; if no ISO 639-1 code is defined, then IRI corresponding to the ISO 639-2 (three-letter) code <em title="SHOULD" class="rfc2119">SHOULD</em> be used.</td></tr>
                <tr><td class="prop">Usage note:</td><td>Multiple values can be used. The publisher might also choose to describe the language on the resource (e.g. dataset, or service) level (see <a href="#Property:resource_language">dataset language</a>).</td></tr>
                </tbody>
            </table>
        </section>

        <section id="Property:catalog_homepage">
            <h4>Property: homepage</h4>
            <table class="definition">
                <thead><tr><th>RDF Property:</th><th><a href="http://xmlns.com/foaf/0.1/homepage">foaf:homepage</a></th></tr></thead>
                <tbody>
                <tr><td class="prop">Definition:</td><td>A homepage of the catalog  (a public web document usually available in HTML).</td></tr>
                <tr><td class="prop">Range:</td><td><a href="http://xmlns.com/foaf/0.1/Document">foaf:Document</a></td></tr>
                <tr><td class="prop">Usage note:</td><td><a href="http://xmlns.com/foaf/0.1/homepage">foaf:homepage</a> is an inverse functional property (IFP) which means that it <em title="SHOULD" class="rfc2119">SHOULD</em> be unique and precisely identify the catalog. This allows smushing various descriptions of the catalog when different URIs are used.</td></tr>
                </tbody>
            </table>
        </section>


        <section id="Property:catalog_publisher">
            <h4>Property: publisher</h4>
            <table class="definition">
                <thead><tr><th>RDF Property:</th><th><a href="http://purl.org/dc/terms/publisher">dct:publisher</a></th></tr></thead>
                <tbody>
                <tr><td class="prop">Definition:</td><td>The entity responsible for making the catalog available.</td></tr>
                <tr><td class="prop">Usage note:</td><td>Resources of type <a href="http://xmlns.com/foaf/0.1/Agent">foaf:Agent</a>
                    are recommended as values for this property.</td></tr>
                <tr><td class="prop">See also:</td><td><a href="#Class:Organization_Person">Class: Organization/Person</a></td></tr>
                </tbody>
            </table>
        </section>

        <section id="Property:catalog_spatial">
            <h4>Property: spatial/geographic </h4>
            <table class="definition">
                <thead><tr><th>RDF Property:</th><th><a href="http://purl.org/dc/terms/spatial">dct:spatial</a></th></tr></thead>
                <tbody>
                <tr><td class="prop">Definition:</td><td>The geographical area covered by the catalog.</td></tr>
                <tr><td class="prop">Range:</td><td><a href="http://purl.org/dc/terms/Location">dct:Location</a></td></tr>
                </tbody>
            </table>
        </section>

        <section id="Property:catalog_themes">
            <h4>Property: themes</h4>

            <table class="definition">
                <thead><tr><th>RDF Property:</th><th><a href="http://www.w3.org/ns/dcat#themeTaxonomy">dcat:themeTaxonomy</a></th></tr></thead>
                <tbody>
                <tr><td class="prop">Definition:</td><td>A knowledge organization system (KOS) used to classify catalog's datasets and services.</td></tr>
                <tr><td class="prop">Domain:</td><td><a href="http://www.w3.org/ns/dcat#Catalog">dcat:Catalog</a></td></tr>
                <tr><td class="prop">Range:</td><td><a href="http://www.w3.org/2004/02/skos/core#ConceptScheme">skos:ConceptScheme</a></td></tr>
                </tbody>
            </table>
        </section>

        <section id="Property:catalog_license">
            <h4>Property: license</h4>

            <p class="issue" data-number="114">
                Models for the kind of license or rights representation indicated by the dct:license and dct:rights property are being considered as part of the revision of DCAT. See also <a href="#license-rights">License and rights statements</a>.
            </p>

            <table class="definition">
                <thead><tr><th>RDF Property:</th><th><a href="http://purl.org/dc/terms/license">dct:license</a></th></tr></thead>
                <tbody>
                <tr><td class="prop">Definition:</td><td>A legal document under which the <strong>catalog</strong>
                    is made available and <strong>not the datasets or services</strong></td></tr>
                <tr><td class="prop">Range:</td><td><a href="http://purl.org/dc/terms/LicenseDocument">dct:LicenseDocument</a></td></tr>
                <tr><td class="prop">Usage note:</td><td>If the license of the catalog applies to all of its
                    datasets and distributions, it <em title="SHOULD" class="rfc2119">SHOULD</em> also be replicated on each distribution.</td></tr>
                <tr><td class="prop">See also:</td><td><a href="#Property:catalog_rights">catalog rights</a>,
                    <a href="#Property:distribution_license">distribution license</a></td></tr>
                </tbody>
            </table>
        </section>

        <section id="Property:catalog_rights">
            <h4>Property: rights</h4>

            <p class="issue" data-number="114">
                Models for the kind of license or rights representation indicated by the dct:license and dct:rights property are being considered as part of the revision of DCAT. See also <a href="#license-rights">License and rights statements</a>.
            </p>

            <table class="definition">
                <thead><tr><th>RDF Property:</th><th><a href="http://purl.org/dc/terms/rights">dct:rights</a></th></tr></thead>
                <tbody>
                <tr><td class="prop">Definition:</td><td>Information about the rights under which the <strong>catalog</strong>
                    can be used/reused, but <strong>not the datasets or services</strong> listed.</td></tr>
                <tr><td class="prop">Range:</td><td><a href="http://purl.org/dc/terms/RightsStatement">dct:RightsStatement</a></td></tr>
                <tr><td class="prop">Usage note:</td><td>If the rights associated with the catalog applies to all of its
                    datasets and distributions, it <em title="SHOULD" class="rfc2119">SHOULD</em> also be replicated on each distribution.</td></tr>
                <tr><td class="prop">See also:</td><td><a href="#Property:catalog_license">catalog license</a>,
                    <a href="#Property:distribution_rights">distribution rights</a></td></tr>
                </tbody>
            </table>
        </section>

        <section id="Property:catalog_hasPart">
            <h4>Property: hasPart</h4>

            <p class="note">
                Explicit use of this property added in this revision of DCAT.
            </p>


            <table class="definition">
                <thead><tr><th>RDF Property:</th><th><a href="http://purl.org/dc/terms/hasPart">dct:hasPart</a></th></tr></thead>
                <tbody>
                <tr><td class="prop">Definition:</td><td>An item that is listed in the catalog.</td></tr>
                <tr><td class="prop">Domain:</td><td><a href="http://www.w3.org/ns/dcat#Catalog">dcat:Catalog</a></td></tr>
                <tr><td class="prop">Range:</td><td><a href="http://www.w3.org/ns/dcat#Resource">dcat:Resource</a></td></tr>
                <tr><td class="prop">Usage note:</td><td>This is the most general predicate for membership of a catalog. Use of a more specific sub-property is recommended when available. </td></tr>
                <tr><td class="prop">See also:</td><td>Sub-properties of dct:hasPart in particular <a href="http://www.w3.org/ns/dcat#/dataset">dcat:dataset</a>, <a href="http://www.w3.org/ns/dcat#catalog">dcat:catalog</a>, <a href="http://www.w3.org/ns/dcat#service">dcat:service</a>. </td></tr>
                </tbody>
            </table>
        </section>

        <section id="Property:catalog_dataset">
            <h4>Property: dataset</h4>

            <table class="definition">
                <thead><tr><th>RDF Property:</th><th><a href="http://www.w3.org/ns/dcat#dataset">dcat:dataset</a></th></tr></thead>
                <tbody>
                <tr><td class="prop">Definition:</td><td>A collection of data that is listed in the catalog.</td></tr>
                <tr><td class="prop">Sub property of:</td><td><a href="http://purl.org/dc/terms/hasPart">dct:hasPart</a></td></tr>
                <tr><td class="prop">Domain:</td><td><a href="http://www.w3.org/ns/dcat#Catalog">dcat:Catalog</a></td></tr>
                <tr><td class="prop">Range:</td><td><a href="http://www.w3.org/ns/dcat#Dataset">dcat:Dataset</a></td></tr>
                </tbody>
            </table>
        </section>

        <section id="Property:catalog_service">
            <h4>Property: service</h4>

            <p class="note">
                Property added in this revision of DCAT.
            </p>

            <table class="definition">
                <thead><tr><th>RDF Property:</th><th><a href="http://www.w3.org/ns/dcat#service">dcat:service</a></th></tr></thead>
                <tbody>
                <tr><td class="prop">Definition:</td><td>A site or end-point that is listed in the catalog.</td></tr>
                <tr><td class="prop">Sub property of:</td><td><a href="http://purl.org/dc/terms/hasPart">dct:hasPart</a></td></tr>
                <tr><td class="prop">Domain:</td><td><a href="http://www.w3.org/ns/dcat#Catalog">dcat:Catalog</a></td></tr>
                <tr><td class="prop">Range:</td><td><a href="http://www.w3.org/ns/dcat#Dataset">dcat:DataService</a></td></tr>
                </tbody>
            </table>
        </section>

        <section id="Property:catalog_catalog">
            <h4>Property: catalog</h4>

            <p class="note">
                Property added in this revision of DCAT.
            </p>

            <table class="definition">
                <thead><tr><th>RDF Property:</th><th><a href="http://www.w3.org/ns/dcat#catalog">dcat:catalog</a></th></tr></thead>
                <tbody>
                <tr><td class="prop">Definition:</td><td>A catalog whose contents are of interest in the context of this catalog</td></tr>
                <tr><td class="prop">Sub property of:</td><td><a href="http://purl.org/dc/terms/hasPart">dct:dataset</a></td></tr>
                <tr><td class="prop">Domain:</td><td><a href="http://www.w3.org/ns/dcat#Catalog">dcat:Catalog</a></td></tr>
                <tr><td class="prop">Range:</td><td><a href="http://www.w3.org/ns/dcat#Dataset">dcat:Catalog</a></td></tr>
                </tbody>
            </table>
        </section>

        <section id="Property:catalog_catalog_record">
            <h4>Property: catalog record</h4>

            <table class="definition">
                <thead><tr><th>RDF Property:</th><th><a href="http://www.w3.org/ns/dcat#record">dcat:record</a></th></tr></thead>
                <tbody>
                <tr><td class="prop">Definition:</td><td>A record describing the registration of a single dataset or dataservice that is part of the catalog.</td></tr>
                <tr><td class="prop">Domain:</td><td><a href="http://www.w3.org/ns/dcat#Catalog">dcat:Catalog</a></td></tr>
                <tr><td class="prop">Range:</td><td><a href="http://www.w3.org/ns/dcat#CatalogRecord">dcat:CatalogRecord</a></td></tr>
                </tbody>
            </table>
        </section>
    </section> <!-- end Class:Catalog -->

    <section id="Class:Resource">
        <h3>Class: Catalogued Resource</h3>

        <p>The following properties are recommended for use on this class:
            <a href="#Property:resource_conformsto">conformsTo</a>,
            <a href="#Property:resource_contact_point">contact point</a>,
            <a href="#Property:resource_description">description</a>,
            <a href="#Property:resource_identifier">identifier</a>,
            <a href="#Property:resource_keyword">keyword/tag</a>,
            <a href="#Property:resource_landing_page">landing page</a>,
            <a href="#Property:resource_language">resource language</a>,
            <a href="#Property:resource_relation">relation</a>,
            <a href="#Property:resource_publisher">publisher</a>,
            <a href="#Property:resource_release_date">release date</a>,
            <a href="#Property:resource_theme">theme/category</a>,
            <a href="#Property:resource_title">title</a>,
            <a href="#Property:resource_type">type/genre</a>,
            <a href="#Property:resource_update_date">update/modification date</a>,
        </p>

        <p class="issue" data-number="62">
            The possible association of items with zero or multiple catalogs has been identified as a requirement to be satisfied in the revision of DCAT.
        </p>

        <p class="issue" data-number="66">
            The need to be able to link a catalogued resource with the source of funding that supported its production has been identified as a requirement to be satisfied in the revision of DCAT.
        </p>

        <p class="issue" data-number="71">
            The need to be able to describe the business or project context related to production of a catalogued resource has been identified as a requirement to be satisfied in the revision of DCAT.
        </p>

        <!--
        -- this issue already closed - prov:wasGeneratedBy added to dcat:Dataset (but not to dcat:Resource) --
        <p class="issue" data-number="77">
            The need to be able to link a catalogued resource with the business or project context of its production has been identified as a requirement to be satisfied in the revision of DCAT.
        </p>
        -->

        <table class="definition">
            <thead><tr><th>RDF Class:</th><th><a href="http://www.w3.org/ns/dcat#Resource">dcat:Resource</a></th></tr></thead>
            <tbody>
            <tr><td class="prop">Definition:</td><td>Resource published or curated by a single agent.</td></tr>
            <tr><td class="prop">Usage note:</td><td>The class of all catalogued resources, the superclass of
                <a href="#Class:Dataset">dcat:Dataset</a>, <a href="#Class:Data_Service">dcat:DataService</a>, <a href="#Class:Catalog">dcat:Catalog</a> and any other member of a <a href="#Class:Catalog">dcat:Catalog</a>.
                This class carries properties common to all catalogued resources, including datasets and data services.

                It is strongly recommended to use a more specific sub-class when available.</td></tr>
            <tr><td class="prop">See also:</td><td><a href="#Class:Catalog_Record" title="">Catalog record</a></td></tr>
            </tbody>
        </table>

        <p class="note">
            The class <a href="#Class:Resource">dcat:Resource</a> has been added to the DCAT vocabulary in this revision.
        </p>

        <section id="Property:resource_title">
            <h4>Property: title</h4>
            <table class="definition">
                <thead><tr><th>RDF Property:</th><th><a href="http://purl.org/dc/terms/title">dct:title</a></th></tr></thead>
                <tbody>
                <tr><td class="prop">Definition:</td><td>A name given to the item.</td></tr>
                <tr><td class="prop">Range:</td><td><a href="http://www.w3.org/2000/01/rdf-schema#Literal">rdfs:Literal</a></td></tr>
                </tbody>
            </table>
        </section>

        <section id="Property:resource_description">
            <h4>Property: description</h4>
            <table class="definition">
                <thead><tr><th>RDF Property:</th><th><a href="http://purl.org/dc/terms/description">dct:description</a></th></tr></thead>
                <tbody>
                <tr><td class="prop">Definition:</td><td>free-text account of the item.</td></tr>
                <tr><td class="prop">Range:</td><td><a href="http://www.w3.org/2000/01/rdf-schema#Literal">rdfs:Literal</a></td></tr>
                </tbody>
            </table>
        </section>

        <section id="Property:resource_release_date">
            <h4>Property: release date</h4>
            <table class="definition">
                <thead><tr><th>RDF Property:</th><th><a href="http://purl.org/dc/terms/issued">dct:issued</a></th></tr></thead>
                <tbody>
                <tr><td class="prop">Definition:</td><td>Date of formal issuance (e.g., publication) of the item.</td></tr>
                <tr><td class="prop">Range:</td><td><a href="http://www.w3.org/2000/01/rdf-schema#Literal">rdfs:Literal</a>
                    encoded using the relevant ISO 8601 Date and Time compliant string [[!DATETIME]] and typed using the appropriate XML Schema datatype [[XMLSCHEMA11-2]]
                </td></tr>
                <tr><td class="prop">Usage note:</td><td>This property <em title="SHOULD" class="rfc2119">SHOULD</em> be set using the first known date of issuance.</td></tr>
                </tbody>
            </table>
        </section>

        <section id="Property:resource_update_date">
            <h4>Property: update/modification date</h4>
            <table class="definition">
                <thead><tr><th>RDF Property:</th><th><a href="http://purl.org/dc/terms/modified">dct:modified</a></th></tr></thead>
                <tbody>
                <tr><td class="prop">Definition:</td><td>Most recent date on which the item was changed, updated or modified.</td></tr>
                <tr><td class="prop">Range:</td><td><a href="http://www.w3.org/2000/01/rdf-schema#Literal">rdfs:Literal</a>
                    encoded using the relevant ISO 8601 Date and Time compliant string [[!DATETIME]] and typed using the appropriate XML Schema datatype [[XMLSCHEMA11-2]]
                </td></tr>
                <tr><td class="prop">Usage note:</td><td>The value of this property indicates a change to the actual item, not a change to the catalog record. An absent value <em title="MAY" class="rfc2119">MAY</em> indicate that the item has never changed after its initial publication, or that the date of last modification is not known, or that the item is continuously updated.</td></tr>
                <tr><td class="prop">See also:</td><td><a href="#Property:dataset_frequency">dataset frequency</a></td></tr>
                </tbody>
            </table>
        </section>

        <section id="Property:resource_language">
            <h4>Property: language</h4>
            <table class="definition">
                <thead><tr><th>RDF Property:</th><th><a href="http://purl.org/dc/terms/language">dct:language</a></th></tr></thead>
                <tbody>
                <tr><td class="prop">Definition:</td><td>The language of the item.</td></tr>
                <tr><td class="prop">Range:</td><td><a href="http://purl.org/dc/terms/LinguisticSystem">dct:LinguisticSystem</a>
                    <br>
                    Resources defined by the Library of Congress (<a href="http://id.loc.gov/vocabulary/iso639-1.html">1</a>,
                    <a href="http://id.loc.gov/vocabulary/iso639-2.html">2</a>) <em title="SHOULD" class="rfc2119">SHOULD</em> be used.
                    <br>
                    If a ISO 639-1 (two-letter) code is defined for language, then its corresponding IRI <em title="SHOULD" class="rfc2119">SHOULD</em> be used; if no ISO 639-1 code is defined, then IRI corresponding to the ISO 639-2 (three-letter) code <em title="SHOULD" class="rfc2119">SHOULD</em> be used.</td></tr>
                <tr><td class="prop">Usage note:</td><td>This overrides the value of the <a href="#Property:catalog_language">catalog language</a> in case of conflict.
                    If the item is available in multiple languages, use multiple values for this property. If each language is available separately for a dataset, define an instance of dcat:Distribution for each language and describe the specific language of each distribution using dct:language (i.e. the dataset will have multiple dct:language values and each distribution will have one of these languages as value of its dct:language property).</td></tr>
                </tbody>
            </table>
        </section>

        <section id="Property:resource_publisher">
            <h4>Property: publisher</h4>

            <p class="issue" data-number="80">
                The desire to have qualified forms of properties (as done in [[PROV-O]]) has been raised. If dcat:Dataset is a prov:Entity (not decided yet) then `publisher` could be a qualified prov:Entity &rarr; prov:Agent relationship.
            </p>

            <table class="definition">
                <thead><tr><th>RDF Property:</th><th><a href="http://purl.org/dc/terms/publisher">dct:publisher</a></th></tr></thead>
                <tbody>
                <tr><td class="prop">Definition:</td><td>The entity responsible for making the item available.</td></tr>
                <tr><td class="prop">Usage note:</td><td>Resources of type <a href="http://xmlns.com/foaf/0.1/Agent">foaf:Agent</a>
                    are recommended as values for this property.</td></tr>
                <tr><td class="prop">See also:</td><td><a href="#Class:Organization_Person">Class: Organization/Person</a></td></tr>
                </tbody>
            </table>
        </section>

        <section id="Property:resource_identifier">
            <h4>Property: identifier</h4>

            <p class="issue" data-number="53">
                The desirability of dereferenceable identifiers has been raised as an item for consideration in the revision of DCAT. dct:identifier has limited expressivity for this. It has been suggested that ADMS identifier, or a property from another ontology might be recruited to help DCAT in this area.
            </p>

            <p class="issue" data-number="67">
                The need to clearly distinguish between primary and legacy identifiers for a dataset has been identified as a requirement to be satisfied in the revision of DCAT.
            </p>

            <p class="issue" data-number="68">
                The need to indicate the scheme or authority for identifiers for a dataset has been identified as a requirement to be satisfied in the revision of DCAT.
            </p>

            <table class="definition">
                <thead><tr><th>RDF Property:</th><th><a href="http://purl.org/dc/terms/identifier">dct:identifier</a></th></tr></thead>
                <tbody>
                <tr><td class="prop">Definition:</td><td>A unique identifier of the item.</td></tr>
                <tr><td class="prop">Range:</td><td><a href="http://www.w3.org/2000/01/rdf-schema#Literal">rdfs:Literal</a></td></tr>
                <tr><td class="prop">Usage note:</td><td>The identifier might be used as part of the URI of the item, but still having it represented explicitly is useful.</td></tr>
                </tbody>
            </table>
        </section>

        <section id="Property:resource_theme">
            <h4>Property: theme/category</h4>

            <p class="note">
                In DCAT 2014 [[VOCAB-DCAT-20140116]] the domain of dcat:theme was dcat:Dataset,
                which limited use of this property in other contexts. The domain has been relaxed in this revision -
                see <a href="https://github.com/w3c/dxwg/issues/123">Issue #123</a>.
            </p>

            <table class="definition">
                <thead><tr><th>RDF Property:</th><th><a href="http://www.w3.org/ns/dcat#theme">dcat:theme</a></th></tr></thead>
                <tbody>
                <tr><td class="prop">Definition:</td><td>A main category of the resource. A resource can have multiple themes.</td></tr>
                <tr><td class="prop">Sub property of:</td><td><a href="http://purl.org/dc/terms/subject">dct:subject</a></td></tr>
                <tr><td class="prop">Range:</td><td><a href="http://www.w3.org/2004/02/skos/core#Concept">skos:Concept</a></td></tr>
                <tr><td class="prop">Usage note:</td><td>The set of <a href="http://www.w3.org/2004/02/skos/core#Concept">skos:Concept</a>s used to categorize the resources are organized in a <a href="http://www.w3.org/2004/02/skos/core#ConceptScheme">skos:ConceptScheme</a> describing all the categories and their relations in the catalog.</td></tr>
                <tr><td>See also:</td><td><a href="#Property:catalog_themes">catalog themes</a></td></tr>
                </tbody>
            </table>
        </section>

        <section id="Property:resource_type">
            <h4>Property: type/genre</h4>

            <p class="note">
                Added in DCAT revision - see <a href="https://github.com/w3c/dxwg/issues/64">Issue #64</a>.
            </p>

            <table class="definition">
                <thead><tr><th>RDF Property:</th><th><a href="http://purl.org/dc/terms/type">dct:type</a></th></tr></thead>
                <tbody>
                <tr><td class="prop">Definition:</td><td>The nature or genre of the resource.</td></tr>
                <tr><td class="prop">Sub property of:</td><td><a href="http://purl.org/dc/elements/1.1/type">dc:type</a></td></tr>
                <tr><td class="prop">Range:</td><td><a href="http://www.w3.org/2000/01/rdf-schema#Class">rdfs:Class</a></td></tr>
                <tr><td class="prop">Usage note:</td><td>The value <em title="SHOULD" class="rfc2119">SHOULD</em> be taken from a well governed and broadly recognised controlled vocabulary, such as:
                    <ol>
                        <li><a href="http://dublincore.org/documents/dcmi-terms/#section-7">DCMI Type vocabulary</a> [[DCTERMS]]</li>
                        <li><a href="https://geo-ide.noaa.gov/wiki/index.php?title=ISO_19115_and_19115-2_CodeList_Dictionaries#MD_ScopeCode">ISO 19115 scope codes</a> [[ISO-19115-1]]</li>
                        <li><a href="https://schema.datacite.org/meta/kernel-4.1/include/datacite-resourceType-v4.1.xsd">Datacite resource types</a> [[DataCite]]</li>
                        <li>PARSE.Insight content-types used by <a href="https://www.re3data.org/">re3data.org</a> [[RE3DATA-SCHEMA]] (see item 15 contentType)</li>
                        <li><a href="http://id.loc.gov/vocabulary/marcgt.html">MARC intellectual resource types</a></li>
                    </ol>
                    To describe the file format, physical medium, or dimensions of the resource, use the <a href="http://purl.org/dc/terms/format">dct:format element</a>.</td></tr>
                </tbody>
            </table>
        </section>

        <section id="Property:resource_relation">
            <h4>Property: resource relation</h4>

            <table class="definition">
                <thead><tr><th>RDF Property:</th><th><a href="http://purl.org/dc/terms/relation">dct:relation</a></th></tr></thead>
                <tbody>
                <tr><td class="prop">Definition:</td><td>A resource with an unspecified relationship to the catalogued item.</td></tr>
                <tr><td class="prop">Usage note:</td><td><a href="http://purl.org/dc/terms/relation">dct:relation</a> <em title="SHOULD" class="rfc2119">SHOULD</em> be used where the nature of the relationship between a catalogued item and related resources is not known. A more specific sub-property <em title="SHOULD" class="rfc2119">SHOULD</em> be used if the nature of the relationship of the link is known.
                    The property <a href="http://www.w3.org/ns/dcat#distribution">dcat:distribution</a> <em title="SHOULD" class="rfc2119">SHOULD</em> be used to link from a <a href="http://www.w3.org/ns/dcat#Dataset">dcat:Dataset</a> to a representation of the dataset, described as a <a href="http://www.w3.org/ns/dcat#Distribution">dcat:Distribution</a></td></tr>
                <tr><td class="prop">See also:</td><td>Sub-properties of dct:relation in particular
                    <a href="http://www.w3.org/ns/dcat#distribution">dcat:distribution</a>,
                    <a href="http://purl.org/dc/terms/hasPart">dct:hasPart</a>,
                    (and its sub-properties
                    <a href="http://www.w3.org/ns/dcat#catalog">dcat:catalog</a>,
                    <a href="http://www.w3.org/ns/dcat#dataset">dcat:dataset</a>,
                    <a href="http://www.w3.org/ns/dcat#service">dcat:service</a>
                    ),
                    <a href="http://purl.org/dc/terms/isPartOf">dct:isPartOf</a>,
                    <a href="http://purl.org/dc/terms/conformsTo">dct:conformsTo</a>,
                    <a href="http://purl.org/dc/terms/isFormatOf">dct:isFormatOf</a>,
                    <a href="http://purl.org/dc/terms/hasFormat">dct:hasFormat</a>,
                    <a href="http://purl.org/dc/terms/isVersionOf">dct:isVersionOf</a>,
                    <a href="http://purl.org/dc/terms/hasVersion">dct:hasVersion</a>,
                    <a href="http://purl.org/dc/terms/replaces">dct:replaces</a>,
                    <a href="http://purl.org/dc/terms/isReplacedBy">dct:isReplacedBy</a>,
                    <a href="http://purl.org/dc/terms/references">dct:references</a>,
                    <a href="http://purl.org/dc/terms/isReferencedBy">dct:isReferencedBy</a>,
                    <a href="http://purl.org/dc/terms/requires">dct:requires</a>,
                    <a href="http://purl.org/dc/terms/isRequiredBy">dct:isRequiredBy</a></td>
                </tr>
                </tbody>
            </table>

            <p>
                Many existing and legacy catalogues do not distinguish between dataset components, representations, documentation, schemata and other resources that are lumped together as part of a dataset.
                <a href="http://purl.org/dc/terms/relation">dct:relation</a> is a super-property of a number of more specific properties which express more precise relationships, so use of dct:relation is not inconsistent with a subsequent reclassification with more specific semantics, though the more specialized sub-properties <em title="SHOULD" class="rfc2119">SHOULD</em> be used to link a dataset to component and supplementary resources if possible.
            </p>

            <p class="issue" data-number="81">
                The general need to describe relationships between datasets has been identified as a requirement to be satisfied in the revision of DCAT.
                Guidance on the use of more specific relationship predicates is required, particularly in the context of the dcat:Dataset sub-class.
            </p>

            <p class="note">
                Use of this Dublin Core Terms property in this context added in this revision of DCAT.
            </p>

        </section>

        <section id="Property:resource_conformsto">
            <h4>Property: conforms to</h4>
            <table class="definition">
                <thead><tr><th>RDF Property:</th><th><a href="http://purl.org/dc/terms/conformsTo">dct:conformsTo</a></th></tr></thead>
                <tbody>
                <tr><td class="prop">Definition:</td><td>An established standard to which the described resource conforms.</td></tr>
                <tr><td class="prop">Range:</td><td><a href="http://purl.org/dc/terms/Standard">dct:Standard</a> (A basis for comparison; a reference point against which other things can be evaluated.)</td></tr>
                </tbody>
            </table>
        </section>

        <section id="Property:resource_keyword">
            <h4>Property: keyword/tag</h4>

            <p class="note">
                In DCAT 2014 [[VOCAB-DCAT-20140116]] the domain of dcat:keyword was dcat:Dataset, which limited use of this property in other contexts. The domain has been relaxed in this revision - see <a href="https://github.com/w3c/dxwg/issues/121">Issue #121</a>.
            </p>

            <table class="definition">
                <thead><tr><th>RDF Property:</th><th><a href="http://www.w3.org/ns/dcat#keyword">dcat:keyword</a></th></tr></thead>
                <tbody>
                <tr><td class="prop">Definition:</td><td>A keyword or tag describing the resource.</td></tr>
                <tr><td class="prop">Range:</td><td><a href="http://www.w3.org/2000/01/rdf-schema#Literal">rdfs:Literal</a></td></tr>
                </tbody>
            </table>
        </section>

        <section id="Property:resource_contact_point">
            <h4>Property: contact point</h4>

            <p class="note">
                In DCAT 2014 [[VOCAB-DCAT-20140116]] the domain of dcat:contactPoint was dcat:Dataset, which limited use of this property in other contexts. The domain has been relaxed in this revision - see <a href="https://github.com/w3c/dxwg/issues/95">Issue #95</a>.
            </p>

            <p class="issue" data-number="109">
                The axiomatization of dcat:contactPoint is being re-evaluated as part of the revision of DCAT.
            </p>

            <table class="definition">
                <thead><tr><th>RDF Property:</th><th><a href="http://www.w3.org/ns/dcat#contactPoint">dcat:contactPoint</a></th></tr></thead>
                <tbody>
                <tr><td class="prop">Definition:</td><td>Relevant contact information (provided using vCard [[VCARD-RDF]]) for the catalogued resource.</td></tr>
                <tr><td class="prop">Range:</td><td><a href="http://www.w3.org/2006/vcard/ns#Kind">vcard:Kind</a></td></tr>
                </tbody>
            </table>
        </section>

        <section id="Property:resource_landing_page">
            <h4>Property: landing page</h4>

            <p class="note">
                In DCAT 2014 [[VOCAB-DCAT-20140116]] the domain of dcat:landingPage was dcat:Dataset, which limited use of this property in other contexts. The domain has been relaxed in this revision - see <a href="https://github.com/w3c/dxwg/issues/122">Issue #122</a>.
            </p>

            <table class="definition">
                <thead><tr><th>RDF Property:</th><th><a href="http://www.w3.org/ns/dcat#landingPage">dcat:landingPage</a></th></tr></thead>
                <tbody>
                <tr><td class="prop">Definition:</td><td>A Web page that can be navigated to in a Web browser to gain access to the catalog, a dataset, its distributions and/or additional information.</td></tr>
                <tr><td class="prop">Sub property of:</td><td><a href="http://xmlns.com/foaf/0.1/page">foaf:page</a></td></tr>
                <tr><td class="prop">Range:</td><td><a href="http://xmlns.com/foaf/0.1/Document">foaf:Document</a></td></tr>
                <tr><td class="prop">Usage note:</td><td>
                    If the distribution(s) are accessible only through a landing page
                    (i.e. direct download URLs are not known), then the landing page link <em title="SHOULD" class="rfc2119">SHOULD</em> be duplicated as dcat:accessURL on a distribution. (see <a href="#example-landing-page"></a>)
                </td></tr>
                </tbody>
            </table>
        </section>

    </section> <!-- end class Resource -->

    <section id="Class:Catalog_Record">
        <h3>Class: Catalog Record</h3>
        <p>The following properties are recommended for use on this class:
            <a href="#Property:record_description">description</a>,
            <a href="#Property:record_listing_date">listing date</a>,
            <a href="#Property:record_primary_topic">primary topic</a>,
            <a href="#Property:record_title">title</a>,
            <a href="#Property:record_update_date">update/modification date</a>
        </p>

        <p class="issue" data-number="70">
            The need to be able to express rights relating to the re-use of DCAT metadata has been identified as a requirement to be satisfied in the revision of DCAT.
        </p>

        <p class="issue" data-number="78">
            The need to be able to link a metadata record to its original source has been identified as a requirement to be satisfied in the revision of DCAT.
        </p>

        <table class="definition">
            <thead><tr><th>RDF Class:</th><th><a href="http://www.w3.org/ns/dcat#CatalogRecord">dcat:CatalogRecord</a></th></tr></thead>
            <tbody>
            <tr><td class="prop">Definition:</td><td>A record in a catalog, describing the registration of a single dataset or data service.</td></tr>
            <tr><td class="prop">Usage note</td><td>This class is optional and not all catalogs will use it. It exists for catalogs where a distinction is made between metadata about
                a <em>dataset or service</em> and metadata about the <em>entry in the catalog about the dataset or service</em>. For example, the <i>publication date</i> property of the <i>dataset</i> reflects
                the date when the information was originally made available by the publishing agency, while the publication date of the <i>catalog record</i> is the date when the dataset was added to the catalog.
                In cases where both dates differ, or where only the latter is known, the <em>publication date</em> <em title="SHOULD" class="rfc2119">SHOULD</em> only be specified for the catalog record.
                Notice that the <abbr title="World Wide Web Consortium">W3C</abbr> PROV Ontology [[PROV-O]] allows describing further provenance information such as the details of the process and the agent involved in a particular change to a dataset or its registration.
            </td></tr>
            <tr><td class="prop">See also</td><td><a href="#Class:Dataset">Dataset</a></td></tr>
            </tbody>
        </table>


        <p>If a catalog is represented as an RDF Dataset with named graphs (as defined in [[SPARQL11-QUERY]]),
            then it is appropriate to place the description of each dataset
            (consisting of all RDF triples that mention the dcat:Dataset, dcat:CatalogRecord, and any of its dcat:Distributions)
            into a separate named graph. The name of that graph <em title="SHOULD" class="rfc2119">SHOULD</em> be the IRI of the catalog record.
        </p>

        <section id="Property:record_title">
            <h4>Property: title</h4>
            <table class="definition">
                <thead><tr><th>RDF Property:</th><th><a href="http://purl.org/dc/terms/title">dct:title</a></th></tr></thead>
                <tbody>
                <tr><td class="prop">Definition:</td><td>A name given to the record.</td></tr>
                <tr><td class="prop">Range:</td><td><a href="http://www.w3.org/2000/01/rdf-schema#Literal">rdfs:Literal</a></td></tr>
                </tbody>
            </table>
        </section>

        <section id="Property:record_description">
            <h4>Property: description</h4>
            <table class="definition">
                <thead><tr><th>RDF Property:</th><th><a href="http://purl.org/dc/terms/description">dct:description</a></th></tr></thead>
                <tbody>
                <tr><td class="prop">Definition:</td><td>A free-text account of the record.</td></tr>
                <tr><td class="prop">Range:</td><td><a href="http://www.w3.org/2000/01/rdf-schema#Literal">rdfs:Literal</a></td></tr>
                </tbody>
            </table>
        </section>

        <section id="Property:record_listing_date">
            <h4>Property: listing date</h4>
            <table class="definition">
                <thead><tr><th>RDF Property:</th><th><a href="http://purl.org/dc/terms/issued">dct:issued</a></th></tr></thead>
                <tbody>
                <tr><td class="prop">Definition:</td><td>The date of listing (i.e. formal recording) of the corresponding dataset or service in the catalog.</td></tr>
                <tr><td class="prop">Range:</td><td><a href="http://www.w3.org/2000/01/rdf-schema#Literal">rdfs:Literal</a>
                    encoded using the relevant ISO 8601 Date and Time compliant string [[!DATETIME]] and typed using the appropriate XML Schema datatype [[XMLSCHEMA11-2]]
                </td></tr>
                <tr><td class="prop">Usage note:</td><td>This indicates the date of listing the dataset in the catalog and not the publication date of the dataset itself.</td></tr>
                <tr><td class="prop">See also:</td><td><a href="#Property:resource_release_date" title=""> resource release date</a></td></tr>
                </tbody>
            </table>
        </section>

        <section id="Property:record_update_date">
            <h4>Property: update/modification date</h4>
            <table class="definition">
                <thead><tr><th>RDF Property:</th><th><a href="http://purl.org/dc/terms/modified">dct:modified</a></th></tr></thead>
                <tbody>
                <tr><td class="prop">Definition:</td><td>Most recent date on which the catalog entry was changed, updated or modified.</td></tr>
                <tr><td class="prop">Range:</td><td><a href="http://www.w3.org/2000/01/rdf-schema#Literal">rdfs:Literal</a>
                    encoded using the relevant ISO 8601 Date and Time compliant string [[!DATETIME]] and typed using the appropriate XML Schema datatype [[XMLSCHEMA11-2]]
                </td></tr>
                <tr><td class="prop">Usage note:</td><td>This indicates the date of last change of a catalog entry, i.e. the catalog metadata description of the dataset, and not the date of the dataset itself.</td></tr>
                <tr><td class="prop">See also:</td><td><a href="#Property:resource_update_date" title=""> resource modification date</a></td></tr>
                </tbody>
            </table>
        </section>

        <section id="Property:record_primary_topic">
            <h4>Property: primary topic</h4>

            <table class="definition">
                <thead><tr><th>RDF Property:</th><th><a href="http://xmlns.com/foaf/0.1/primaryTopic">foaf:primaryTopic</a></th></tr></thead>
                <tbody>
                <tr><td class="prop">Definition:</td><td>The  <a href="http://www.w3.org/ns/dcat#dcat:Resource">dcat:Resource</a> (dataset or service) described in the record.</td></tr>
                <tr><td class="prop">Usage note:</td><td><a href="http://xmlns.com/foaf/0.1/primaryTopic">foaf:primaryTopic</a> property is functional:
                    each catalog record can have at most one primary topic i.e. describes one dataset or service.</td></tr>
                </tbody>
            </table>
        </section>
    </section> <!-- end Class catalog record -->

    <section id="Class:Data_Distribution_Service">
        <h3>Class: Data Distribution Service</h3>

        <p class="note">
            The class <a href="#Class:Data_Distribution_Service">dcat:DataDistributionService</a> has been added to the DCAT vocabulary in this revision.
        </p>

        <p>In addition to the properties inherited from the super-class <a href="http://www.w3.org/ns/dcat#DataService">dcat:DataService</a>, the following properties are recommended for use on this class:
            <a href="#Property:datadistributionservice_servesdataset">servesDataset</a>,
        </p>

        <table class="definition">
            <thead><tr><th>RDF Class:</th><th><a href="http://www.w3.org/ns/dcat#DataDistributionService">dcat:DataDistributionService</a></th></tr></thead>
            <tbody>
            <tr><td class="prop">Definition:</td><td>A site or end-point that provides access to datasets through distributions of the datasets</td></tr>
            <tr><td class="prop">Sub class of:</td><td><a href="http://www.w3.org/ns/dcat#DataService">dcat:DataService</a></td></tr>
            </tbody>
        </table>

        <section id="Property:datadistributionservice_servesdataset">
            <h4>Property: serves dataset</h4>
            <table class="definition">
                <thead><tr><th>RDF Property:</th><th><a href="http://www.w3.org/ns/dcat#servesdataset">dcat:servesDataset</a></th></tr></thead>
                <tbody>
                <tr><td class="prop">Definition:</td><td>A collection of data that this DataDistributionService can distribute</td></tr>
                <tr><td class="prop">Range:</td><td><a href="http://www.w3.org/ns/dcat#Dataset">dcat:Dataset</a></td></tr>
                </tbody>
            </table>
        </section>

    </section> <!-- end class DataDistributionService -->

    <section id="Class:Data_Service">
        <h3>Class: Data Service</h3>

        <p class="note">
            The class <a href="#Class:Data_Service">dcat:DataService</a> has been added to the DCAT vocabulary in this revision.
        </p>

        <p>In addition to the properties inherited from the super-class <a href="http://www.w3.org/ns/dcat#Resource">dcat:Resource</a>, the following properties are recommended for use on this class:
            <a href="#Property:dataservice_endpointdescription">endpointDescription</a>,
            <a href="#Property:dataservice_endpointurl">endpointURL</a>,
            <a href="#Property:dataservice_license">license</a>,
            <a href="#Property:dataservice_access_rights">accessRights</a>
        </p>

        <table class="definition">
            <thead><tr><th>RDF Class:</th><th><a href="http://www.w3.org/ns/dcat#DataService">dcat:DataService</a></th></tr></thead>
            <tbody>
            <tr><td class="prop">Definition:</td><td>A site or end-point for discovery, access or processing data or related resources.</td></tr>
            <tr><td class="prop">Sub class of:</td><td><a href="http://www.w3.org/ns/dcat#Resource">dcat:Resource</a></td></tr>
            <tr><td class="prop">Sub class of:</td><td><a href="http://purl.org/dc/dcmitype/Service">dctype:Service</a></td></tr>
            </tbody>
        </table>



        <section id="Property:dataservice_endpointurl">
            <h4>Property: endpoint address</h4>
            <table class="definition">
                <thead><tr><th>RDF Property:</th><th><a href="http://www.w3.org/ns/dcat#endpointURL">dcat:endpointURL</a></th></tr></thead>
                <tbody>
                <tr><td class="prop">Definition:</td><td>The IRI of the service end-point.</td></tr>
                <tr><td class="prop">Domain:</td><td><a href="http://www.w3.org/ns/dcat#DataService">dcat:DataService</a> </td></tr>
                <tr><td class="prop">Range:</td><td><a href="http://www.w3.org/TR/xmlschema11-2/#anyURI">xsd:anyURI</a> </td></tr>
                </tbody>
            </table>
        </section>

        <section id="Property:dataservice_endpointdescription">
            <h4>Property: endpoint description</h4>
            <table class="definition">
                <thead><tr><th>RDF Property:</th><th><a href="http://www.w3.org/ns/dcat#endpointDescription">dcat:endpointDescription</a></th></tr></thead>
                <tbody>
                <tr><td class="prop">Definition:</td><td>A description of the service end-point, for example an OpenAPI (Swagger) description, an OGC getCapabilities response, a SD Service, an OpenSearch or WSDL document.  </td></tr>
                <tr><td class="prop">Domain:</td><td><a href="http://www.w3.org/ns/dcat#DataService">dcat:DataService</a> </td></tr>
                <tr><td class="prop">Range:</td><td><a href="http://www.w3.org/2000/01/rdf-schema#Resource">rdfs:Resource</a> </td></tr>
                </tbody>
            </table>
        </section>

        <section id="Property:dataservice_license">
            <h4>Property: license</h4>
            <table class="definition">
                <thead><tr><th>RDF Property:</th><th><a href="http://purl.org/dc/terms/license">dct:license</a></th></tr></thead>
                <tbody>
                <tr><td class="prop">Definition:</td><td>A legal document under which the service is made available.</td></tr>
                <tr><td class="prop">Range:</td><td><a href="http://purl.org/dc/terms/LicenseDocument">dct:LicenseDocument</a></td></tr>
                <tr><td class="prop">See also:</td><td><a href="#Property:distribution_rights" title=""> distribution rights</a>,
                    <a href="#Property:catalog_license" title="">catalog license</a></td></tr>
                </tbody>
            </table>
        </section>

        <section id="Property:dataservice_access_rights">
            <h4>Property: access rights</h4>
            <table class="definition">
                <thead><tr><th>RDF Property:</th><th><a href="http://purl.org/dc/terms/accessRights">dct:accessRights</a></th></tr></thead>
                <tbody>
                <tr><td class="prop">Definition:</td><td>Access Rights <em title="MAY" class="rfc2119">MAY</em> include information regarding access or restrictions based on privacy, security, or other policies. </td></tr>
                <tr><td class="prop">Range:</td><td><a href="http://purl.org/dc/terms/RightsStatement">dct:RightsStatement</a></td></tr>
                </tbody>
            </table>
        </section>

    </section> <!-- end class DataService -->

    <section id="Class:Dataset">
        <h3>Class: Dataset</h3>
        <p>In addition to the properties inherited from the super-class <a href="http://www.w3.org/ns/dcat#Resource">dcat:Resource</a>, the following properties are recommended for use on this class:
            <a href="#Property:dataset_creator">creator</a>,
            <a href="#Property:dataset_distribution">distribution</a>,
            <a href="#Property:dataset_frequency">frequency</a>,
            <a href="#Property:dataset_spatial">spatial/geographic coverage</a>,
            <a href="#Property:dataset_temporal">temporal coverage</a>,
            <a href="#Property:dataset_wasgeneratedby">was generated by</a>
        </p>

        <p>
            Information about licences and rights <em title="SHOULD" class="rfc2119">SHOULD</em> be provided on the level of Distribution. Information about licences and rights MAY be provided for a Dataset in addition to but not instead of the information provided for the Distributions of that Dataset. Providing licence or rights information for a Dataset that is different from information provided for a Distribution of that Dataset <em title="SHOULD" class="rfc2119">SHOULD</em> be avoided as this can create legal conflicts.
        </p>


        <p class="issue" data-number="59">
            The need to more formally encode access restrictions for both datasets and distributions has been identified as a requirement to be satisfied in the revision of DCAT.
        </p>

        <p class="issue" data-number="60">
            The need to provide richer descriptions of dataset aspects (e.g. instrument/sensor used, spatial feature, observable property, quantity kind) has been identified as a requirement to be satisfied in the revision of DCAT.
        </p>

        <p class="issue" data-number="61">
            The need to provide better guidance and vocabulary elements for dataset citation has been identified as a requirement to be satisfied in the revision of DCAT.
        </p>

        <p class="note">
            <a href="https://www.w3.org/TR/dcat-ucr/#RDSC">Dataset citation</a> is one of the requirements identified for the DCAT revision.
            Data citation is the practice of referencing data in a similar way as when providing bibliographic references, acknowledging data
            as a first class output in any investigative process. Data citation offers multiple benefits, such as crediting those producing the data,
            facilitating data discovery, supporting tracking the impact and reuse of data.

            To support data citation, the dataset description should include at a minimum: the dataset identifier, the dataset creator (added in this DCAT revision
            as part of the properties recommended for Dataset), the dataset title, the dataset publisher and the dataset release date.

            The constraints on the availability of such properties in the dataset description can be represented as a DCAT data citation profile.

            See the wiki page on <a href="https://github.com/w3c/dxwg/wiki/Provenance-patterns">Data Citation</a> for more discussion.
        </p>

        <p class="issue" data-number="63">
            The need to be able to link a dataset with publications arising from it has been identified as a requirement to be satisfied in the revision of DCAT.
        </p>

        <p class="issue" data-number="76">
            The need provide a more comprehensive method for describing dataset provenance has been identified as a requirement to be satisfied in the revision of DCAT. A preliminary <a href="https://raw.githubusercontent.com/w3c/dxwg/gh-pages/dcat/rdf/dcat-prov.ttl">alignment of DCAT with PROV-O is available</a>.
        </p>

        <p class="issue" data-number="84">
            The need to be able to provide summary statistics about a dataset has been identified as a requirement to be satisfied in the revision of DCAT.
        </p>

        <p class="issue" data-number="86">
            The need to be able to provide usage notes for a dataset or distribution has been identified as a requirement to be satisfied in the revision of DCAT.
        </p>
        <p class="issue" data-number="433">
            The need to be able to provide citations for a distribution has been identified as a potential requirement to be satisfied in the revision of DCAT.
        </p>

        <table class="definition">
            <thead><tr><th>RDF Class:</th><th><a href="http://www.w3.org/ns/dcat#Dataset">dcat:Dataset</a></th></tr></thead>
            <tbody>
            <tr><td class="prop">Definition:</td><td>A collection of data, published or curated by a single agent, and available for access or download in one or more formats.</td></tr>
            <tr><td class="prop">Sub class of:</td><td><a href="http://www.w3.org/ns/dcat#Resource">dcat:Resource</a></td></tr>
            <tr><td class="prop">Usage note:</td><td>This class represents the actual dataset as published by the dataset publisher. In cases where a distinction between the actual dataset and its entry in the catalog is necessary (because metadata such as modification date and maintainer might differ), the <i><a href="#Class:Catalog_Record">catalog record</a></i> class can be used for the latter.</td></tr>
            </tbody>
        </table>

        <div class="note">
            <p>
                In DCAT 2014 [[VOCAB-DCAT-20140116]] <a href="#Class:Dataset">dcat:Dataset</a> was a sub-class of <a href="http://purl.org/dc/dcmitype/Dataset">dctype:Dataset</a>, which is a member of the <a href="http://dublincore.org/documents/dcmi-terms/#section-7">DCMI Types vocabulary</a> [[DCTERMS]].
                The scope of <a href="#Class:Dataset">dcat:Dataset</a> also includes other members of the <a href="http://dublincore.org/documents/dcmi-terms/#section-7">DCMI Types vocabulary</a>, so the implicitly limited sub-class relationship from DCAT 2014 [[VOCAB-DCAT-20140116]] has been removed in this revised DCAT vocabulary - see <a href="https://github.com/w3c/dxwg/issues/98">Issue #98</a>.
            </p>
            <p>
                Note that members of the <a href="http://dublincore.org/documents/dcmi-terms/#section-7">DCMI Types vocabulary</a> may appear as the value of the <a href="#Property:resource_type">dct:type</a> property, as shown in <a href="#classifying-dataset-types">Classifying dataset types</a>.
            </p>
        </div>


        <section id="Property:dataset_creator">
            <h4>Property: dataset creator</h4>

            <p class="note">
                New property for Dataset in this revision of DCAT, added when considering the data citation requirement.
            </p>


            <table class="definition">
                <thead><tr><th>RDF Property:</th><th><a href="http://purl.org/dc/terms/creator">dct:creator</a></th></tr></thead>
                <tbody>
                <tr><td class="prop">Definition:</td><td>The entity responsible for producing the dataset.</td></tr>
                <tr><td class="prop">Range:</td><td><a href="http://xmlns.com/foaf/0.1/Agent">foaf:Agent</a></td></tr>
                <tr><td class="prop">Usage note:</td><td>Resources of type <a href="http://xmlns.com/foaf/0.1/Agent">foaf:Agent</a>
                    are recommended as values for this property.</td></tr>
                <tr><td class="prop">See also:</td><td><a href="#Class:Organization_Person">Class: Organization/Person</a></td></tr>
                </tbody>
            </table>

        </section>

        <section id="Property:dataset_distribution">
            <h4>Property: dataset distribution</h4>

            <table class="definition">
                <thead><tr><th>RDF Property:</th><th><a href="http://www.w3.org/ns/dcat#distribution">dcat:distribution</a></th></tr></thead>
                <tbody>
                <tr><td class="prop">Definition:</td><td>An available distribution of the dataset.</td></tr>
                <tr><td class="prop">Sub property of:</td><td><a href="http://purl.org/dc/terms/relation">dct:relation</a></td></tr>
                <tr><td class="prop">Domain:</td><td><a href="http://www.w3.org/ns/dcat#Dataset">dcat:Dataset</a></td></tr>
                <tr><td class="prop">Range:</td><td><a href="http://www.w3.org/ns/dcat#Distribution">dcat:Distribution</a></td></tr>
                </tbody>
            </table>
        </section>

        <p class="issue">
            <a href="https://github.com/w3c/dxwg/issues/81">Issue #81</a> concerns the general need to describe relationships between datasets.
            Guidance on the use of specializations of dct:relation is required in the context of dcat:Dataset.
        </p>

        <section id="Property:dataset_frequency">
            <h4>Property: frequency</h4>
            <table class="definition">
                <thead><tr><th>RDF Property:</th><th><a href="http://purl.org/dc/terms/accrualPeriodicity">dct:accrualPeriodicity</a></th></tr></thead>
                <tbody>
                <tr><td class="prop">Definition:</td><td>The frequency at which dataset is published.</td></tr>
                <tr><td class="prop">Range:</td><td><a href="http://purl.org/dc/terms/Frequency">dct:Frequency</a> (A rate at which something recurs)</td></tr>
                </tbody>
            </table>
        </section>

        <section id="Property:dataset_spatial">
            <h4>Property: spatial/geographical coverage</h4>

            <p class="issue" data-number="82">
                The need to indicate the spatial reference system used in the spatial description of a dataset has been identified as a requirement to be satisfied in the revision of DCAT.
            </p>

            <p class="issue" data-number="83">
                The need to be able to describe the spatial coverage of a dataset as a geometry has been identified as a requirement to be satisfied in the revision of DCAT.
            </p>

            <table class="definition">
                <thead><tr><th>RDF Property:</th><th><a href="http://purl.org/dc/terms/spatial">dct:spatial</a></th></tr></thead>
                <tbody>
                <tr><td class="prop">Definition:</td><td>The geographical area covered by the dataset.</td></tr>
                <tr><td class="prop">Range:</td><td><a href="http://purl.org/dc/terms/Location">dct:Location</a> (A spatial region or named place)</td></tr>
                </tbody>
            </table>
        </section>

        <section id="Property:dataset_temporal">
            <h4>Property: temporal coverage</h4>

            <p class="issue" data-number="85">
                The need to be able to describe the temporal coverage of a dataset in a structured way has been identified as a requirement to be satisfied in the revision of DCAT.
            </p>

            <table class="definition">
                <thead><tr><th>RDF Property:</th><th><a href="http://purl.org/dc/terms/temporal">dct:temporal</a></th></tr></thead>
                <tbody>
                <tr><td class="prop">Definition:</td><td>The temporal period that the dataset covers.</td></tr>
                <tr><td class="prop">Range:</td><td><a href="http://purl.org/dc/terms/PeriodOfTime">dct:PeriodOfTime</a> (An interval of time that is named or defined by its start and end dates)</td></tr>
                </tbody>
            </table>
        </section>

        <section id="Property:dataset_wasgeneratedby">
            <h4>Property: was generated by</h4>

            <table class="definition">
                <thead><tr><th>RDF Property:</th><th><a href="http://www.w3.org/ns/prov#wasGeneratedBy">prov:wasGeneratedBy</a></th></tr></thead>
                <tbody>
                <tr><td class="prop">Definition:</td><td>An activity that generated, or provides the business context for, the creation of the dataset.</td></tr>
                <tr><td class="prop">Domain:</td><td><a href="http://www.w3.org/ns/prov#Entity">prov:Entity</a></td></tr>
                <tr><td class="prop">Range:</td><td><a href="http://www.w3.org/ns/prov#Activity">prov:Activity</a> An activity is something that occurs over a period of time and acts upon or with entities; it may include consuming, processing, transforming, modifying, relocating, using, or generating entities.</td></tr>
                <tr><td class="prop">Usage note:</td><td>The activity associated with generation of a dataset will typically be an initiative, project, mission, survey, on-going activity ("business as usual") etc. Multiple prov:wasGeneratedBy properties can be used to indicate the dataset production context at various levels of granularity. </td></tr>
                <tr><td class="prop">Usage note:</td><td>Use <a href="http://www.w3.org/ns/prov#qualifiedGeneration">prov:qualifiedGeneration</a> to attach additional details about the relationship between the dataset and the activity, e.g. the exact time that the dataset was produced during the lifetime of a project</td></tr>
                </tbody>
            </table>

            <p class="note">
                New property in this context in this revision of DCAT.
            </p>

            <p>
                Details about how to describe the activity that generated a dataset, such as a project, initiative, on-going activity, mission or survey, are out of scope for this document.
                <a href="http://www.w3.org/ns/prov#Activity">prov:Activity</a> provides for some basic properties such as begin and end time, associated agents etc.
                Further details may be provided through classes defined in applications.
                A number of ontologies for describing projects are available, for example
                VIVO for academic research projects [[VIVO-ISF]],
                DOAP (Description of a Project) for software projects [[DOAP]], and
                DBPedia for general projects [[DBPEDIA-ONT]] which are expected to be suitable for different applications.
            </p>
        </section>

    </section> <!-- end class Dataset -->

    <section id="Class:Discovery_Service">
        <h3>Class: Discovery Service</h3>
        <p>In addition to the properties inherited from the super-class <a href="http://www.w3.org/ns/dcat#DataService">dcat:DataDistributionService</a>, the following properties are recommended for use on this class: <i>none yet</i>
        </p>

        <table class="definition">
            <thead><tr><th>RDF Class:</th><th><a href="http://www.w3.org/ns/dcat#DiscoveryService">dcat:DiscoveryService</a></th></tr></thead>
            <tbody>
            <tr><td class="prop">Definition:</td><td>A site or end-point that supports data discovery, usually by providing access to catalogs</td></tr>
            <tr><td class="prop">Sub class of:</td><td><a href="http://www.w3.org/ns/dcat#DataDistributionService">dcat:DataDistributionService</a></td></tr>
            <tr><td class="prop">Usage note:</td><td> </td></tr>
            <tr><td class="prop">See also:</td><td> </td></tr>
            </tbody>
        </table>

        <p class="note">
            The class <a href="#Class:Discovery_Service">dcat:DiscoveryService</a> has been added to the DCAT vocabulary in this revision.
        </p>

    </section> <!-- end class DiscoveryService -->

    <section id="Class:Distribution">
        <h3>Class: Distribution</h3>
        <p>The following properties are recommended for use on this class:
            <a href="#Property:distribution_accessurl">access URL</a>,
            <a href="#Property:distribution_accessservice">access service</a>,
            <a href="#Property:distribution_size">byte size</a>,
            <a href="#Property:distribution_conformsto">conforms to</a>,
            <a href="#Property:distribution_description">description</a>,
            <a href="#Property:distribution_downloadurl">download URL</a>,
            <a href="#Property:distribution_format">format</a>,
            <a href="#Property:distribution_license">license</a>,
            <a href="#Property:distribution_media_type">media type</a>,
            <a href="#Property:distribution_release_date">release date</a>,
            <a href="#Property:distribution_rights">rights</a>,
            <a href="#Property:distribution_title">title</a>,
            <a href="#Property:distribution_update_date">update/modification date</a>
        </p>

        <p class="issue" data-number="54">
            The packaging of files in a dcat:Distribution is being considered as part of the revision of DCAT.
        </p>

        <p class="issue" data-number="59">
            The need to more formally encode access restrictions for both datasets and distributions has been identified as a requirement to be satisfied in the revision of DCAT.
        </p>

        <table class="definition">
            <thead><tr><th>RDF class:</th><th><a href="http://www.w3.org/ns/dcat#Distribution">dcat:Distribution</a></th></tr></thead>
            <tbody>
            <tr><td class="prop">Definition:</td><td>A specific representation of a dataset. A dataset might be available in several different forms,
                and these forms might comprise both different serializations or different schematic arrangements of the same data.
                Examples of distributions include a CSV file, a netCDF file, or a data-cube</td></tr>
            <tr><td class="prop">Usage note:</td><td>This represents a general availability of a dataset. It implies no information
                about the actual access method of the data, i.e. whether by direct download, API, or through a Web page.
                The use of <a href="#Property:distribution_downloadurl">dcat:downloadURL</a> property indicates directly downloadable distributions.</td></tr>
            <tr><td class="prop">See also:</td><td><a href="#Class:Data_Distribution_Service" title="">Data distribution service</a></td></tr>
            </tbody>
        </table>

        <div class="note">
            <p>
                The scope of dcat:Distribution here is narrower than in DCAT-2014 [[VOCAB-DCAT-20140116]], where it also included APIs and feeds.
                Data catalogues designed using DCAT-2014 therefore used instances of type dcat:Distribution to describe data distribution services.
                <b>Applications consuming DCAT should be aware that catalogues designed using DCAT-2014 might use dcat:Distribution to represent both services and representations.</b>
            </p>
            <p>
                Under the revised scope, instances of type dcat:Distribution <em title="SHOULD" class="rfc2119">SHOULD</em> be limited to <i>representations</i> of datasets which might be transported as files, and <em title="SHOULD NOT" class="rfc2119">SHOULD NOT</em> be used for data <i>services</i> such as APIs or feeds. Data services including APIs and feeds <em title="SHOULD" class="rfc2119">SHOULD</em> be described using instances of type <a href="#Class:Data_Service">dcat:DataService</a> whose sub-class <a href="#Class:Data_Distribution_Service">dcat:DataDistributionService</a> <em title="MAY" class="rfc2119">MAY</em> serve <a href="#Class:Distribution">dcat:Distributions</a>.
            </p>
            <p>
                Links between a dcat:Distribution and services or web addresses where it can be accessed are expressed using <a href="#Property:distribution_accessurl">dcat:accessURL</a>, <a href="#Property:distribution_accessservice">dcat:accessService</a>, <a href="#Property:distribution_downloadurl">dcat:downloadURL</a>, as shown in <a href="#fig1">Figure 1</a> and described in the definitions below.
            </p>
        </div>

        <p class="note">
            The definition text of dcat:Distribution has been revised to clarify that distributions are primarily <i>representations</i> of datasets.  As such, all distributions of a given dataset should be informationally equivalent.
        </p>

        <p class="issue" data-number="411">
            The intention of the phrase "informationally equivalent" needs to be clarified, in particular as different serializations may have different expressivity.
        </p>

        <section id="Property:distribution_title">
            <h4>Property: title</h4>
            <table class="definition">
                <thead><tr><th>RDF Property:</th><th><a href="http://purl.org/dc/terms/title">dct:title</a></th></tr></thead>
                <tbody>
                <tr><td class="prop">Definition:</td><td>A name given to the distribution.</td></tr>
                <tr><td class="prop">Range:</td><td><a href="http://www.w3.org/2000/01/rdf-schema#Literal">rdfs:Literal</a></td></tr>
                </tbody>
            </table>
        </section>

        <section id="Property:distribution_description">
            <h4>Property: description</h4>
            <table class="definition">
                <thead><tr><th>RDF Property:</th><th><a href="http://purl.org/dc/terms/description">dct:description</a></th></tr></thead>
                <tbody>
                <tr><td class="prop">Definition:</td><td>free-text account of the distribution.</td></tr>
                <tr><td class="prop">Range:</td><td><a href="http://www.w3.org/2000/01/rdf-schema#Literal">rdfs:Literal</a></td></tr>
                </tbody>
            </table>
        </section>

        <section id="Property:distribution_release_date">
            <h4>Property: release date</h4>
            <table class="definition">
                <thead><tr><th>RDF Property:</th><th><a href="http://purl.org/dc/terms/issued">dct:issued</a></th></tr></thead>
                <tbody>
                <tr><td class="prop">Definition:</td><td>Date of formal issuance (e.g., publication) of the distribution.</td></tr>
                <tr><td class="prop">Range:</td><td><a href="http://www.w3.org/2000/01/rdf-schema#Literal">rdfs:Literal</a>
                    encoded using the relevant ISO 8601 Date and Time compliant string [[!DATETIME]] and typed using the appropriate XML Schema datatype [[XMLSCHEMA11-2]]
                </td></tr>
                <tr><td class="prop">Usage note:</td><td>This property <em title="SHOULD" class="rfc2119">SHOULD</em> be set using the first known date of issuance.</td></tr>
                <tr><td class="prop">See also:</td><td><a href="#Property:resource_release_date" title=""> resource release date</a></td></tr>
                </tbody>
            </table>
        </section>

        <section id="Property:distribution_update_date">
            <h4>Property: update/modification date</h4>
            <table class="definition">
                <thead><tr><th>RDF Property:</th><th><a href="http://purl.org/dc/terms/modified">dct:modified</a></th></tr></thead>
                <tbody>
                <tr><td class="prop">Definition:</td><td>Most recent date on which the distribution was changed, updated or modified.</td></tr>
                <tr><td class="prop">Range:</td><td><a href="http://www.w3.org/2000/01/rdf-schema#Literal">rdfs:Literal</a>
                    encoded using the relevant ISO 8601 Date and Time compliant string [[!DATETIME]] and typed using the appropriate XML Schema datatype [[XMLSCHEMA11-2]]</td></tr>
                <tr><td class="prop">See also:</td><td><a href="#Property:resource_update_date" title=""> resource modification date</a></td></tr>
                </tbody>
            </table>
        </section>

        <section id="Property:distribution_license">
            <h4>Property: license</h4>

            <p class="issue" data-number="114">
                Models for the kind of license or rights representation indicated by the dct:license and dct:rights property are being considered as part of the revision of DCAT. See also <a href="#license-rights">License and rights statements</a>.
            </p>

            <table class="definition">
                <thead><tr><th>RDF Property:</th><th><a href="http://purl.org/dc/terms/license">dct:license</a></th></tr></thead>
                <tbody>
                <tr><td class="prop">Definition:</td><td>A legal document under which the distribution is made available.</td></tr>
                <tr><td class="prop">Range:</td><td><a href="http://purl.org/dc/terms/LicenseDocument">dct:LicenseDocument</a></td></tr>
                <tr><td class="prop">Usage note:</td><td>Information about licences and rights <em title="SHOULD" class="rfc2119">SHOULD</em> be provided on the level of Distribution. Information about licences and rights <em title="MAY" class="rfc2119">MAY</em> be provided for a Dataset in addition to but not instead of the information provided for the Distributions of that Dataset. Providing licence or rights information for a Dataset that is different from information provided for a Distribution of that Dataset <em title="SHOULD" class="rfc2119">SHOULD</em> be avoided as this can create legal conflicts.</td></tr>
                <tr><td class="prop">See also:</td><td><a href="#Property:distribution_rights" title=""> distribution rights</a>,
                    <a href="#Property:catalog_license" title="">catalog license</a></td></tr>
                </tbody>
            </table>
        </section>

        <section id="Property:distribution_rights">
            <h4>Property: rights</h4>

            <p class="issue" data-number="114">
                Models for the kind of license or rights representation indicated by the dct:license and dct:rights property are being considered as part of the revision of DCAT. See also <a href="#license-rights">License and rights statements</a>.
            </p>

            <table class="definition">
                <thead><tr><th>RDF Property:</th><th><a href="http://purl.org/dc/terms/rights">dct:rights</a></th></tr></thead>
                <tbody>
                <tr><td class="prop">Definition:</td><td>Information about rights held in and over the distribution.</td></tr>
                <tr><td class="prop">Range:</td><td><a href="http://purl.org/dc/terms/RightsStatement">dct:RightsStatement</a></td></tr>
                <tr><td class="prop">Usage note:</td><td>dct:license, which is a sub-property of dct:rights, can be used to link
                    a distribution to a license document. However, dct:rights allows linking to a rights statement that
                    can include licensing information as well as other information that supplements the licence such as attribution.<br/>
                    Information about licences and rights <em title="SHOULD" class="rfc2119">SHOULD</em> be provided on the level of Distribution. Information about licences and rights MAY be provided for a Dataset in addition to but not instead of the information provided for the Distributions of that Dataset. Providing licence or rights information for a Dataset that is different from information provided for a Distribution of that Dataset <em title="SHOULD" class="rfc2119">SHOULD</em> be avoided as this can create legal conflicts.</td></tr>
                <tr><td class="prop">See also:</td><td><a href="#Property:distribution_license" title=""> distribution license</a>,
                    <a href="#Property:catalog_rights" title="">catalog rights</a></td></tr>
                </tbody>
            </table>
        </section>


        <section id="Property:distribution_accessurl">
            <h4>Property: access address</h4>

            <p class="issue" data-number="145">
                The granularity of dcat:accessURL is being re-considered to provide different usages for list and item endpoints as well as supporting the declaration of different profiles (for list results and data payload).
            </p>

            <table class="definition">
                <thead><tr><th>RDF Property:</th><th><a href="http://www.w3.org/ns/dcat#accessURL">dcat:accessURL</a></th></tr></thead>
                <tbody>
                <tr><td class="prop">Definition:</td><td>A URL of the resource that gives access to a distribution of the dataset. E.g. landing page, feed, SPARQL endpoint.</td></tr>
                <tr><td class="prop">Domain:</td><td><a href="http://www.w3.org/ns/dcat#Distribution">dcat:Distribution</a></td></tr>
                <tr><td class="prop">Range:</td><td><a href="http://www.w3.org/2000/01/rdf-schema#Resource">rdfs:Resource</a></td></tr>
                <tr><td class="prop">Usage note:</td><td><a href="#Property:distribution_accessurl">dcat:accessURL</a> <em title="SHOULD" class="rfc2119">SHOULD</em> be used for the address of a service or location that can provide access to this distribution, typically through a web form, query or API call.
                    <br/><a href="#Property:distribution_downloadurl">dcat:downloadURL</a> is preferred for direct links to downloadable resources.
                    <br/>If the distribution(s) are accessible only through a landing page (i.e. direct download URLs are not known), then the landingPage address associated with the dcat:Dataset <em title="SHOULD" class="rfc2119">SHOULD</em> be duplicated as accessURL on a distribution. (see <a href="#example-landing-page"></a>)
                </td></tr>
                <tr><td class="prop">See also</td><td><a href="#Property:distribution_downloadurl">download address</a>, <a href="#Property:distribution_accessservice">access service</a></td></tr>
                </tbody>
            </table>

            <p>
                dcat:accessURL generally matches the property-chain dcat:accessService/dcat:endpointURL. In the RDF representation of DCAT this is axiomatized as an OWL property-chain axiom.
            </p>
        </section>

        <section id="Property:distribution_accessservice">
            <h4>Property: access service</h4>

            <p class="note">
                New property in this revision of DCAT.
            </p>

            <table class="definition">
                <thead><tr><th>RDF Property:</th><th><a href="http://www.w3.org/ns/dcat#accessService">dcat:accessService</a></th></tr></thead>
                <tbody>
                <tr><td class="prop">Definition:</td><td>A site or end-point that gives access to the distribution of the dataset</td></tr>
                <tr><td class="prop">Sub-property of:</td><td><a href="http://www.w3.org/ns/dcat#accessURL">dcat:accessURL</a></td></tr>
                <tr><td class="prop">Range:</td><td><a href="http://www.w3.org/ns/dcat#DataDistributionService">dcat:DataDistributionService</a></td></tr>
                <tr><td class="prop">Usage note:</td><td><a href="#Property:distribution_accessservice">dcat:accessService</a> <em title="SHOULD" class="rfc2119">SHOULD</em> be used to link to a description of a <a href="#Class:Data_Distribution_Service">dcat:DataDistributionService</a> that can provide access to this distribution.</td></tr>
                <tr><td class="prop">See also</td><td><a href="#Property:distribution_downloadurl">download address</a>, <a href="#Property:distribution_accessurl">access address</a></td></tr>
                </tbody>
            </table>
        </section>

        <section id="Property:distribution_downloadurl">
            <h4>Property: download address</h4>

            <table class="definition">
                <thead><tr><th>RDF Property:</th><th><a href="http://www.w3.org/ns/dcat#downloadURL">dcat:downloadURL</a></th></tr></thead>
                <tbody>
                <tr><td class="prop">Definition:</td><td>The URL of the downloadable file in a given format. E.g. CSV file or RDF file. The format is indicated by the distribution's dct:format and/or dcat:mediaType</td></tr>
                <tr><td class="prop">Domain:</td><td><a href="http://www.w3.org/ns/dcat#Distribution">dcat:Distribution</a></td></tr>
                <tr><td class="prop">Range:</td><td><a href="http://www.w3.org/2000/01/rdf-schema#Resource">rdfs:Resource</a></td></tr>
                <tr><td class="prop">Usage note:</td><td><a href="#Property:distribution_downloadurl">dcat:downloadURL</a> <em title="SHOULD" class="rfc2119">SHOULD</em> be used for the address at which this distribution is available directly, typically through a HTTP Get request.  </td></tr>
                <tr><td class="prop">See also</td><td><a href="#Property:distribution_accessurl">access address</a>, <a href="#Property:distribution_accessservice">access service</a></td></tr>
                </tbody>
            </table>
        </section>

        <section id="Property:distribution_size">
            <h4>Property: byteSize</h4>

            <p class="issue" data-number="125">
                The axiomatization of dcat:byteSize is being re-evaluated as part of the revision of DCAT.
            </p>

            <table class="definition">
                <thead><tr><th>RDF Property:</th><th><a href="http://www.w3.org/ns/dcat#size">dcat:byteSize</a></th></tr></thead>
                <tbody>
                <tr><td class="prop">Definition:</td><td>The size of a distribution in bytes.</td></tr>
                <tr><td class="prop">Domain:</td><td><a href="http://www.w3.org/ns/dcat#Distribution">dcat:Distribution</a></td></tr>
                <tr><td class="prop">Range:</td><td><a href="http://www.w3.org/2000/01/rdf-schema#Literal">rdfs:Literal</a> typed as <a href="http://www.w3.org/TR/xmlschema-2/#decimal">xsd:decimal</a>.</td></tr>
                <tr><td class="prop">Usage note:</td><td>The size in bytes can be approximated when the precise size is not known.</td></tr>
                </tbody>
            </table>
        </section>

        <section id="Property:distribution_conformsto">
            <h4>Property: conforms to</h4>

            <p class="note">
                New property in this context in this revision of DCAT.
            </p>

            <table class="definition">
                <thead><tr><th>RDF Property:</th><th><a href="http://purl.org/dc/terms/conformsTo">dct:conformsTo</a></th></tr></thead>
                <tbody>
                <tr><td class="prop">Definition:</td><td>An established standard to which the described resource conforms.</td></tr>
                <tr><td class="prop">Range:</td><td><a href="http://purl.org/dc/terms/Standard">dct:Standard</a> (A basis for comparison; a reference point against which other things can be evaluated.)</td></tr>
                <tr><td class="prop">Usage note:</td><td>This property <em title="SHOULD" class="rfc2119">SHOULD</em> be used to indicate the model, schema, ontology, view or profile that this representation conforms to. This is (generally) a complementary concern to the media-type or format. </td></tr>
                <tr><td class="prop">See also:</td><td><a href="#Property:distribution_format">format</a> , <a href="#Property:distribution_media_type">media type</a></td></tr>
                </tbody>
            </table>

            <p class="note">
                <a href="http://purl.org/dc/terms/Standard">dct:Standard</a> is defined as "A basis for comparison; a reference point against which other things can be evaluated." It is not restricted to formal standards issued by bodies like ISO and W3C. In this context it will usually be used for a schema, ontology, data model or profile which specifies the structure of a dataset. This is not necessarily tied to a single encoding or serialization.
            </p>
        </section>

        <section id="Property:distribution_media_type">
            <h4>Property: media type</h4>

            <p class="note">
                The range of dcat:mediaType has been tightened from dct:MediaTypeOrExtent to dct:MediaType as part of the revision of DCAT.
            </p>

            <table class="definition">
                <thead><tr><th>RDF Property:</th><th><a href="http://www.w3.org/ns/dcat#mediaType">dcat:mediaType</a></th></tr></thead>
                <tbody>
                <tr><td class="prop">Definition:</td><td>The media type of the distribution as defined by IANA [[!IANA-MEDIA-TYPES]].</td></tr>
                <tr><td class="prop">Sub property of:</td><td><a href="http://purl.org/dc/terms/format">dct:format</a></td></tr>
                <tr><td class="prop">Domain:</td><td><a href="http://www.w3.org/ns/dcat#Distribution">dcat:Distribution</a></td></tr>
                <tr><td class="prop">Range:</td><td><a href="http://purl.org/dc/terms/MediaType">dct:MediaType</a></td></tr>
                <tr><td class="prop">Usage note:</td><td>This property <em title="SHOULD" class="rfc2119">SHOULD</em> be used when the media type of the distribution is defined in IANA [[!IANA-MEDIA-TYPES]], otherwise dct:format <em title="MAY" class="rfc2119">MAY</em> be used with different values.</td></tr>
                <tr><td class="prop">See also:</td><td><a href="#Property:distribution_format">format</a> , <a href="#Property:distribution_conformsto">conforms to</a></td></tr>
                </tbody>
            </table>
        </section>

        <section id="Property:distribution_format">
            <h4>Property: format</h4>

            <table class="definition">
                <thead><tr><th>RDF Property:</th><th><a href="http://purl.org/dc/terms/format">dct:format</a></th></tr></thead>
                <tbody>
                <tr><td class="prop">Definition:</td><td>The file format of the distribution.</td></tr>
                <tr><td class="prop">Range:</td><td><a href="http://purl.org/dc/terms/MediaTypeOrExtent">dct:MediaTypeOrExtent</a></td></tr>
                <tr><td class="prop">Usage note:</td><td> <a href="#Property:distribution_media_type">dcat:mediaType</a> <em title="SHOULD" class="rfc2119">SHOULD</em> be used if the type of the distribution is defined by IANA [[!IANA-MEDIA-TYPES]].</td></tr>
                <tr><td class="prop">See also:</td><td><a href="#Property:distribution_media_type">media type</a> , <a href="#Property:distribution_conformsto">conforms to</a></td></tr>
                </tbody>
            </table>
        </section>
    </section> <!-- end class Distribution -->


    <section id="Class:Concept_Scheme">
        <h3>Class: Concept Scheme</h3>
        <table class="definition">
            <thead><tr><th>RDF Class:</th><th><a href="http://www.w3.org/2004/02/skos/core#ConceptScheme">skos:ConceptScheme</a></th></tr></thead>
            <tbody>
            <tr><td class="prop">Definition:</td><td>A knowledge organization system (KOS) used to represent themes/categories of datasets in the catalog.</td></tr>
            <tr><td class="prop">See also:</td><td><a href="#Property:catalog_themes">catalog themes</a>, <a href="#Property:resource_theme">dataset theme</a></td></tr>
            </tbody>
        </table>
    </section>

    <section id="Class:Concept">
        <h3>Class: Concept</h3>
        <table class="definition">
            <thead><tr><th>RDF Class:</th><th><a href="http://www.w3.org/2004/02/skos/core#Concept">skos:Concept</a></th></tr></thead>
            <tbody>
            <tr><td class="prop">Definition:</td><td>A category or a theme used to describe datasets in the catalog.</td></tr>
            <tr><td class="prop">Usage note:</td><td>It is recommended to use either skos:inScheme or skos:topConceptOf on every skos:Concept
                used to classify datasets to link it to the concept scheme it belongs to. This concept scheme is typically associated with the catalog using dcat:themeTaxonomy</td></tr>
            <tr><td class="prop">See also:</td><td><a href="#Property:catalog_themes">catalog themes</a>, <a href="#Property:resource_theme">dataset theme</a></td></tr>
            </tbody>
        </table>
    </section>

    <section id="Class:Organization_Person">
        <h3>Class: Organization/Person</h3>

        <table class="definition">
            <thead><tr><th>RDF Classes:</th><th><a href="http://xmlns.com/foaf/0.1/Person">foaf:Person</a> for people and <a href="http://xmlns.com/foaf/0.1/Organization">foaf:Organization</a> for government agencies or other entities.</th></tr></thead>
            <tbody>
            <tr><td class="prop">Usage note:</td><td>[[!FOAF]] provides sufficient properties to describe these entities.</td></tr>
            </tbody>
        </table>
    </section>

</section>

<section id="quality-information" class="informative">
    <h2>Quality information</h2>
    <div class="note"><p>This section is not-normative as it provides guidance on how to document the quality of DCAT first class entities (e.g., datasets, distributions) and it does not define new DCAT terms. The guidance relies on the Data Quality Vocabulary(DQV)[[VOCAB-DQV]], which is a W3C Group Note.</p></div>

    The Data Quality Vocabulary (DQV) offers common modelling patterns for different aspects of Data Quality.

    It can relate  DCAT datasets and distributions with different types of quality information including
    <ul>
        <li> <a href="https://www.w3.org/TR/vocab-dqv/#dqv:QualityAnnotation"> dqv:QualityAnnotation</a>, which represents feedback and quality certificates given about the dataset or its distribution. </li>
        <li> <a href="https://www.w3.org/TR/vocab-dqv/#dqv:QualityPolicy">dqv:QualityPolicy</a>, which represents a policy or agreement that is chiefly governed by data quality concerns.</li>
        <li><a href="https://www.w3.org/TR/vocab-dqv/#dqv:QualityMeasurement">dqv:QualityMeasurement</a>, which represents a metric value providing quantitative or qualitative information about the dataset or distribution.</li>
    </ul>

    Each type of quality information can pertain to one or more quality dimensions, namely, quality characteristics relevant to the consumer. The practice to see the quality as a multi-dimensional space is consolidated in the field of quality management to split the quality management into addressable chunks. DQV does not define a normative list of quality dimensions. It offers the quality dimensions proposed in ISO/IEC 25012 [[ISOIEC25012]] and Zaveri et al. [[ZaveriEtAl]] as two possible starting points. It also provides an <a href="https://www.w3.org/2016/05/ldqd">RDF representation</a> for the quality dimensions and categories defined in the latter. Ultimately, implementers will need to choose themselves the collection of quality dimensions that best fits their needs.

    The following section shows how DCAT and DQV can be coupled to describe the quality of datasets and distributions.
    For a comprehensive introduction  and further examples of use, please refer to the Data Quality Vocabulary (DQV) group note [[VOCAB-DQV]].
    <div class="note">
        <p>The following examples make no comments on where the quality information would reside and how it is managed. That is out of scope for the DCAT vocabulary.  The assumption made is that the quality individuals are available using the URIs indicated.
            Besides, the examples and more in general the DQV  is neutral to the data portal design choices on how to collect quality information. For example, data portals can collect DQV instances by implementing specific UI to annotate data or by taking inputs from 3rd-party services.
        </p>
    </div>

    <p class="issue" data-number="252">
        We might want to include examples of quality documentation related to services.
    </p>

    <section id="quality-example1">
        <h2>Providing quality information</h2>

        <p>
            A data consumer (:consumer1)  describes the quality of the dataset :genoaBusStopsDataset that includes a georeferenced list of bus stops in Genoa. He/she annotates the dataset with a DQV quality note (:genoaBusStopsDatasetCompletenessNote) about data completeness (ldqd:completeness) to warn that the dataset includes only 20500 out of the 30000 stops.
        </p>

        <div class="example">
  <pre class="nohighlight turtle" aria-busy="false" aria-live="polite">
:genoaBusStopsDataset a dcat:Dataset ;
    dqv:hasQualityAnnotation :genoaBusStopsDatasetCompletenessNote .

:genoaBusStopsDatasetCompletenessNote
    a dqv:UserQualityFeedback ;
    oa:hasTarget :genoaBusStopsDataset ;
    oa:hasBody :textBody ;
    oa:motivatedBy dqv:qualityAssessment ;
    prov:wasAttributedTo :consumer1 ;
    prov:generatedAtTime "2018-05-27T02:52:02Z"^^xsd:dateTime ;
    dqv:inDimension ldqd:completeness
    .

:textBody a oa:TextualBody ;
    rdf:value "Incomplete dataset: it contains only 20500 out of 30000 existing bus stops" ;
    dc:language "en" ;
    dc:format "text/plain"
    .
    </pre></div>
        <p>
            The activity :myQualityChecking employs the service :myQualityChecker to check the quality of the :genoaBusStopsDataset dataset. The metric :completenessWRTExpectedNumberOfEntities is applied to measure the dataset completeness (ldqd:completeness) and it results in the quality measurement :genoaBusStopsDatasetCompletenessMeasurement.
        </p>
        <div class="example">
  <pre class="nohighlight turtle" aria-busy="false" aria-live="polite">
:genoaBusStopsDataset
    dqv:hasQualityMeasurement :genoaBusStopsDatasetCompletenessMeasurement .

:genoaBusStopsDatasetCompletenessMeasurement
    a dqv:QualityMeasurement ;
    dqv:computedOn :genoaBusStopsDataset ;
    dqv:isMeasurementOf :completenessWRTExpectedNumberOfEntities ;
    dqv:value "0.6833333"^^xsd:decimal  ;
    prov:wasAttributedTo :myQualityChecker ;
    prov:generatedAtTime "2018-05-27T02:52:02Z"^^xsd:dateTime ;
    prov:wasGeneratedBy :myQualityChecking
    .

:completenessWRTExpectedNumberOfEntities
    a dqv:Metric ;
    skos:definition "it returns the degree of completeness as ratio between the actual number of entities included in the dataset and the declared expected number of entities."@en ;
    dqv:expectedDataType xsd:decimal ;
    dqv:inDimension ldqd:completeness .

# :myQualityChecker is a service computing some quality metrics
:myQualityChecker
    a prov:SoftwareAgent ;
    rdfs:label "A quality assessment service"^^xsd:string .
    # Further details about quality service/software can be provided, for example,
    # deploying  vocabularies such as Dataset Usage Vocabulary (DUV), Dublin Core or ADMS.SW

# :myQualityChecking is the activity that has generated :genoaBusStopsDatasetCompletenessMeasurement from :genoaBusStopsDataset
:myQualityChecking
    a prov:Activity;
    rdfs:label "The checking of genoaBusStopsDataset's quality"^^xsd:string;
    prov:wasAssociatedWith :myQualityChecker;
    prov:used              :genoaBusStopsDataset;
    prov:generated         :genoaBusStopsDatasetCompletenessMeasurement;
    prov:endedAtTime      "2018-05-27T02:52:02Z"^^xsd:dateTime;
    prov:startedAtTime     "2018-05-27T00:52:02Z"^^xsd:dateTime .
    </pre></div>
        Other examples of quality documentation are available in the W3C Group Note DQV [[VOCAB-DQV]], including examples about <a href="https://www.w3.org/TR/vocab-dqv/#ExpressDatasetAccuracyPrecision">how express dataset accuracy and precision</a>.
    </section>
    <section id="quality-conformance">
        <h2>Documenting conformance to standards</h2>
        <p class="issue" data-number="58">
            The issue suggests to represent "the degree a dataset conforms to a stated quality standard" and "the details of data quality conformance test results". This section is a starter to deal with the above requests by relying on the existing  W3C vocabularies.
            Comments and suggestions about the following examples as well as the proposal of alternative patterns are more than welcome.
        </p>
        <p> This subsection  shows different modelling patterns combining DQV [[VOCAB-DQV]] with  PROV [[PROV-O]] and EARL [[EARL10-Schema]] to represent the conformance degree to a stated quality standard and the details about the conformance tests.
        </p>

        <section id="quality-conformance-statement">
            <h3>Conformance to a standard</h3>
            <p>The use of <a href="http://dublincore.org/documents/dcmi-terms/#terms-conformsTo">dct:conformsTo</a> and <a href="http://dublincore.org/documents/dcmi-terms/#terms-Standard">dct:Standard</a> is a well-known pattern to represent the conformance to a standard. The following example declares a fictional a:Dataset conformant to the "Commission Regulation (EU) No 1089/2010 of 23 November 2010 implementing Directive 2007/2/EC".</p>
            <div class="example">
  <pre class="nohighlight turtle" aria-busy="false" aria-live="polite">

a:Dataset a dcat:Dataset;
    dct:conformsTo &lt;http://data.europa.eu/eli/reg/2014/1312/oj&gt; .

# Reference standard / specification
&lt;http://data.europa.eu/eli/reg/2014/1312/oj&gt; a dct:Standard ;
    dct:title "Commission Regulation (EU) No 1089/2010 of 23 November 2010 implementing Directive 2007/2/EC of the European Parliament and of the Council as regards interoperability of spatial data sets and services"@en
    dct:issued "2010-11-23"^^xsd:date .
</pre></div>
        </section>
        <section id="quality-conformance-degree">
            <h3> Degree of conformance</h3>
            <p>Some legal context requires to specify the degree of conformance. For example,  INSPIRE metadata adopts a specific <a href="http://inspire.ec.europa.eu/metadata-codelist/DegreeOfConformity">controlled vocabulary</a> to express  non-conformance and non-evaluation beside the full compliance. As suggested in [[GeoDCAT-AP]], the following example specifies the degree of conformance (i.e.,  not conformant) by declaring the  <a href="http://dublincore.org/documents/dcmi-terms/#terms-type">dct:type</a> for the result of conformance test.  [[GeoDCAT-AP]] suggests to use a PROV entity to model the  conformance test (e.g., a:TestResult),  a PROV activity to model the testing activity (e,g., a:TestingActivity), a PROV plan derived by the INSPIRE Directive to represent  conformance test (e.g., a:ConformanceTest). A qualified PROV association binds the testing activity to the conformance test.
            </p>
            <div class="example">
  <pre class="nohighlight turtle" aria-busy="false" aria-live="polite">

a:Dataset a dcat:Dataset ;
    prov:wasUsedBy a:TestingActivity .

a:TestingActivity a prov:Activity ;
      prov:generated a:TestResult ;
      prov:qualifiedAssociation [
          a prov:Association ;
        # http://validator.example.org/ is the agent who did the test.
        prov:agent  &lt;http://validator.example.org/&gt;
        #following the plan  a:ConformanceTest
        prov:hadPlan a:ConformanceTest
        ] .

# Conformance test result
a:TestResult a prov:Entity ;
   dcterms:type &lt;http://inspire.ec.europa.eu/metadata-codelist/DegreeOfConformity/notConformant&gt; .

a:ConformanceTest a prov:Plan ;
    # Here you can specify additional information on the test
    prov:wasDerivedFrom &lt;http://data.europa.eu/eli/reg/2014/1312/oj&gt; .
    </pre></div>
            <p>Also,  DQV [[VOCAB-DQV]] can be deployed to  measure the compliance to a specific standard. In the following, the :levelOfComplianceToINSPIRE is a quality metrics which measures the compliance of a dataset to INSPIRE in terms of the percentage of passed compliance tests. The example assumes iso as a namespace representing the quality dimensions and categories defined in the ISO/IEC 25012.</p>
            <div class="example">
  <pre class="nohighlight turtle" aria-busy="false" aria-live="polite">

:levelOfComplianceToINSPIRE
    a dqv:Metric ;
    skos:definition "It returns the degree of compliance to INSPIRE defined as the percentage of passed compleance tests."@en
    dqv:expectedDataType xsd:double ;
    dqv:inDimension  iso:compliance .

iso:compliance
    a  dqv:Dimension ;
    skos:prefLabel "Compliance"@en ;
    skos:definition "The degree to which data has attributes that adhere to standards, conventions or regulations in force and similar rules relating to data quality in a specific context of use."@en ;
    dqv:inCategory  iso:InherentandSystemDependentDataQuality
    .
iso:inherentandSystemDependentDataQuality
    a  dqv:Category ;
   skos:prefLabel "Inherent and System-Dependent Data Quality"@en.
        </pre></div>
            <p>The quality measurement :measurement_complianceToINSPIRE represents the level of compliance for a dataset a:Dataset, namely, measurement of the metric :levelOfComplianceToINSPIRE. If only a part of the compliance tests succeeds (e.g. half of the compliance tests), the measurement would look like in the following:</p>
            <div class="example">
  <pre class="nohighlight turtle" aria-busy="false" aria-live="polite">

:measurement_complianceToINSPIRE
   a         dqv:QualityMeasurement;
   dqv:computedOn      a:Dataset;
   dqv:value           "50"^^xsd:double ;
   sdmx-attribute:unitMeasure &lt;http://www.wurvoc.org/vocabularies/om-1.8/Percentage&gt;
   dcterms:date      "2018-01-10"^^xsd:date ;
   dqv:isMeasurementOf    :levelOfComplianceToINSPIRE .
    </pre></div>

        </section>
        <section id="quality-conformance-test-results">
            <h3>Conformance test results</h3>
            <p> Further information about the tests can be provided using EARL [[EARL10-Schema]]. EARL provides specific classes to describe the testing activity, which can be adopted in conjunction with PROV.
                The following example describes the Testing activity a:TestingActivity as an EARL Assertion instead of a qualified association on the PROV activity. The EARL Assertion states the dataset a:Dataset has been tested with the conformance test a:ConformanceTest, and it has passed the test as described in a:testResult.
            </p>
            <div class="example">
  <pre class="nohighlight turtle" aria-busy="false" aria-live="polite">

a:assertion a earl:Assertion;
    earl:subject a:Dataset;
    earl:test a:ConformanceTest;
    earl:result a:testResult ;
    # let's indicate if the test was manual, automatic, or what ..
    earl:mode earl:automatic ;
    earl:assertedBy &lt;http://validator.example.org/&gt; ;
    prov:wasAttributedTo  &lt;http://validator.example.org/&gt;.

a:ConformanceTest a earl:TestRequirement, prov:Plan;
         dct:title "Set of conformance test derived by the Commission Regulation (EU) No 1089/2010 of 23 November 2010 implementing  Directive 2007/2/EC of the European Parliament and of the Council as regards interoperability of spatial data sets and services"@en";
         # it includes different subtests
         dct:hasPart a:test1, a:test2, ...,  a:testn.
         #It is derived  by the reference standard
         prov:wasDerivedFrom  &lt;http://data.europa.eu/eli/reg/2014/1312/oj&gt;.

a:testResult a earl:TestResult;
        #  results in conformancy.
        dcterms:type  &lt;http://inspire.ec.europa.eu/metadata-codelist/DegreeOfConformity/conformant&gt;;
        #the overall set of tests have been passed
        earl:outcome earl:passed .
        ];

# the description of the validator
 &lt;http://validator.example.org/&gt; a earl:Assertor, prov:Agent ;
      dcterms:description "A test execution service that runs conformance test suites."@en ;
      dcterms:title "Validator"@en .

#the testing activity
a:TestingActivity a prov:Activity;
    prov:generated a:TestAssertion, a:TestResult;
    prov:use a:Dataset ;
    prov:wasAssociatedWith   &lt;http://validator.example.org/&gt; .
    </pre></div>
            <p> The following example shows how the description would have looked like if the subtest a:testq1 had failed. In particular, dcterms:description and earl:info provide additional warnings or error messages in a human-readable form.</p>
            <div class="example">
  <pre class="nohighlight turtle" aria-busy="false" aria-live="polite">

a:assertion1 a earl:Assertion ;
    earl:subject a:Dataset ;
    earl:test a:testq1 ;
    earl:result [
        a earl:TestResult;
        #  results in no conformancy.
        dcterms:type  &lt;http://inspire.ec.europa.eu/metadata-codelist/DegreeOfConformity/notConformant&gt;
        #the overall set of tests have not been passed (!?)
        dcterms:date "2015-09-29T11:50:00+00:00"^^xsd:dateTime ;
        # Some XML encoding of the error
            dcterms:description """
                 &lt;ul xmlns="http://www.w3.org/1999/xhtml"&gt;
                 &lt;li&gt; test 1 has failed. Some description of the errors found&lt;/li&gt;
                 &lt;/ul&gt;"^^rdf:XMLLiteral;
            earl:info """"
                &lt;test-method duration-ms="47" finished-at="2015-09-29T11:50:00Z"
                name="validate" signature="validate()" started-at="2015-09-29T11:50:00Z"
                status="FAIL"&gt;
                &lt;exception class="java.lang.AssertionError"&gt;
                    &lt;message&gt;
                     Total validation errors found: 2
                     &lt;/message&gt;
               &lt;/exception&gt;
             &lt;/test-method&gt;"""^^rdf:XMLLiteral;
       earl:outcome earl:fail .
        ];
    # we do not know if the test was manual, automatic, or what ..
    earl:mode earl:automatic.
    </pre></div>
            Depending on the details required about tests, DQV can express the testing activity and errors as well. In the following, :error is a quality annotation that represents the previous error, and  a:testResult is defined as a DQV quality metadata to  collect the above annotations and the compliance measurements providing  provenance information.
            <div class="example">
  <pre class="nohighlight turtle" aria-busy="false" aria-live="polite">

:error
    a dqv:QualityAnnotation ;
    #this annotation is derived by the measurement
    prov:wasGeneratedBy  a:TestingActivity;
    oa:hasTarget a:Dataset ;
    oa:hasBody [
        #errors/failed test description
          a  oa:TextualBody;
          rdf:value  """&lt;test-method duration-ms="47" finished-at="2015-09-29T11:50:00Z"
                name="validate" signature="validate()" started-at="2015-09-29T11:50:00Z"
                status="FAIL"&gt;
                &lt;exception class="java.lang.AssertionError"&gt;
                    &lt;message&gt;
                     Total validation errors found: 2
                     &lt;/message&gt;
               &lt;/exception&gt;
             &lt;/test-method&gt;"""^^rdf:XMLLiteral ;
          #it can be in any format suppored by dc
          dct:format  "text/xml"
          ]
    oa:motivatedBy dqv:qualityAssessment, oa:assessing ;
    dqv:inDimension iso:compliance
    .

a:TestResult
    a dqv:QualityMetadata ;
    #  change the the dcterms:type according to the resulted compliance
    dcterms:type &lt;http://inspire.ec.europa.eu/metadata-codelist/DegreeOfConformity/conformant&gt; ;
    prov:wasAttributedTo &lt;http://validator.example.org/&gt; ;
    prov:generatedAtTime "2018-05-27T02:52:02Z"^^xsd:dateTime ;
    prov:wasGeneratedBy a:TestingActivity .

# The graph contains the rest of the statements presented in the previous examples.
a:testResult {
    a:Dataset
        dqv:hasQualityMeasurement :measurement_complianceToINSPIRE;
        dqv:hasQualityAnnotation :errors .
}

#the testing activity
a:TestingActivity a prov:Activity;
    prov:generated  a:TestResult;
    prov:use a:Dataset ;
    prov:wasAssociatedWith  &lt;http://validator.example.org/&gt;
     .
</pre></div>
            Of course,  the above modelling patterns can represent any quality tests not only conformance to standards.
        </section>
    </section>
</section>


<section id="prov-patterns">

    <h2>Provenance patterns</h2>
    <p class="issue" data-number="128">
        A number of requirements identify the need to provide better support for Dataset and Record provenance - see
        <a href="https://github.com/w3c/dxwg/issues/77">Issue #78</a>,
        <a href="https://github.com/w3c/dxwg/issues/77">Issue #77</a>,
        <a href="https://github.com/w3c/dxwg/issues/76">Issue #76</a>,
        <a href="https://github.com/w3c/dxwg/issues/71">Issue #71</a>,
        <a href="https://github.com/w3c/dxwg/issues/66">Issue #66</a>,
        <a href="https://github.com/w3c/dxwg/issues/63">Issue #63</a>.
        It has been suggested that many of the requirements can be satisfied by using capabilities from the [[PROV-O]] ontology,
        in particular by treating dcat:Resource and/or dcat:CatalogRecord a sub-class of <a href="http://www.w3.org/ns/prov#Entity">prov:Entity</a>.
        A preliminary <a href="https://raw.githubusercontent.com/w3c/dxwg/gh-pages/dcat/rdf/dcat-prov.ttl">alignment of DCAT with PROV-O is available</a>.
    </p>

    <p class="note">
        In this chapter it is planned to describe patterns for the use of the [[PROV-O]] vocabulary to support the various provenance-related requirements.
        See the wiki page on <a href="https://github.com/w3c/dxwg/wiki/Provenance-patterns">Provenance Patterns</a> for more discussion.
    </p>

</section>

<section id="license-rights">

    <h2>License and rights statements</h2>

	<p class="note">
		DCAT 2014 handling of license and rights do not appear to satisfy all requirements [[VOCAB-DCAT-20140116]].
		The recently completed W3C ODRL vocabulary [[ODRL-VOCAB]] provides a rich language for describing many kinds of rights and obligations.
		In this chapter it is planned to describe some patterns for linking DCAT Datasets and/or Distributions to suitable rights expressions.
		See the wiki page on <a href="https://github.com/w3c/dxwg/wiki/License-and-rights">License and rights</a> for more discussion.
	</p>
	<p>
		Selecting the right way to express conditions for access to and re-use of resources can be complex.
		Implementers should always seek legal advice before deciding which conditions apply to the resource being described.
	</p>
	<p>
		This specification distinguishes three main situations: one where a statement is associated with the resource that is explicitly declared as a 'licence';
		a second where the statement is not explicitly declared as a 'licence'; and a third where the conditions are explicitly expressed as an ODRL Policy.
	</p>
	<p>
		The following approach is recommended:
		<ol>
			<li>use <a href="http://dublincore.org/documents/dcmi-terms/#terms-license">dct:license</a> to refer to well-known licences such as <a href="https://creativecommons.org/share-your-work/licensing-types-examples/">those defined by Creative Commons</a></br>
			The object of dct:license, a <a href="http://dublincore.org/documents/dcmi-terms/#terms-LicenseDocument">dct:LicenseDocument</a>, is "A legal document giving official permission to do something with a Resource."</li>
			<li>use <a href="http://dublincore.org/documents/dcmi-terms/#terms-rights">dct:rights</a> to refer to rights statements that are not licences, such as copyright statements</br>
			The object of dct:rights, a <a href="http://dublincore.org/documents/dcmi-terms/#terms-RightsStatement">dct:RightsStatement</a>, is "A statement about the intellectual property rights (IPR) held in or over a Resource, a legal document giving official permission to do something with a resource, or a statement about access rights." 
			This is more general than a <a href="http://dublincore.org/documents/dcmi-terms/#terms-LicenseDocument">dct:LicenseDocument</a> and therefore should be used if it the statement contains more general information about rights.</li>
			<li>use <a href="https://www.w3.org/TR/odrl-vocab/#term-hasPolicy">odrl:hasPolicy</a> for linking to <a href="https://www.w3.org/TR/odrl-vocab/#term-Policy">ODRL policies</a></br>
			The Open Digital Rights Language (ODRL) is a policy expression language that provides a flexible and interoperable information model, vocabulary, and encoding mechanisms for representing statements about usage (i.e. permissions, prohibitions, and obligations) of content and services.</li>
		</ol>
	</p>

</section>

<section id="dataset-versions">

    <h2>Dataset versions</h2>

    <p class="issue" data-number="90">
        The need to be able to describe version relationships of datasets has been identified as a requirement to be satisfied in the revision of DCAT. Also see detailed requirements in
        <a href="https://github.com/w3c/dxwg/issues/89">Issue #89</a>,
        <a href="https://github.com/w3c/dxwg/issues/91">Issue #91</a>,
        <a href="https://github.com/w3c/dxwg/issues/92">Issue #92</a>,
        <a href="https://github.com/w3c/dxwg/issues/93">Issue #93</a>,
    </p>

    <p class="note">
        In this chapter it is planned to describe some patterns for describing Dataset and/or Distribution versions.
        See the wiki page on <a href="https://github.com/w3c/dxwg/wiki/Dataset-versioning">Dataset versioning</a> for more discussion.
    </p>

</section>

<section id="alignments">

    <h2>Alignment with other metadata vocabularies</h2>
    <p class="note">
        See the wiki page on <a href="https://github.com/w3c/dxwg/wiki/Alignments-and-crosswalks">Alignments and Crosswalks</a> for more discussion.
    </p>

    <section id="dcat-sdo" class="informative">
        <h3>Schema.org</h3>
        <p>
            Schema.org [[SCHEMA-ORG]] includes a number of types and properties based on the original DCAT work (see <a href="https://schema.org/Dataset">schema:Dataset</a> as a starting point),
            and the index for Google's <a href="https://g.co/datasetsearch">Dataset Search service</a> relies on structured description in web pages about datasets based on both
            <a href="https://developers.google.com/search/docs/data-types/dataset">schema.org and DCAT</a>.
        </p>
        <p>
            Most general purpose web search services that pay attention to metadata at all rely primarily on schema.org, so the detailed relationship of DCAT to schema.org is of interest for data providers
            who wish their datasets and services to be exposed through those indexes.
        </p>
        <p>
            A <a href="https://www.w3.org/wiki/WebSchemas/Datasets">mapping between DCAT 2014 and schema.org</a> was discussed on the original proposal to extend schema.org for describing datasets and data catalogs.
            Partial mappings between DCAT 2014 [[VOCAB-DCAT-20140116]] and schema.org were provided earlier by the
            <a href="https://ec-jrc.github.io/dcat-ap-to-schema-org/">European Commission</a> and the <a href="https://www.w3.org/2015/spatial/wiki/ISO_19115_-_DCAT_-_Schema.org_mapping">Spatial Data on the Web Working Group</a>.
        </p>
        <p>
            A recommended mapping from the revised DCAT (this document) to schema.org is <a href="https://raw.githubusercontent.com/w3c/dxwg/gh-pages/dcat/rdf/dcat-schema.ttl">available in an RDF file</a>.
            This mapping is axiomatized using the standard predicates <code>rdfs:subClassOf</code>, <code>rdfs:subPropertyOf</code>, <code>owl:equivalentClass</code>, <code>owl:equivalentProperty</code>, and also using the
            annotation properties <code>schema:domainIncludes</code> and <code>schema:rangeIncludes</code> to match schema.org semantics. The mapping is summarized in the table below, considering the prefix <code>schema</code> as <code>http://schema.org/</code>.
        </p>
        <p class="issue" data-number="251">
            This alignment of DCAT with schema.org is provisional and non-normative. Feedback is invited in the <a href="https://github.com/w3c/dxwg/issues/251">issue tracker</a>.
        </p>

        <table>
            <thead>
            <tr>
                <th style="text-align: right">DCAT element</th>
                <th style="text-align: center">mapping property</th>
                <th>target element from schema.org</th>
            </tr>
            </thead>
            <tbody>
            <tr>
                <td style="text-align: right">dct:description</td>
                <td style="text-align: center"><code>owl:equivalentProperty</code></td>
                <td>schema:description</td>
            </tr>
            <tr>
                <td style="text-align: right">dct:format</td>
                <td style="text-align: center"><code>owl:equivalentProperty</code></td>
                <td>schema:encodingFormat</td>
            </tr>
            <tr>
                <td style="text-align: right">dct:identifier</td>
                <td style="text-align: center"><code>owl:equivalentProperty</code></td>
                <td>schema:identifier</td>
            </tr>
            <tr>
                <td style="text-align: right">dct:issued</td>
                <td style="text-align: center"><code>owl:equivalentProperty</code></td>
                <td>schema:datePublished</td>
            </tr>
            <tr>
                <td style="text-align: right">dct:language</td>
                <td style="text-align: center"><code>owl:equivalentProperty</code></td>
                <td>schema:inLanguage</td>
            </tr>
            <tr>
                <td style="text-align: right">dct:license</td>
                <td style="text-align: center"><code>owl:equivalentProperty</code></td>
                <td>schema:license</td>
            </tr>
            <tr>
                <td style="text-align: right">dct:modified</td>
                <td style="text-align: center"><code>owl:equivalentProperty</code></td>
                <td>schema:dateModified</td>
            </tr>
            <tr>
                <td style="text-align: right">dct:publisher</td>
                <td style="text-align: center"><code>owl:equivalentProperty</code></td>
                <td>schema:publisher</td>
            </tr>
            <tr>
                <td style="text-align: right">dct:spatial</td>
                <td style="text-align: center"><code>owl:equivalentProperty</code></td>
                <td>schema:spatialCoverage</td>
            </tr>
            <tr>
                <td style="text-align: right">dct:temporal</td>
                <td style="text-align: center"><code>owl:equivalentProperty</code></td>
                <td>schema:temporalCoverage</td>
            </tr>
            <tr>
                <td style="text-align: right">dct:title</td>
                <td style="text-align: center"><code>owl:equivalentProperty</code></td>
                <td>schema:name</td>
            </tr>
            <tr>
                <td style="text-align: right">dct:type</td>
                <td style="text-align: center"><code>owl:equivalentProperty</code></td>
                <td>schema:additionalType</td>
            </tr>
            <tr>
                <td style="text-align: right">dcat:Catalog</td>
                <td style="text-align: center"><code>owl:equivalentClass</code></td>
                <td>schema:DataCatalog</td>
            </tr>
            <tr>
                <td style="text-align: right" rowspan="2">dcat:DataService</td>
                <td style="text-align: center"><code>owl:equivalentClass</code></td>
                <td>schema:DataFeed</td>
            </tr>
            <tr>
                <td style="text-align: center" colspan="2">Unclear if a <code>DataFeed</code> is a data <strong>service</strong>, or a data <strong>collection</strong>. From a REST viewpoint there is no difference, but some commonly used APIs support additional queries, slices, etc which make the characterization of a service more efficient than listing the (potentially infinite) set of resources available from it. </td>
            </tr>
            <tr>
                <td style="text-align: right">dcat:Dataset</td>
                <td style="text-align: center"><code>owl:equivalentClass</code></td>
                <td>schema:Dataset</td>
            </tr>
            <tr>
                <td style="text-align: right">dcat:Distribution</td>
                <td style="text-align: center"><code>owl:equivalentClass</code></td>
                <td>schema:DataDownload</td>
            </tr>
            <tr>
                <td style="text-align: right">dcat:Resource</td>
                <td style="text-align: center"><code>rdfs:subClassOf</code></td>
                <td>schema:Thing</td>
            </tr>
            <tr>
                <td style="text-align: right" rowspan="3">dcat:accessURL</td>
                <td style="text-align: center"><code>rdfs:subPropertyOf</code></td>
                <td>schema:contentUrl</td>
            </tr>
            <tr>
                <td style="text-align: center"><code>schema:domainIncludes</code></td>
                <td>dcat:Distribution , schema:DataDownload</td>
            </tr>
            <tr>
                <td style="text-align: center"><code>schema:rangeIncludes</code></td>
                <td>rdfs:Resource , schema:URL</td>
            </tr>
            <tr>
                <td style="text-align: right" rowspan="3">dcat:byteSize</td>
                <td style="text-align: center"><code>rdfs:subPropertyOf</code></td>
                <td>schema:contentSize</td>
            </tr>
            <tr>
                <td style="text-align: center"><code>schema:domainIncludes</code></td>
                <td>dcat:Distribution , schema:DataDownload</td>
            </tr>
            <tr>
                <td style="text-align: center"><code>schema:rangeIncludes</code></td>
                <td>rdfs:Literal , schema:Text</td>
            </tr>
            <tr>
                <td style="text-align: right" rowspan="2">dcat:catalog</td>
                <td style="text-align: center"><code>schema:domainIncludes</code></td>
                <td>dcat:Catalog , schema:DataCatalog</td>
            </tr>
            <tr>
                <td style="text-align: center"><code>schema:rangeIncludes</code></td>
                <td>dcat:Catalog , schema:DataCatalog</td>
            </tr>
            <tr>
                <td style="text-align: right" rowspan="2">dcat:contactPoint</td>
                <td style="text-align: center"><code>owl:equivalentProperty</code></td>
                <td>schema:contactPoint</td>
            </tr>
            <tr>
                <td style="text-align: center"><code>schema:domainIncludes</code></td>
                <td>dcat:Resource , dcat:Dataset , dcat:DataService , schema:Dataset</td>
            </tr>
            <tr>
                <td style="text-align: right" rowspan="3">dcat:dataset</td>
                <td style="text-align: center"><code>owl:equivalentProperty</code></td>
                <td>schema:dataset</td>
            </tr>
            <tr>
                <td style="text-align: center"><code>schema:domainIncludes</code></td>
                <td>dcat:Catalog , schema:DataCatalog</td>
            </tr>
            <tr>
                <td style="text-align: center"><code>schema:rangeIncludes</code></td>
                <td>dcat:Dataset , schema:Dataset</td>
            </tr>
            <tr>
                <td style="text-align: right" rowspan="3">dcat:distribution</td>
                <td style="text-align: center"><code>owl:equivalentProperty</code></td>
                <td>schema:distribution</td>
            </tr>
            <tr>
                <td style="text-align: center"><code>schema:domainIncludes</code></td>
                <td>dcat:Dataset , schema:Dataset</td>
            </tr>
            <tr>
                <td style="text-align: center"><code>schema:rangeIncludes</code></td>
                <td>dcat:Distribution , schema:DataDownload</td>
            </tr>
            <tr>
                <td style="text-align: right" rowspan="3">dcat:downloadURL</td>
                <td style="text-align: center"><code>rdfs:subPropertyOf</code></td>
                <td>schema:contentUrl</td>
            </tr>
            <tr>
                <td style="text-align: center"><code>schema:domainIncludes</code></td>
                <td>dcat:Distribution , schema:DataDownload</td>
            </tr>
            <tr>
                <td style="text-align: center"><code>schema:rangeIncludes</code></td>
                <td>rdfs:Resource , schema:Thing</td>
            </tr>
            <tr>
                <td style="text-align: right" rowspan="4">dcat:keyword</td>
                <td style="text-align: center"><code>rdfs:subPropertyOf</code></td>
                <td>schema:keywords</td>
            </tr>
            <tr>
                <td style="text-align: center" colspan="2"><em>dcat:keyword is singular, schema:keywords is plural</em></td>
            </tr>
            <tr>
                <td style="text-align: center"><code>schema:domainIncludes</code></td>
                <td>dcat:Resource , dcat:Dataset , dcat:DataService , schema:Dataset</td>
            </tr>
            <tr>
                <td style="text-align: center"><code>schema:rangeIncludes</code></td>
                <td>rdfs:Literal , schema:Text</td>
            </tr>
            <tr>
                <td style="text-align: right" rowspan="3">dcat:landingPage</td>
                <td style="text-align: center"><code>rdfs:subPropertyOf</code></td>
                <td>schema:url</td>
            </tr>
            <tr>
                <td style="text-align: center"><code>schema:domainIncludes</code></td>
                <td>dcat:Resource , dcat:Dataset , dcat:DataService , schema:Dataset</td>
            </tr>
            <tr>
                <td style="text-align: center"><code>schema:rangeIncludes</code></td>
                <td>foaf:Document , schema:WebPage</td>
            </tr>
            <tr>
                <td style="text-align: right" rowspan="3">dcat:mediaType</td>
                <td style="text-align: center"><code>owl:equivalentProperty</code></td>
                <td>schema:encodingFormat</td>
            </tr>
            <tr>
                <td style="text-align: center"><code>schema:domainIncludes</code></td>
                <td>dcat:Distribution , schema:DataDownload</td>
            </tr>
            <tr>
                <td style="text-align: center"><code>schema:rangeIncludes</code></td>
                <td>dct:MediaTypeOrExtent , schema:Text , schema:url </td>
            </tr>
            <tr>
                <td style="text-align: right" rowspan="2">dcat:record</td>
                <td style="text-align: center"><code>schema:domainIncludes</code></td>
                <td>dcat:Catalog , schema:DataCatalog</td>
            </tr>
            <tr>
                <td style="text-align: center"><code>schema:rangeIncludes</code></td>
                <td>dcat:CatalogRecord</td>
            </tr>
            <tr>
                <td style="text-align: right" rowspan="2">dcat:service</td>
                <td style="text-align: center"><code>schema:domainIncludes</code></td>
                <td>dcat:Catalog , schema:DataCatalog</td>
            </tr>
            <tr>
                <td style="text-align: center"><code>schema:rangeIncludes</code></td>
                <td>dcat:DataService</td>
            </tr>
            <tr>
                <td style="text-align: right" rowspan="3">dcat:theme</td>
                <td style="text-align: center"><code>owl:equivalentProperty</code></td>
                <td>schema:about</td>
            </tr>
            <tr>
                <td style="text-align: center"><code>schema:domainIncludes</code></td>
                <td>dcat:Resource , dcat:Dataset , dcat:DataService , schema:Dataset</td>
            </tr>
            <tr>
                <td style="text-align: center"><code>schema:rangeIncludes</code></td>
                <td>skos:Concept , schema:Class</td>
            </tr>
            <tr>
                <td style="text-align: right" rowspan="2">dcat:themeTaxonomy</td>
                <td style="text-align: center"><code>schema:domainIncludes</code></td>
                <td>dcat:Catalog , schema:DataCatalog</td>
            </tr>
            <tr>
                <td style="text-align: center"><code>schema:rangeIncludes</code></td>
                <td>skos:ConceptScheme</td>
            </tr>
            <tr>
                <td style="text-align: right">foaf:Organization</td>
                <td style="text-align: center"><code>owl:equivalentClass</code></td>
                <td>schema:Organization</td>
            </tr>
            <tr>
                <td style="text-align: right">foaf:Person</td>
                <td style="text-align: center"><code>owl:equivalentClass</code></td>
                <td>schema:Person</td>
            </tr>
            <tr>
                <td style="text-align: right">foaf:homepage</td>
                <td style="text-align: center"><code>owl:equivalentProperty</code></td>
                <td>schema:url</td>
            </tr>
            <tr>
                <td style="text-align: right">foaf:mbox</td>
                <td style="text-align: center"><code>owl:equivalentProperty</code></td>
                <td>schema:email</td>
            </tr>
            <!--
            <tr>
            <td colspan="3"><em>... and potentially of interest to be mixed-in for descriptions of scientific data</em></td>
            </tr>
            <tr>
            <td style="text-align: right">sosa:hasFeatureOfInterest</td>
            <td style="text-align: center"><code>rdfs:subPropertyOf</code></td>
            <td>schema:object</td>
            </tr>
            <tr>
            <td style="text-align: right">sosa:hasResult</td>
            <td style="text-align: center"><code>rdfs:subPropertyOf</code></td>
            <td>schema:result</td>
            </tr>
            <tr>
            <td style="text-align: right">sosa:madeByActuator</td>
            <td style="text-align: center"><code>rdfs:subPropertyOf</code></td>
            <td>schema:instrument</td>
            </tr>
            <tr>
            <td style="text-align: right">sosa:madeBySampler</td>
            <td style="text-align: center"><code>rdfs:subPropertyOf</code></td>
            <td>schema:instrument</td>
            </tr>
            <tr>
            <td style="text-align: right">sosa:madeBySensor</td>
            <td style="text-align: center"><code>rdfs:subPropertyOf</code></td>
            <td>schema:instrument</td>
            </tr>
            <tr>
            <td style="text-align: right">sosa:observedProperty</td>
            <td style="text-align: center"><code>owl:equivalentProperty</code></td>
            <td>schema:variableMeasured</td>
            </tr>
            <tr>
            <td style="text-align: right">sosa:phenomenonTime</td>
            <td style="text-align: center"><code>rdfs:subPropertyOf</code></td>
            <td>schema:temporalCoverage</td>
            </tr>
            <tr>
            <td style="text-align: right">sosa:resultTime</td>
            <td style="text-align: center"><code>rdfs:subPropertyOf</code></td>
            <td>schema:endTime</td>
            </tr>
            <tr>
            <td style="text-align: right">sosa:usedProcedure</td>
            <td style="text-align: center"><code>dcat:hasSubProperty</code></td>
            <td>schema:measurementTechnique</td>
            </tr>
            -->
            </tbody>
        </table>

    </section>


    <section id="dcat-prov-o" class="informative">
        <h3>PROV-O</h3>
        <p class="issue" data-number="128">
            An alignment of DCAT with PROV-O [[PROV-O]] is being prepared. A <a href="https://raw.githubusercontent.com/w3c/dxwg/gh-pages/dcat/rdf/dcat-prov.ttl">provisional version</a> is available.
        </p>

    </section>

    <section id="dcat-dats" class="informative">
        <h3>DATS</h3>
        <p class="issue" data-number="149">
            An alignment of DCAT with DATS [[DATS]] is being considered.
        </p>

    </section>

    <section id="dcat-hcls" class="informative">
        <h3>HCLS</h3>
        <p class="issue" data-number="150">
            An alignment of DCAT with HCLS [[HCLS-Dataset]] is being prepared.
        </p>

    </section>

    <section id="dcat-iso-19115" class="informative">
        <h3>ISO 19115</h3>
        <p class="issue" data-number="151">
            An alignment of DCAT with ISO 19115 [[ISO-19115-1]] is being prepared.
        </p>

    </section>

    <section id="dcat-datacite" class="informative">
        <h3>Datacite</h3>
        <p class="issue" data-number="152">
            An alignment of DCAT with Datacite metadata schema [[DataCite]] is being prepared.
        </p>

    </section>

    <section id="dcat-ddi" class="informative">
        <h3>DDI</h3>
        <p class="issue" data-number="164">
            An alignment of DCAT with DDI [[DDI]] is being prepared.
        </p>

    </section>

</section>

<section id="profiles">

    <h2>DCAT Profiles</h2>
    <p class="issue" data-number="72">
        DCAT provides a generic metadata vocabulary for cataloguing datasets.
        Profiles of DCAT are required for specific applications and disciplines.
        Providing a model and formalization for profiles is planned to be an important part of the Dataset eXchange Working Group (DXWG).
        Also see <a href="https://github.com/w3c/dxwg/issues/73">Issue #73</a>, <a href="https://github.com/w3c/dxwg/issues/74">Issue #74</a>, <a href="https://github.com/w3c/dxwg/issues/75">Issue #75</a>.
    </p>

    <p class="note">
        See the <a href="https://w3c.github.io/dxwg/profiles/">Profile Guidance</a> working document and wiki page on <a href="https://github.com/w3c/dxwg/wiki/Application-profiles">Application Profiles</a> for more discussion.
    </p>

</section>

<section id="security_and_privacy">
    <h2>Security and Privacy</h2>
    <p class="issue" data-number="460">
        This section will describe security and privacy considerations relevant to the DCAT revision.
    </p>
</section>

<section id="other-w3c-recommendations">

    <h2>Relation to other W3C Recommendations</h2>

    <p class="issue" data-number="254">
        DCAT should be aligned with other recent Linked Data based Recommendations.
    </p>

    <section id="ldp">
        <h3>Linked Data Platform (LDP)</h3>

        <p>
            DCAT provides a data model for representation of metadata about datasets in the form of Linked Data, but it does not specify how this metadata can be accessed or modified.
            The DCAT compatible metadata can be viewed as collections of Catalog Records, Datasets and Data Services contained in a Catalog, and a collection of Distributions contained in a Dataset.
            The Linked Data Platform [[LDP]] specification deals with access to and modification of Linked Data Platform Containers (LDPCs).
            This section provides guidance on how to represent DCAT metadata as LDP Containers, which supports namely the implementation of <a href="https://solid.mit.edu/" title="Solid">Solid</a> based DCAT catalogs.
        </p>

        <p>
            First, we will present an example of a LDPC for datasets in a catalog.
            There is one catalog with one dataset.
            The dataset is contained in the <code>&lt;/datasets/&gt;</code> LDP Direct Container.
            To ensure the LDPC discovery, we connect it to the Catalog using the <code>dcat:datasets</code> predicate.
        </p>
        <div class="example">
            <div class="example-title marker">
                <span>Example 1</span>
            </div>
            <pre class="nohighlight turtle" aria-busy="false" aria-live="polite">
@prefix dcat: &lt;http://www.w3.org/ns/dcat#&gt; .
@prefix ldp:  &lt;http://www.w3.org/ns/ldp#&gt; .

@base &lt;https://example.org/resource/catalog&gt; .

&lt;&gt; a dcat:Catalog ;
	dcat:datasets &lt;/datasets/&gt; ;
	dcat:dataset &lt;/datasets/001&gt; .

&lt;/datasets/&gt; a ldp:Container, ldp:DirectContainer ;
	ldp:membershipResource &lt;&gt; ;
	ldp:hasMemberRelation dcat:dataset ;
	ldp:contains &lt;/datasets/001&gt; .

&lt;/datasets/001&gt; a dcat:Dataset .</pre>
        </div>

        <p>
            In the second example, we add LDPCs <code>&lt;/records/&gt;</code> for Catalog Records and <code>&lt;/services/&gt;</code> for Data Services, discoverable using <code>dcat:records</code> and <code>dcat:services</code> predicates from the Catalog:
        </p>
        <div class="example">
            <div class="example-title marker">
                <span>Example 2</span>
            </div>
            <pre class="nohighlight turtle" aria-busy="false" aria-live="polite">
@prefix dcat: &lt;http://www.w3.org/ns/dcat#&gt; .
@prefix ldp:  &lt;http://www.w3.org/ns/ldp#&gt; .

@base &lt;https://example.org/resource/catalog&gt; .

&lt;&gt; a dcat:Catalog ;
	dcat:records &lt;/records/&gt; ;
	dcat:datasets &lt;/datasets/&gt; ;
	dcat:services &lt;/services/&gt; ;
	dcat:dataset &lt;/datasets/001&gt; .

&lt;/records/&gt; a ldp:Container, ldp:DirectContainer ;
	ldp:membershipResource &lt;&gt; ;
	ldp:hasMemberRelation dcat:record ;
	ldp:contains &lt;/records/001&gt; .

&lt;/datasets/&gt; a ldp:Container, ldp:DirectContainer ;
	ldp:membershipResource &lt;&gt; ;
	ldp:hasMemberRelation dcat:dataset ;
	ldp:contains &lt;/datasets/001&gt; .

&lt;/services/&gt; a ldp:Container, ldp:DirectContainer ;
	ldp:membershipResource &lt;&gt; ;
	ldp:hasMemberRelation dcat:service ;
	ldp:contains &lt;/services/001&gt; .

&lt;/records/001&gt; a dcat:CatalogRecord ;
	foaf:primaryTopic &lt;/datasets/001&gt; .

&lt;/datasets/001&gt; a dcat:Dataset ;

&lt;/services/001&gt; a dcat:DataService .</pre>
        </div>
        <p>
            Each dataset has its own LDPC for its distributions.
            In the third example, we show the LDPC <code>&lt;/datasets/001/distributions/&gt;</code> for distributions of a single dataset, <code>&lt;/datasets/001&gt;</code>, discoverable through the <code>dcat:distributions</code> predicate.
        </p>
        <div class="example">
            <div class="example-title marker">
                <span>Example 3</span>
            </div>
            <pre class="nohighlight turtle" aria-busy="false" aria-live="polite">
@prefix dcat: &lt;http://www.w3.org/ns/dcat#&gt; .
@prefix ldp:  &lt;http://www.w3.org/ns/ldp#&gt; .

@base &lt;https://example.org/resource/catalog&gt; .

&lt;/datasets/001&gt; a dcat:Dataset ;
	dcat:distributions &lt;/datasets/001/distributions/&gt; ;
	dcat:distribution &lt;/datasets/001/distributions/001&gt; .

&lt;/datasets/001/distributions/&gt; a ldp:Container, ldp:DirectContainer ;
	ldp:membershipResource &lt;/datasets/001&gt; ;
	ldp:hasMemberRelation dcat:distribution ;
	ldp:contains &lt;/datasets/001/distributions/001&gt; .

&lt;/datasets/001/distributions/001&gt; a dcat:Distribution .</pre>
        </div>

        <p class="note">For catalogs with many datasets, catalog records, data services or distributions,
            the Linked Data Platform Paging mechanism [[LDP-Paging]] <em title="SHOULD" class="rfc2119">SHOULD</em> be used to provide access to them.</p>

        <p>
            In the next sections we formally define the additional properties used for discovery of LDP containers.
        </p>

        <section id="Property:catalog_datasets">
            <h4>Property: datasets</h4>

            <table class="definition">
                <thead><tr><th>RDF Property:</th><th><a href="http://www.w3.org/ns/dcat#datasets">dcat:datasets</a></th></tr></thead>
                <tbody>
                <tr><td class="prop">Definition:</td><td>Connects a catalog to the LDP container of its datasets.</td></tr>
                <tr><td class="prop">Domain:</td><td><a href="http://www.w3.org/ns/dcat#Catalog">dcat:Catalog</a></td></tr>
                <tr><td class="prop">Range:</td><td><a href="http://www.w3.org/ns/ldp#DirectContainer">ldp:DirectContainer</a></td></tr>
                </tbody>
            </table>
        </section>

        <section id="Property:catalog_records">
            <h4>Property: catalog records</h4>

            <table class="definition">
                <thead><tr><th>RDF Property:</th><th><a href="http://www.w3.org/ns/dcat#records">dcat:records</a></th></tr></thead>
                <tbody>
                <tr><td class="prop">Definition:</td><td>Connects a catalog to the LDP container of its catalog records.</td></tr>
                <tr><td class="prop">Domain:</td><td><a href="http://www.w3.org/ns/dcat#Catalog">dcat:Catalog</a></td></tr>
                <tr><td class="prop">Range:</td><td><a href="http://www.w3.org/ns/ldp#DirectContainer">ldp:DirectContainer</a></td></tr>
                </tbody>
            </table>
        </section>

        <section id="Property:catalog_services">
            <h4>Property: data services</h4>

            <table class="definition">
                <thead><tr><th>RDF Property:</th><th><a href="http://www.w3.org/ns/dcat#services">dcat:services</a></th></tr></thead>
                <tbody>
                <tr><td class="prop">Definition:</td><td>Connects a catalog to the LDP container of its data services.</td></tr>
                <tr><td class="prop">Domain:</td><td><a href="http://www.w3.org/ns/dcat#Catalog">dcat:Catalog</a></td></tr>
                <tr><td class="prop">Range:</td><td><a href="http://www.w3.org/ns/ldp#DirectContainer">ldp:DirectContainer</a></td></tr>
                </tbody>
            </table>
        </section>

        <section id="Property:dataset_distributions">
            <h4>Property: distributions</h4>

            <table class="definition">
                <thead><tr><th>RDF Property:</th><th><a href="http://www.w3.org/ns/dcat#distributions">dcat:distributions</a></th></tr></thead>
                <tbody>
                <tr><td class="prop">Definition:</td><td>Connects a dataset to the LDP container of its distributions.</td></tr>
                <tr><td class="prop">Domain:</td><td><a href="http://www.w3.org/ns/dcat#Dataset">dcat:Dataset</a></td></tr>
                <tr><td class="prop">Range:</td><td><a href="http://www.w3.org/ns/ldp#DirectContainer">ldp:DirectContainer</a></td></tr>
                </tbody>
            </table>
        </section>

    </section>

    <section id="ldn">
        <h3>Linked Data Notifications (LDN)</h3>

        <p>
            Linked Data Notifications (LDN) [[LDN]] can be used with DCAT e.g. for feedback collection.
            Any resource can have an LDN Inbox.
            In the following example we show a dataset <code>&lt;/datasets/001&gt;</code> as an LDN Target with an LDN Inbox.
        </p>
        <div class="example">
            <div class="example-title marker">
                <span>Example 4</span>
            </div>
            <pre class="nohighlight turtle" aria-busy="false" aria-live="polite">
@prefix dcat: &lt;http://www.w3.org/ns/dcat#&gt; .
@prefix ldp:  &lt;http://www.w3.org/ns/ldp#&gt; .

@base &lt;https://example.org/resource/catalog&gt; .

&lt;/datasets/001&gt; a dcat:Dataset ;
	ldp:inbox &lt;/datasets/001/inbox/&gt; .

&lt;/datasets/001/inbox/&gt; ldp:contains &lt;/datasets/001/inbox/001&gt; .</pre>
        </div>
    </section>

</section>

<section class="appendix" id="issue-summary">
    <!-- A list of issues will magically appear here -->
</section>

<p class="note">
    All currently open issues are available at: <a href="https://github.com/w3c/dxwg/labels/dcat">https://github.com/w3c/dxwg/labels/dcat</a>
</p>

<section class="appendix" id="acknowledgments">
    <h2>Acknowledgments</h2>
    <p>The editors gratefully acknowledge the contributions made to this document by <a href="https://www.w3.org/2000/09/dbwg/details?group=99375&public=1">all members of the working group</a><!--; especially, ...-->.</p>
    <!--
          <p>The editors would also like to thank comments received from ...</p>
    -->
    <p>The editors also gratefully acknowledge the chairs of this Working Group: Karen Coyle, Caroline Burle and Peter Winstanley &mdash; and staff contacts Phil Archer and Dave Raggett.</p>
</section>

<section class="appendix" id="collection-of-examples">
  <h2>Examples</h2>
  <section id="bag-of-files">
      <h3>Loosely structured catalog</h3>

      <p class="note">
          The background to this example is discussed in 	<a href="https://github.com/w3c/dxwg/issues/253">Best practice for a loosely-structured catalog</a>
      </p>

      <p>
          In many legacy catalogues and repositories (e.g. CKAN), ‘datasets’ are ‘just a bag of files’. There is no distinction made between part/whole, distribution (representation), and other kinds of relationship (e.g. documentation, schema, supporting documents) from the dataset to each of the files.
      </p>
      <p>
          If the nature of the relationships between a dataset and component resources in a catalogue, repository, or elsewhere are not known, <b>dct:relation</b> can be used:
      </p>
      <div class="example">
<pre class="nohighlight turtle" aria-busy="false" aria-live="polite">
:d33937
dct:description "A set of RDF graphs representing the International [Chrono]stratigraphic Chart, ..." ;
dct:identifier "https://doi.org/10.25919/5b4d2b83cbf2d"^^xsd:anyURI ;
dct:creator &lt;https://orcid.org/0000-0002-3884-3420&gt;;
dct:relation &lt;https://vocabs.ands.org.au/viewById/196&gt; ;
dct:relation :ChronostratChart2017-02.pdf  ;
dct:relation :ChronostratChart2017-02.jpg ;
dct:relation :timescale.zip ;
dct:relation :isc2017.jsonld ;
dct:relation :isc2017.nt ;
dct:relation :isc2017.rdf ;
dct:relation :isc2017.ttl ;
.
</pre></div>
      <p>
          If it is clear that any of these related resources is a proper <i>representation</i> of the dataset, dcat:distribution should be used.
      </p>
      <div class="example">
<pre class="nohighlight turtle" aria-busy="false" aria-live="polite">
:d33937
rdf:type dcat:Dataset ;
dct:description "A set of RDF graphs representing the International [Chrono]stratigraphic Chart, ..." ;
dct:identifier "https://doi.org/10.25919/5b4d2b83cbf2d"^^xsd:anyURI ;
dct:relation &lt;https://vocabs.ands.org.au/viewById/196&gt; ;
dct:relation :ChronostratChart2017-02.pdf  ;
dct:relation :ChronostratChart2017-02.jpg ;
dct:relation :timescale.zip ;
dcat:distribution :d33937-jsonld ;
dcat:distribution :d33937-nt ;
dcat:distribution :d33937-rdf ;
dcat:distribution :d33937-ttl ;
.
:d33937-jsonld  rdf:type dcat:Distribution ;
dcat:downloadURL :isc2017.jsonld ;
dcat:byteSize "698039"^^xsd:decimal ;
dcat:mediaType &lt;https://www.iana.org/assignments/media-types/application/ld+json&gt; ;
.
:d33937-nt  rdf:type dcat:Distribution ;
dcat:downloadURL :isc2017.nt ;
dcat:byteSize "2047874"^^xsd:decimal ;
dcat:mediaType &lt;https://www.iana.org/assignments/media-types/application/n-triples&gt; ;
.
:d33937-rdf  rdf:type dcat:Distribution ;
dcat:downloadURL :isc2017.rdf ;
dcat:byteSize "1600569"^^xsd:decimal ;
dcat:mediaType &lt;https://www.iana.org/assignments/media-types/application/rdf+xml&gt; ;
.
:d33937-ttl  rdf:type dcat:Distribution ;
dcat:downloadURL :isc2017.ttl ;
dcat:byteSize "531703"^^xsd:decimal ;
dcat:mediaType &lt;https://www.iana.org/assignments/media-types/text/turtle&gt; ;
.
</pre></div>
      <p>
          This example is available from the <a href="https://github.com/w3c/dxwg/tree/gh-pages/dcat/examples">DXWG code repository</a> at <a href="https://raw.githubusercontent.com/w3c/dxwg/gh-pages/dcat/examples/csiro-dap-examples.ttl">csiro-dap-examples.ttl</a>
      </p>
  </section>

  <section id="examples-dataset-provenance">
      <h3>Dataset provenance</h3>
      <p>
          The provenance or business context of a dataset can be described using elements from the W3C Provenance Ontology [[PROV-O]].
      </p>
      <p>
          For example, a simple link from a dataset description to the project that generated the dataset can be formalized as follows (other details elided for clarity):
      </p>
      <div class="example">
<pre class="nohighlight turtle" aria-busy="false" aria-live="polite">
dap:atnf-P366-2003SEPT
rdf:type dcat:Dataset ;
dct:bibliographicCitation "Burgay, M; McLaughlin, M; Kramer, M; Lyne, A; Joshi, B; Pearce, G; D'Amico, N; Possenti, A; Manchester, R; Camilo, F (2017): Parkes observations for project P366 semester 2003SEPT. v1. CSIRO. Data Collection. https://doi.org/10.4225/08/598dc08d07bb7" ;
dct:title "Parkes observations for project P366 semester 2003SEPT" ;
dcat:landingPage &lt;https://data.csiro.au/dap/landingpage?pid=csiro:P366-2003SEPT&gt; ;
prov:wasGeneratedBy dap:P366 ;
.

dap:P366
rdf:type prov:Activity ;
dct:type "Observation" ;
prov:startedAtTime "2000-11-01"^^xsd:date ;
prov:used dap:Parkes-radio-telescope ;
prov:wasInformedBy dap:ATNF ;
rdfs:label "P366 - Parkes multibeam high-latitude pulsar survey" ;
rdfs:seeAlso &lt;https://doi.org/10.1111/j.1365-2966.2006.10100.x&gt; ;
.
</pre></div>
      <p>
          This example is available from the <a href="https://github.com/w3c/dxwg/tree/gh-pages/dcat/examples">DXWG code repository</a> at <a href="https://raw.githubusercontent.com/w3c/dxwg/gh-pages/dcat/examples/csiro-dap-examples.ttl">csiro-dap-examples.ttl</a>
      </p>
      <p>
          Several properties capture provenance information, including within the citation and title, but the primary link to a formal description of the project is through <a href="#Property:dataset_wasgeneratedby">prov:wasGeneratedBy</a>.
          A terse description of the project is shown as a <a href="http://www.w3.org/ns/prov#Activity">prov:Activity</a>, though this would not necessarily be part of the same catalog.
          Note that as the project is ongoing, the activity has no end date.
      </p>
      <p>
          Further provenance information might be provided using the other <i>starting point properties</i> from PROV, in particular <a href="http://www.w3.org/TR/prov-o/#wasAttributedTo">prov:wasAttributedTo</a> (to link to an agent associated with the dataset production) and <a href="http://www.w3.org/TR/prov-o/#wasDerivedFrom">prov:wasDerivedFrom</a> (to link to a predecessor dataset). Both of these complement Dublin Core properties already used in DCAT, as follows:
      </p>
      <ul>
          <li>
              <b>prov:wasAttributedTo</b> provides a general link to all kinds of associated agents, such as project sponsors, managers, dataset owners, etc which are not correctly characterized using <b>dct:creator</b>, <b>dct:contributor</b> or <b>dct:publisher</b>.
          </li>
          <li>
              <b>prov:wasDerivedFrom</b> supports a more specific relationship to an input or predecessor dataset compared with <b>dct:source</b>, which is not necessarily a previous dataset.
          </li>
      </ul>
      <p>
          For a more detailed discussion of the use of PROV for dataset provenance, including recommendations on the use of <i>qualified properties</i>, see the chapter on <a href="#prov-patterns">Provenance Patterns</a> below.
      </p>

  </section>

  <section id="data-service-examples">
      <h3>Data services</h3>
      <p>
          Data services may be described using DCAT.
          The values of the classifiers <b>dct:type</b>, <b>dct:conformsTo</b>, and <b>dcat:endpointDescription</b> provide progressively more detail about a service, whose actual endpoint is given by the <b>dcat:endpointURL</b>.
      </p>
      <p>
          The first example describes a data catalog hosted by the European Environment Agency.
          This is classified as a <a href="#Class:Discovery_Service">dcat:DiscoveryService</a> and also has the <code>dct:type</code> set to <a href="http://inspire.ec.europa.eu/metadata-codelist/SpatialDataServiceType/discovery">discovery</a> from the <a href="http://inspire.ec.europa.eu/metadata-codelist/SpatialDataServiceType/">INSPIRE classification of spatial data service types</a>.
      </p>
      <p>
          This example is available from the <a href="https://github.com/w3c/dxwg/tree/gh-pages/dcat/examples">DXWG code repository</a> at <a href="https://raw.githubusercontent.com/w3c/dxwg/gh-pages/dcat/examples/eea-csw.ttl">eea-csw.ttl</a>
      </p>
      <div class="example">
<pre class="nohighlight turtle" aria-busy="false" aria-live="polite">
a:EEA-CSW-Endpoint
rdf:type dcat:DiscoveryService ;
dc:subject "infoCatalogueService"@en ;
dct:accessRights &lt;http://publications.europa.eu/resource/authority/access-right/PUBLIC&gt; ;
dct:conformsTo &lt;http://www.opengis.net/def/serviceType/ogc/csw&gt; ;
dct:description "The EEA public catalogue of spatial datasets references the spatial datasets used by the European Environment Agency as well as the spatial datasets produced by or for the EEA. In the latter case, when datasets are publicly available, a link to the location from where they can be downloaded is included in the dataset's metadata. The catalogue has been initially populated with the most important spatial datasets already available on the data&maps section of the EEA website and is currently updated with any newly published spatial dataset."@en ;
dct:identifier "eea-sdi-public-catalogue" ;
dct:issued "2012-01-01"^^xsd:date ;
dct:license &lt;https://creativecommons.org/licenses/by/2.5/dk/&gt; ;
dct:spatial [
    rdf:type dct:Location ;
    locn:geometry "&lt;gml:Envelope srsName=\"http://www.opengis.net/def/crs/OGC/1.3/CRS84\"&gt;&lt;gml:lowerCorner&gt;-180 -90&lt;/gml:lowerCorner&gt;&lt;gml:upperCorner&gt;180 90&lt;/gml:upperCorner&gt;&lt;/gml:Envelope&gt;"^^gsp:gmlLiteral ;
    locn:geometry "POLYGON((-180 90,180 90,180 -90,-180 -90,-180 90))"^^gsp:wktLiteral ;
  ] ;
dct:title "European Environment Agency's public catalogue of spatial datasets."@en ;
dct:type &lt;http://inspire.ec.europa.eu/metadata-codelist/ResourceType/service&gt; ;
dct:type &lt;http://inspire.ec.europa.eu/metadata-codelist/SpatialDataServiceType/discovery&gt; ;
dcat:contactPoint a:EEA ;
dcat:endpointDescription &lt;https://sdi.eea.europa.eu/catalogue/srv/eng/csw?service=CSW&request=GetCapabilities&gt; ;
dcat:endpointURL &lt;http://sdi.eea.europa.eu/catalogue/srv/eng/csw&gt; ;
.
</pre></div>
      <p>
          The next example shows a dataset hosted by Geoscience Australia, which is available from three distinct services, as indicated by the value of the <a href="#Property:datadistributionservice_servesdataset">dcat:servesDataset</a> property of each of the service descriptions.
          These are classified as a <a href="#Class:Data_Distribution_Service">dcat:DataDistributionService</a> and also have the <code>dct:type</code> set to <a href="http://inspire.ec.europa.eu/metadata-codelist/SpatialDataServiceType/download">download</a> and <a href="http://inspire.ec.europa.eu/metadata-codelist/SpatialDataServiceType/view">view</a> from the <a href="http://inspire.ec.europa.eu/metadata-codelist/SpatialDataServiceType/">INSPIRE classification of spatial data service types</a>.
      </p>
      <p>
          This example is available from the <a href="https://github.com/w3c/dxwg/tree/gh-pages/dcat/examples">DXWG code repository</a> at <a href="https://raw.githubusercontent.com/w3c/dxwg/gh-pages/dcat/examples/ga-courts.ttl">ga-courts.ttl</a>
      </p>
      <div class="example">
<pre class="nohighlight turtle" aria-busy="false" aria-live="polite">
ga-courts:jc
rdf:type dcat:Dataset ;
dct:description "The dataset contains spatial locations, in point format, of the Australian High Court, Australian Federal Courts and the Australian Magistrates Courts." ;
dct:spatial [
    rdf:type dct:Location ;
    locn:geometry "&lt;gml:Envelope srsName=\"http://www.opengis.net/def/crs/EPSG/0/4283\"&gt;&lt;gml:lowerCorner&gt;115.864566 -42.885989&lt;/gml:lowerCorner&gt;&lt;gml:upperCorner&gt;153.276835 -12.460578&lt;/gml:upperCorner&gt;&lt;/gml:Envelope&gt;"^^gsp:gmlLiteral ;
  ] ;
dct:title "Judicial Courts" ;
dct:type &lt;http://purl.org/dc/dcmitype/Dataset&gt; ;
dcat:landingPage &lt;https://ecat.ga.gov.au/geonetwork/srv/eng/catalog.search#/metadata/cc365600-294a-597d-e044-00144fdd4fa6&gt; ;
.
ga-courts:jc-esri
rdf:type dcat:DataDistributionService ;
dct:conformsTo &lt;https://developers.arcgis.com/rest/&gt; ;
dct:description "This web service provides access to the National Judicial Courts dataset and presents the spatial locations of all the known Australian High Courts, Australian Federal Courts and the Australian Federal Circuit Courts located within Australia, all complemented with feature attribution." ;
dct:identifier "2b8540c8-4a43-144d-e053-12a3070a3ff7" ;
dct:title "National Judicial Courts MapServer" ;
dct:type &lt;http://purl.org/dc/dcmitype/Service&gt; ;
dct:type &lt;https://inspire.ec.europa.eu/metadata-codelist/SpatialDataServiceType/download&gt; ;
dct:type &lt;https://inspire.ec.europa.eu/metadata-codelist/SpatialDataServiceType/view&gt; ;
dcat:endpointURL &lt;http://services.ga.gov.au/gis/rest/services/Judicial_Courts/MapServer&gt; ;
dcat:landingPage &lt;https://ecat.ga.gov.au/geonetwork/srv/eng/catalog.search#/metadata/2b8540c8-4a43-144d-e053-12a3070a3ff7&gt; ;
dcat:servesDataset ga-courts:jc ;
.
ga-courts:jc-wfs
rdf:type dcat:DataDistributionService ;
dct:conformsTo &lt;http://www.opengis.net/def/serviceType/ogc/wfs/2.0.0&gt; ;
dct:conformsTo &lt;http://www.opengis.net/def/serviceType/ogc/wfs/1.1.0&gt; ;
dct:conformsTo &lt;http://www.opengis.net/def/serviceType/ogc/wfs/1.0.0&gt; ;
dct:description "This web service provides access to the National Judicial Courts dataset and presents the spatial locations of all the known Australian High Courts, Australian Federal Courts and the Australian Federal Circuit Courts located within Australia, all complemented with feature attribution." ;
dct:identifier "2b8540c8-4a42-144d-e053-12a3070a3ff7" ;
dct:title "National Judicial Courts WFS" ;
dct:type &lt;http://purl.org/dc/dcmitype/Service&gt; ;
dct:type &lt;https://inspire.ec.europa.eu/metadata-codelist/SpatialDataServiceType/download&gt; ;
dcat:endpointDescription &lt;http://services.ga.gov.au/gis/services/Judicial_Courts/MapServer/WFSServer?request=GetCapabilities&service=WFS&gt; ;
dcat:endpointURL &lt;http://services.ga.gov.au/gis/services/Judicial_Courts/MapServer/WFSServer&gt; ;
dcat:landingPage &lt;https://ecat.ga.gov.au/geonetwork/srv/eng/catalog.search#/metadata/2b8540c8-4a42-144d-e053-12a3070a3ff7&gt; ;
dcat:servesDataset ga-courts:jc ;
.
ga-courts:jc-wms
rdf:type dcat:DataDistributionService ;
dct:conformsTo &lt;http://www.opengis.net/def/serviceType/ogc/wms/1.3&gt; ;
dct:description "This web service provides access to the National Judicial Courts dataset and presents the spatial locations of all the known Australian High Courts, Australian Federal Courts and the Australian Federal Circuit Courts located within Australia, all complemented with feature attribution." ;
dct:identifier "2b8540c8-4a41-144d-e053-12a3070a3ff7" ;
dct:title "National Judicial Courts WMS" ;
dct:type &lt;http://purl.org/dc/dcmitype/Service&gt; ;
dct:type &lt;https://inspire.ec.europa.eu/metadata-codelist/SpatialDataServiceType/view&gt; ;
dcat:endpointDescription &lt;http://services.ga.gov.au/gis/services/Judicial_Courts/MapServer/WMSServer?request=GetCapabilities&service=WMS&gt; ;
dcat:endpointURL &lt;http://services.ga.gov.au/gis/services/Judicial_Courts/MapServer/WMSServer&gt; ;
dcat:landingPage &lt;https://ecat.ga.gov.au/geonetwork/srv/eng/catalog.search#/metadata/2b8540c8-4a41-144d-e053-12a3070a3ff7&gt; ;
dcat:servesDataset ga-courts:jc ;
.
</pre></div>

  </section>

  <section id="more-examples-needed">
      <h3>More examples needed</h3>

      <p class="note">
          This section will contain more examples on the use of DCAT.
      </p>

  </section>

</section>



<section class="appendix" id="changes">
    <h2>Change history</h2>
    <p>A full change-log is available on <a href="https://github.com/w3c/dxwg/commits/gh-pages/dcat">GitHub</a></p>
    <section id="changes-since-20140116">
        <h3>Changes since the W3C Recommendation of 16 January 2014</h3>
        <p>The document has undergone the following changes since the W3C Recommendation of 16 January 2014 [[VOCAB-DCAT-20140116]]:</p>

        <ul>

            <li>
                <a href="#Property:dataset_creator">Property: dataset creator</a>: The property dct:creator is recommended for use in the context of a dataset to allow the entity responsible for generating the dataset to be recorded - see <a href="https://github.com/w3c/dxwg/issues/61">Issue #61</a>
            </li>


            <li>
                <a href="#Property:dataset_wasgeneratedby">Property: was generated by</a>: The property prov:wasGeneratedBy is recommended for use in the context of a dataset to allow the provenance or business context to be recorded - see <a href="https://github.com/w3c/dxwg/issues/71">Issue #71</a>
            </li>

            <li>
                <a href="#Property:resource_relation">Property: resource relation</a>: The property dct:relation is recommended for use in the context of a catalogued resource to capture general relationships, including the case where the package of resources associated with a catalogued item includes a mixture of representations, parts, documentation and other elements which are not strictly 'distributions' of a dataset - see <a href="https://github.com/w3c/dxwg/issues/253">Issue #253</a>.
            </li>


            <li>
                <a href="#Property:distribution_media_type">Property:media_type</a>: The range of dcat:mediaType has been tightened from dct:MediaTypeOrExtent to dct:MediaType - see <a href="https://github.com/w3c/dxwg/issues/127">Issue #127</a>.
            </li>

            <li>
                <a href="#Property:distribution_conformsto">Property: conforms to</a>: The property dct:conformsTo is recommended for use in the context of a dcat:Distribution to allow the model or schema used for the representation to be indicated as well as the serialization (which is indicated using dct:format and dcat:mediaType) - see <a href="https://github.com/w3c/dxwg/issues/55">Issue #55</a>.
            </li>

            <li>
                Errors in examples of <a href="#Property:distribution_media_type">dcat:mediaType</a> usage fixed - see <a href="https://github.com/w3c/dxwg/issues/170">Issue #170</a>.
            </li>

            <li>
                <a href="#quality-information">Quality information</a>: Recommendations for how to associate quality information to datasets using elements from the W3C DQV vocabulary [[VOCAB-DQV]] are provided. Since [[VOCAB-DQV]] is not a rec-track document, these are non-normative - see <a href="https://github.com/w3c/dxwg/issues/57">Issue #57</a> and <a href="https://github.com/w3c/dxwg/issues/58">Issue #58</a>.
            </li>

            <li>
                <a href="#Class:Resource">Class: Catalogued resource</a>: In DCAT 2014 [[VOCAB-DCAT-20140116]] the scope of a <a href="#Class:Catalog">dcat:Catalog</a> was limited to Datasets. This has been generalized, and properties common to all catalogued resources are now associated with a super-class dcat:Resource - see <a href="https://github.com/w3c/dxwg/issues/172">Issue #172</a> and <a href="https://github.com/w3c/dxwg/issues/116">Issue #116</a>. The wiki page on <a href="https://github.com/w3c/dxwg/wiki/Cataloguing-data-services">Cataloguing data services</a> describes some proposals related to this requirement.
            </li>

            <li>
                <a href="#Class:Data_Service">Class: Data service</a>: In DCAT 2014 [[VOCAB-DCAT-20140116]] the scope of a <a href="#Class:Catalog">dcat:Catalog</a> was limited to Datasets. The new class dcat:DataService has been added to support cataloguing various kinds of data services - see <a href="https://github.com/w3c/dxwg/issues/172">Issue #172</a>.
            </li>

            <li>
                <a href="#Class:Data_Distribution_Service">Class: Data distribution service</a>: In DCAT 2014 [[VOCAB-DCAT-20140116]] the scope of a <a href="#Class:Catalog">dcat:Catalog</a> was limited to Datasets. The new class dcat:DataDistributionService has been added to support cataloguing data distribution services - see <a href="https://github.com/w3c/dxwg/issues/172">Issue #172</a> and <a href="https://github.com/w3c/dxwg/issues/56">Issue #56</a>.
            </li>

            <li>
                <a href="#Class:Discovery_Service">Class: Discovery service</a>: In DCAT 2014 [[VOCAB-DCAT-20140116]] the scope of a <a href="#Class:Catalog">dcat:Catalog</a> was limited to Datasets. The new class dcat:DiscoveryService has been added to support cataloguing data discovery services - see <a href="https://github.com/w3c/dxwg/issues/172">Issue #172</a>.
            </li>

            <li><a href="#Class:Dataset">Class: Dataset</a>:
                In DCAT 2014 [[VOCAB-DCAT-20140116]] <a href="#Class:Dataset">dcat:Dataset</a> was a sub-class of <a href="http://purl.org/dc/dcmitype/Dataset">dctype:Dataset</a>, which is a term of the <a href="http://dublincore.org/documents/dcmi-terms/#section-7">DCMI Types vocabulary</a> [[DCTERMS]]. This relationship has been removed in the revised DCAT vocabulary - see <a href="https://github.com/w3c/dxwg/issues/98">Issue #98</a>.
            </li>

            <li>
                <a href="#Class:Distribution">Class: Distribution</a>
                : In DCAT 2014 [[VOCAB-DCAT-20140116]] the definition of a <a href="#Class:Distribution">dcat:Distribution</a> allowed a number of alternative interpretations. The definition has been rephrased to clarify that distributions are primarily <i>representations</i> of datasets. See <a href="https://github.com/w3c/dxwg/issues/172">Issue #52</a> and related use cases.
            </li>


            <li><a href="#Property:resource_theme">Property: theme/category</a>:
                In DCAT 2014 [[VOCAB-DCAT-20140116]] the domain of dcat:theme was dcat:Dataset,
                which limited use of this property in other contexts. The domain has been relaxed in this revision -
                see <a href="https://github.com/w3c/dxwg/issues/123">Issue #123</a>.
            </li>

            <li><a href="#Property:resource_type">Property: type/genre</a>:
                Added in DCAT revision - see <a href="https://github.com/w3c/dxwg/issues/64">Issue #64</a>, with examples of usage in overview section.
            </li>

            <li><a href="#Property:resource_keyword">Property: keyword/tag</a>:
                In DCAT 2014 [[VOCAB-DCAT-20140116]] the domain of dcat:keyword was dcat:Dataset,
                which limited use of this property in other contexts. The domain has been relaxed in this revision -
                see <a href="https://github.com/w3c/dxwg/issues/121">Issue #121</a>.
            </li>

            <li><a href="#Property:resource_contact_point">Property: contact point</a>:
                In DCAT 2014 [[VOCAB-DCAT-20140116]] the domain of dcat:contactPoint was dcat:Dataset,
                which limited use of this property in other contexts. The domain has been relaxed in this revision -
                see <a href="https://github.com/w3c/dxwg/issues/95">Issue #95</a>.
            </li>

            <li><a href="#Property:resource_landing_page">Property: landing page</a>:
                In DCAT 2014 [[VOCAB-DCAT-20140116]] the domain of dcat:landingPage was dcat:Dataset,
                which limited use of this property in other contexts. The domain has been relaxed in this revision -
                see <a href="https://github.com/w3c/dxwg/issues/122">Issue #122</a>.
            </li>

            <li><a href="http://vocab.org/vann/#usageNote">Property: vann:usageNote</a>:
                DCAT 2014 [[VOCAB-DCAT-20140116]] included documentation captured as text using <a href="http://vocab.org/vann/#usageNote">vann:usageNote</a> elements,
                which is a sub-property of rdfs:seeAlso - an owl:ObjectProperty that cannot have a Literal value.
                This revision of DCAT has fixed these issues and replaced the use of vann:usageNote with <a href="https://www.w3.org/TR/skos-primer/#secdocumentation">skos:scopeNote</a> -
                see <a href="https://github.com/w3c/dxwg/issues/233">Issue #233</a>.
            </li>

        </ul>

    </section>
</section>

</body>
</html>