### PR TITLE
Fixed wrong namespace prefix for dcat:bbox in §9.2

### DIFF
--- a/dcat/index.html
+++ b/dcat/index.html
@@ -3158,7 +3158,7 @@ ex:InternationalDOIFundation a foaf:Organization ;
 
       <aside class="note">
       <p>The following examples are built on the relevant ones included in [[?SDW-BP]] (in particular, <a data-cite="?SDW-BP#geometry-and-crs">&sect;&nbsp;<span class="secno">12.2.2 </span>Geometries and coordinate reference systems</a>).</p>
-      <p>In the examples, for properties <code>locn:geometry</code>, <code>dct:bbox</code>, and <code>dcat:centroid</code>, the geometry is always specified with WKT. As per [[GeoSPARQL]], when the CRS specification is omitted this implies that the default CRS is used - namely CRS84 (corresponding to WGS84, but with axis order longitude/latitude).</p>
+      <p>In the examples, for properties <code>locn:geometry</code>, <code>dcat:bbox</code>, and <code>dcat:centroid</code>, the geometry is always specified with WKT. As per [[GeoSPARQL]], when the CRS specification is omitted this implies that the default CRS is used - namely CRS84 (corresponding to WGS84, but with axis order longitude/latitude).</p>
       <p>For more details on coordinate reference systems and geometry encoding, we refer the reader to [[?SDW-BP]], and, in particular, to the following sections:</p>
       <ul>
         <li><a data-cite="?SDW-BP#CRS-background">&sect;&nbsp;<span class="secno">9 </span>Coordinate Reference Systems (CRS)</a></li>


### PR DESCRIPTION
Fixing https://github.com/w3c/dxwg/issues/1248.