### PR TITLE
Changing title and adding a new section for tracking changes since latest DCAT 2 rec

### DIFF
--- a/dcat/index.html
+++ b/dcat/index.html
@@ -4637,7 +4637,7 @@ ga-courts:jc-wms
     <p>A full change-log is available on <a href="https://github.com/w3c/dxwg/commits/gh-pages/dcat">GitHub</a></p>
     <section id="changes-since-20140116">
         <h3>Changes since the W3C Recommendation of 4 February 2020</h3>
-        <p>The document has undergone the following changes since the W3C Recommendation of 4 February 2020 [[?VOCAB-DCAT-2-20200204]]:</p>
+        <p>The document has undergone the following changes since the DCAT 2 W3C Recommendation of 4 February 2020 [[?VOCAB-DCAT-2-20200204]]:</p>
         <li>
         Section <a href="#dataset-versions"></a> was extended with draft guidelines to deal with version delta (<a href="https://github.com/w3c/dxwg/issues/#89">Issue #89</a>), version release date (<a href="https://github.com/w3c/dxwg/issues/#91">Issue #91</a>),  version identifier (<a href="https://github.com/w3c/dxwg/issues/#92">Issue #92</a>),  version compatibility (<a href="https://github.com/w3c/dxwg/issues/#1258">Issue #1258</a>) and resource status (<a href="https://github.com/w3c/dxwg/issues/#1238">Issue #1238</a>). 
         </li>

--- a/dcat/index.html
+++ b/dcat/index.html
@@ -4642,6 +4642,7 @@ ga-courts:jc-wms
         <li>
         Section <a href="#dataset-versions"></a> was extended with draft guidelines to deal with version delta (<a href="https://github.com/w3c/dxwg/issues/#89">Issue #89</a>), version release date (<a href="https://github.com/w3c/dxwg/issues/#91">Issue #91</a>),  version identifier (<a href="https://github.com/w3c/dxwg/issues/#92">Issue #92</a>),  version compatibility (<a href="https://github.com/w3c/dxwg/issues/#1258">Issue #1258</a>) and resource status (<a href="https://github.com/w3c/dxwg/issues/#1238">Issue #1238</a>). 
         </li>
+        </ul>
     </section>
     <section id="changes-since-20140116">
         <h3>Changes since the W3C Recommendation of 16 January 2014</h3>

--- a/dcat/index.html
+++ b/dcat/index.html
@@ -4644,7 +4644,7 @@ ga-courts:jc-wms
     </section>
     <section id="changes-since-20140116">
         <h3>Changes since the W3C Recommendation of 16 January 2014</h3>
-        <p>The document has undergone the following changes since the W3C Recommendation of 16 January 2014 [[?VOCAB-DCAT-20140116]]:</p>
+        <p>The document has undergone the following changes since the  DCAT 2014 W3C Recommendation of 16 January 2014 [[?VOCAB-DCAT-20140116]]:</p>
 
         <ul>
 

--- a/dcat/index.html
+++ b/dcat/index.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html lang="en" dir="ltr">
 <head>
-    <title>Data Catalog Vocabulary (DCAT) - Version 2</title>
+    <title>Data Catalog Vocabulary (DCAT) - Version 3</title>
     <meta content="text/html; charset=utf-8" http-equiv="content-type" />
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
     <script class="remove" src="https://www.w3.org/Tools/respec/respec-w3c" defer></script>

--- a/dcat/index.html
+++ b/dcat/index.html
@@ -13,9 +13,9 @@
 
 <!-- Disclaimer -->
 <aside class="note">
-    <p>DCAT 2 supersedes DCAT [[?VOCAB-DCAT-20140116]], but it does not make it obsolete. DCAT 2 maintains the DCAT namespace as its terms preserve backward compatibility with DCAT [[?VOCAB-DCAT-20140116]]. DCAT 2 relaxes constraints and adds new classes and properties, but these changes do not break the definition of previous terms.</p>
+    <p>DCAT 2 supersedes DCAT [[?VOCAB-DCAT-20140116]] (hereafter named DCAT 1), but it does not make it obsolete. DCAT 2 maintains the DCAT namespace as its terms preserve backward compatibility with DCAT [[?VOCAB-DCAT-20140116]]. DCAT 2 relaxes constraints and adds new classes and properties, but these changes do not break the definition of previous terms.</p>
     
-    <p>Any new implementation is expected to adopt DCAT 2, while the existing implementations do not need to upgrade to it, unless they want to use the new features. In particular, current DCAT deployments that do not overlap with the DCAT 2 new features (e.g., data services, time and space properties qualified relations, packaging) don't need to change anything to remain in conformance with DCAT 2.
+    <p>Any new implementation is expected to adopt DCAT 2, while the existing implementations do not need to upgrade to it, unless they want to use the new features. In particular, current DCAT 1 deployments that do not overlap with the DCAT 2 new features (e.g., data services, time and space properties qualified relations, packaging) don't need to change anything to remain in conformance with DCAT 2.
     </p>
     </aside>
 <section  id="abstract">
@@ -309,7 +309,7 @@
 
     <aside class="note">
       <p>
-        The scope of DCAT 2014 [[?VOCAB-DCAT-20140116]] was limited to catalogs of datasets.
+        The scope of DCAT 1 [[?VOCAB-DCAT-20140116]] was limited to catalogs of datasets.
         A number of use cases for the revision [[?DCAT-UCR]] involve <b>data services</b> as members of a catalog - see <a data-cite="DCAT-UCR#ID6">&sect;&nbsp;<span class="secno">5.16 </span>DCAT Distribution to describe Web services</a> and
         <a data-cite="DCAT-UCR#ID18">&sect;&nbsp;<span class="secno">5.18 </span>Modeling service-based data access</a>.
         Hence, the scope of this revision of DCAT includes both datasets and data services to enable these to be part of a DCAT conformant catalog.
@@ -675,7 +675,7 @@
         </p-->
 
         <!--NoBacklogNorCR p class="issue" data-number="110">
-            The axiomatization of DCAT 2014 used global domain and range constraints for many of the properties defined in the DCAT namespace [[?VOCAB-DCAT-20140116]]. This makes quite strong ontological commitments, some of which are now being reconsidered - see individual issues noted inline below.
+            The axiomatization of DCAT 1 used global domain and range constraints for many of the properties defined in the DCAT namespace [[?VOCAB-DCAT-20140116]]. This makes quite strong ontological commitments, some of which are now being reconsidered - see individual issues noted inline below.
         </p-->
 
         <p>The (revised) DCAT vocabulary is <a href="https://www.w3.org/ns/dcat#">available in RDF</a>.
@@ -694,7 +694,7 @@
         </ol>
 
         <!--NoBacklogNorCR p class="issue" data-number="144">
-            The implementation of a DCAT 2014 profile of the revised DCAT is being considered.
+            The implementation of a DCAT 1 profile of the revised DCAT is being considered.
         </p -->
 
 
@@ -731,7 +731,7 @@
         <h3>Class: Catalog</h3>
 
         <aside class="note">
-          <p>The scope of DCAT 2014 was catalogs of datasets [[?VOCAB-DCAT-20140116]]. This has been generalized, and properties common to all cataloged resources are now associated with a super-class <a href="#Class:Resource"><code>dcat:Resource</code></a>.</p>
+          <p>The scope of DCAT 1 was catalogs of datasets [[?VOCAB-DCAT-20140116]]. This has been generalized, and properties common to all cataloged resources are now associated with a super-class <a href="#Class:Resource"><code>dcat:Resource</code></a>.</p>
           <p>Moreover, an explicit class for <a href="#Class:Data_Service">data services</a> has been added in this revision of DCAT, to enable these to be part of a catalog.</p>
           <p>Finally, <code>dcat:Catalog</code> has been made a sub-class of <code>dcat:Dataset</code>, and provision for catalogs to be composed of other catalogs is also enabled.</p>
           <p>See <a href="https://github.com/w3c/dxwg/issues/116">Issue #116</a> and <a href="https://github.com/w3c/dxwg/issues/172">Issue #172</a>.</p>
@@ -1023,7 +1023,7 @@
 
             <aside class="note">
               <p>
-                In DCAT 2014 [[VOCAB-DCAT-20140116]] the domain of <code>dcat:contactPoint</code> was <code>dcat:Dataset</code>, which limited use of this property in other contexts. The domain has been relaxed in this revision. See <a href="https://github.com/w3c/dxwg/issues/95">Issue #95</a>.
+                In DCAT 1 [[VOCAB-DCAT-20140116]] the domain of <code>dcat:contactPoint</code> was <code>dcat:Dataset</code>, which limited use of this property in other contexts. The domain has been relaxed in this revision. See <a href="https://github.com/w3c/dxwg/issues/95">Issue #95</a>.
               </p>
             </aside>
 
@@ -1177,7 +1177,7 @@
 
             <aside class="note">
               <p>
-                In DCAT 2014 [[?VOCAB-DCAT-20140116]] the domain of <code>dcat:theme</code> was <code>dcat:Dataset</code>, which limited use of this property in other contexts. The domain has been relaxed in this revision. 
+                In DCAT 1 [[?VOCAB-DCAT-20140116]] the domain of <code>dcat:theme</code> was <code>dcat:Dataset</code>, which limited use of this property in other contexts. The domain has been relaxed in this revision. 
                 See <a href="https://github.com/w3c/dxwg/issues/123">Issue #123</a>.
               </p>
             </aside>
@@ -1331,7 +1331,7 @@
 
             <aside class="note">
               <p>
-                In DCAT 2014 [[?VOCAB-DCAT-20140116]] the domain of <code>dcat:keyword</code> was <code>dcat:Dataset</code>, which limited use of this property in other contexts. The domain has been relaxed in this revision - see <a href="https://github.com/w3c/dxwg/issues/121">Issue #121</a>.
+                In DCAT 1 [[?VOCAB-DCAT-20140116]] the domain of <code>dcat:keyword</code> was <code>dcat:Dataset</code>, which limited use of this property in other contexts. The domain has been relaxed in this revision - see <a href="https://github.com/w3c/dxwg/issues/121">Issue #121</a>.
               </p>
             </aside>
 
@@ -1350,7 +1350,7 @@
 
             <aside class="note">
               <p>
-                In DCAT 2014 [[?VOCAB-DCAT-20140116]] the domain of <code>dcat:landingPage</code> was <code>dcat:Dataset</code>, which limited use of this property in other contexts. The domain has been relaxed in this revision - see <a href="https://github.com/w3c/dxwg/issues/122">Issue #122</a>.
+                In DCAT 1 [[?VOCAB-DCAT-20140116]] the domain of <code>dcat:landingPage</code> was <code>dcat:Dataset</code>, which limited use of this property in other contexts. The domain has been relaxed in this revision - see <a href="https://github.com/w3c/dxwg/issues/122">Issue #122</a>.
               </p>
             </aside>
 
@@ -1622,8 +1622,8 @@
 
         <aside class="note">
             <p>
-              In DCAT 2014 [[?VOCAB-DCAT-20140116]] <a href="#Class:Dataset"><code>dcat:Dataset</code></a> was a sub-class of <a href="http://purl.org/dc/dcmitype/Dataset"><code>dctype:Dataset</code></a>, which is a member of the <a data-cite="?DCTERMS#section-7">DCMI Types vocabulary</a> [[?DCTERMS]].
-              The scope of <a href="#Class:Dataset"><code>dcat:Dataset</code></a> also includes other members of the <a data-cite="?DCTERMS#section-7">DCMI Types vocabulary</a>, such as various multimedia (imagery, sound, video) and text, so the sub-class relationship from DCAT 2014 [[?VOCAB-DCAT-20140116]] has been removed in this revised DCAT vocabulary - see <a href="https://github.com/w3c/dxwg/issues/98">Issue #98</a>.
+              In DCAT 1 [[?VOCAB-DCAT-20140116]] <a href="#Class:Dataset"><code>dcat:Dataset</code></a> was a sub-class of <a href="http://purl.org/dc/dcmitype/Dataset"><code>dctype:Dataset</code></a>, which is a member of the <a data-cite="?DCTERMS#section-7">DCMI Types vocabulary</a> [[?DCTERMS]].
+              The scope of <a href="#Class:Dataset"><code>dcat:Dataset</code></a> also includes other members of the <a data-cite="?DCTERMS#section-7">DCMI Types vocabulary</a>, such as various multimedia (imagery, sound, video) and text, so the sub-class relationship from DCAT 1 [[?VOCAB-DCAT-20140116]] has been removed in this revised DCAT vocabulary - see <a href="https://github.com/w3c/dxwg/issues/98">Issue #98</a>.
             </p>
             <p>
               Note that members of the <a data-cite="?DCTERMS#section-7">DCMI Types vocabulary</a> may appear as the value of the <a href="#Property:resource_type"><code>dct:type</code></a> property, as shown in <a href="#classifying-dataset-types"></a>.
@@ -2941,7 +2941,7 @@ ex:InternationalDOIFundation a foaf:Organization ;
 
   <aside class="note">
     <p>
-    DCAT 2014 handling of license and rights do not appear to satisfy all requirements [[?VOCAB-DCAT-20140116]].
+    DCAT 1 handling of license and rights do not appear to satisfy all requirements [[?VOCAB-DCAT-20140116]].
     The recently completed W3C ODRL model [[?ODRL-MODEL]] and vocabulary [[?ODRL-VOCAB]] provide a rich language for describing many kinds of rights and obligations.
     In this section, we describe some patterns for linking DCAT Datasets and/or Distributions to suitable license and rights expressions.
   </p>
@@ -3407,7 +3407,7 @@ For indicating the version release date and identifier, the use of, respectively
 
     <p>
         In order to support data citation, this DCAT revision has added the consideration of <a href="#dereferenceable-identifiers">dereferenceable identifiers</a> and support for indicating
-        <a href="#Property:resource_creator">the creators of the cataloged resources</a>. The remaining properties necessary for data citation were already available in DCAT 2014 [[?VOCAB-DCAT-20140116]].
+        <a href="#Property:resource_creator">the creators of the cataloged resources</a>. The remaining properties necessary for data citation were already available in DCAT 1 [[?VOCAB-DCAT-20140116]].
     </p>
 
     <p>
@@ -3992,8 +3992,8 @@ ex:Test543L
             General purpose Web search services that use metadata at all rely primarily on [[?SCHEMA-ORG]], so the relationship of DCAT to [[?SCHEMA-ORG]] is of interest for data providers and catalog publishers who wish their datasets and services to be exposed through those indexes.
         </p>
         <p>
-            A <a href="https://www.w3.org/wiki/WebSchemas/Datasets">mapping between DCAT 2014 and schema.org</a> was discussed on the original proposal to extend [[?SCHEMA-ORG]] for describing datasets and data catalogs.
-            Partial mappings between DCAT 2014 [[?VOCAB-DCAT-20140116]] and [[?SCHEMA-ORG]] were provided earlier by the
+            A <a href="https://www.w3.org/wiki/WebSchemas/Datasets">mapping between DCAT 1 and schema.org</a> was discussed on the original proposal to extend [[?SCHEMA-ORG]] for describing datasets and data catalogs.
+            Partial mappings between DCAT 1 [[?VOCAB-DCAT-20140116]] and [[?SCHEMA-ORG]] were provided earlier by the
             <a href="https://www.w3.org/2015/spatial/wiki/ISO_19115_-_DCAT_-_Schema.org_mapping">Spatial Data on the Web Working Group</a>, building upon previous work.
         </p>
         <p>
@@ -4644,7 +4644,7 @@ ga-courts:jc-wms
     </section>
     <section id="changes-since-20140116">
         <h3>Changes since the W3C Recommendation of 16 January 2014</h3>
-        <p>The document has undergone the following changes since the  DCAT 2014 W3C Recommendation of 16 January 2014 [[?VOCAB-DCAT-20140116]]:</p>
+        <p>The document has undergone the following changes since the  DCAT 1 W3C Recommendation of 16 January 2014 [[?VOCAB-DCAT-20140116]]:</p>
 
         <ul>
 
@@ -4756,7 +4756,7 @@ See <a href="https://github.com/w3c/dxwg/issues/57">Issue #57</a> and <a href="h
 
 <li>
 <a href="#Class:Resource">Class: Cataloged resource</a>: 
-In DCAT 2014 [[?VOCAB-DCAT-20140116]] the scope of a <a href="#Class:Catalog"><code>dcat:Catalog</code></a> was limited to datasets. This has been generalized, and properties common to all cataloged resources are now associated with a super-class <a href="#Class:Resource"><code>dcat:Resource</code></a>.
+In DCAT 1 [[?VOCAB-DCAT-20140116]] the scope of a <a href="#Class:Catalog"><code>dcat:Catalog</code></a> was limited to datasets. This has been generalized, and properties common to all cataloged resources are now associated with a super-class <a href="#Class:Resource"><code>dcat:Resource</code></a>.
 See <a href="https://github.com/w3c/dxwg/issues/172">Issue #172</a> and <a href="https://github.com/w3c/dxwg/issues/116">Issue #116</a>. 
 <!--
 The wiki page on <a href="https://github.com/w3c/dxwg/wiki/Cataloguing-data-services">Cataloguing data services</a> describes some proposals related to this requirement.
@@ -4765,23 +4765,23 @@ The wiki page on <a href="https://github.com/w3c/dxwg/wiki/Cataloguing-data-serv
 
 <li>
 <a href="#Class:Data_Service">Class: Data service</a>: 
-In DCAT 2014 [[?VOCAB-DCAT-20140116]] the scope of a <a href="#Class:Catalog"><code>dcat:Catalog</code></a> was limited to datasets. The new class <code>dcat:DataService</code> has been added to support cataloging of various kinds of data services. 
+In DCAT 1 [[?VOCAB-DCAT-20140116]] the scope of a <a href="#Class:Catalog"><code>dcat:Catalog</code></a> was limited to datasets. The new class <code>dcat:DataService</code> has been added to support cataloging of various kinds of data services. 
 See <a href="https://github.com/w3c/dxwg/issues/172">Issue #172</a>, <a href="https://github.com/w3c/dxwg/issues/56">Issue #56</a>, <a href="https://github.com/w3c/dxwg/issues/432">Issue #432</a>, <a href="https://github.com/w3c/dxwg/issues/821">Issue #821</a>.
 </li>
 
 <li><a href="#Class:Dataset">Class: Dataset</a>:
-In DCAT 2014 [[?VOCAB-DCAT-20140116]] <a href="#Class:Dataset"><code>dcat:Dataset</code></a> was a sub-class of <a href="http://purl.org/dc/dcmitype/Dataset"><code>dctype:Dataset</code></a>, which is a term of the <a data-cite="?DCTERMS#section-7">DCMI Types vocabulary</a> [[!DCTERMS]]. This relationship has been removed in the revised DCAT vocabulary. 
+In DCAT 1 [[?VOCAB-DCAT-20140116]] <a href="#Class:Dataset"><code>dcat:Dataset</code></a> was a sub-class of <a href="http://purl.org/dc/dcmitype/Dataset"><code>dctype:Dataset</code></a>, which is a term of the <a data-cite="?DCTERMS#section-7">DCMI Types vocabulary</a> [[!DCTERMS]]. This relationship has been removed in the revised DCAT vocabulary. 
 See <a href="https://github.com/w3c/dxwg/issues/98">Issue #98</a>.
 </li>
 
 <li>
 <a href="#Class:Distribution">Class: Distribution</a>: 
-In DCAT 2014 [[?VOCAB-DCAT-20140116]] the definition of a <a href="#Class:Distribution"><code>dcat:Distribution</code></a> allowed a number of alternative interpretations. The definition has been rephrased to clarify that distributions are primarily <i>representations</i> of datasets. 
+In DCAT 1 [[?VOCAB-DCAT-20140116]] the definition of a <a href="#Class:Distribution"><code>dcat:Distribution</code></a> allowed a number of alternative interpretations. The definition has been rephrased to clarify that distributions are primarily <i>representations</i> of datasets. 
 See <a href="https://github.com/w3c/dxwg/issues/172">Issue #52</a> and related use cases.
 </li>
 
 <li><a href="#Property:resource_theme">Property: theme/category</a>:
-In DCAT 2014 [[?VOCAB-DCAT-20140116]] the domain of <code>dcat:theme</code> was <code>dcat:Dataset</code>, which limited use of this property in other contexts. The domain has been relaxed in this revision. 
+In DCAT 1 [[?VOCAB-DCAT-20140116]] the domain of <code>dcat:theme</code> was <code>dcat:Dataset</code>, which limited use of this property in other contexts. The domain has been relaxed in this revision. 
 See <a href="https://github.com/w3c/dxwg/issues/123">Issue #123</a>.
 </li>
 
@@ -4791,27 +4791,27 @@ See <a href="https://github.com/w3c/dxwg/issues/64">Issue #64</a>, with examples
 </li>
 
 <li><a href="#Property:resource_keyword">Property: keyword/tag</a>:
-In DCAT 2014 [[?VOCAB-DCAT-20140116]] the domain of <code>dcat:keyword</code> was <code>dcat:Dataset</code>, which limited use of this property in other contexts. The domain has been relaxed in this revision. 
+In DCAT 1 [[?VOCAB-DCAT-20140116]] the domain of <code>dcat:keyword</code> was <code>dcat:Dataset</code>, which limited use of this property in other contexts. The domain has been relaxed in this revision. 
 See <a href="https://github.com/w3c/dxwg/issues/121">Issue #121</a>.
 </li>
 
 <li><a href="#Property:resource_contact_point">Property: contact point</a>:
-In DCAT 2014 [[?VOCAB-DCAT-20140116]] the domain of <code>dcat:contactPoint</code> was <code>dcat:Dataset</code>, which limited use of this property in other contexts. The domain has been relaxed in this revision. 
+In DCAT 1 [[?VOCAB-DCAT-20140116]] the domain of <code>dcat:contactPoint</code> was <code>dcat:Dataset</code>, which limited use of this property in other contexts. The domain has been relaxed in this revision. 
 See <a href="https://github.com/w3c/dxwg/issues/95">Issue #95</a>.
 </li>
 
 <li><a href="#Property:resource_landing_page">Property: landing page</a>:
-In DCAT 2014 [[?VOCAB-DCAT-20140116]] the domain of <code>dcat:landingPage</code> was <code>dcat:Dataset</code>, which limited use of this property in other contexts. The domain has been relaxed in this revision. 
+In DCAT 1 [[?VOCAB-DCAT-20140116]] the domain of <code>dcat:landingPage</code> was <code>dcat:Dataset</code>, which limited use of this property in other contexts. The domain has been relaxed in this revision. 
 See <a href="https://github.com/w3c/dxwg/issues/122">Issue #122</a>.
 </li>
 
 <li><a href="http://vocab.org/vann/#usageNote">Property: <code>vann:usageNote</code></a>:
-DCAT 2014 [[?VOCAB-DCAT-20140116]] included documentation captured as text using <a href="http://vocab.org/vann/#usageNote"><code>vann:usageNote</code></a> elements, which is a sub-property of <code>rdfs:seeAlso</code> - an <code>owl:ObjectProperty</code> that cannot have a Literal value. This revision of DCAT has fixed these issues and replaced the use of <code>vann:usageNote</code> with <a href="https://www.w3.org/TR/skos-primer/#secdocumentation"><code>skos:scopeNote</code></a>. 
+DCAT 1 [[?VOCAB-DCAT-20140116]] included documentation captured as text using <a href="http://vocab.org/vann/#usageNote"><code>vann:usageNote</code></a> elements, which is a sub-property of <code>rdfs:seeAlso</code> - an <code>owl:ObjectProperty</code> that cannot have a Literal value. This revision of DCAT has fixed these issues and replaced the use of <code>vann:usageNote</code> with <a href="https://www.w3.org/TR/skos-primer/#secdocumentation"><code>skos:scopeNote</code></a>. 
 See <a href="https://github.com/w3c/dxwg/issues/233">Issue #233</a>.
 </li>
 
 <li><a href="#Property:record_conforms_to">Property: conforms to</a>:
-DCAT 2014 [[?VOCAB-DCAT-20140116]] had no way of representing the conformance of a record metadata with a metadata standard. This revision has added the property <code>dct:conformsTo</code> for <code>dcat:CatalogRecord</code> to cover this requirement.
+DCAT 1 [[?VOCAB-DCAT-20140116]] had no way of representing the conformance of a record metadata with a metadata standard. This revision has added the property <code>dct:conformsTo</code> for <code>dcat:CatalogRecord</code> to cover this requirement.
 See <a href="https://github.com/w3c/dxwg/issues/502">Issue #502</a>.
 </li>
 

--- a/dcat/index.html
+++ b/dcat/index.html
@@ -4638,7 +4638,9 @@ ga-courts:jc-wms
     <section id="changes-since-20140116">
         <h3>Changes since the W3C Recommendation of 4 February 2020</h3>
         <p>The document has undergone the following changes since the W3C Recommendation of 4 February 2020 [[?VOCAB-DCAT-2-20200204]]:</p>
-
+        <li>
+        Section <a href="#dataset-versions"></a> was extended with draft guidelines to deal with version delta (<a href="https://github.com/w3c/dxwg/issues/#89">Issue #89</a>), version release date (<a href="https://github.com/w3c/dxwg/issues/#91">Issue #91</a>),  version identifier (<a href="https://github.com/w3c/dxwg/issues/#92">Issue #92</a>),  version compatibility (<a href="https://github.com/w3c/dxwg/issues/#1258">Issue #1258</a>) and resource status (<a href="https://github.com/w3c/dxwg/issues/#1238">Issue #1238</a>). 
+        </li>
     </section>
     <section id="changes-since-20140116">
         <h3>Changes since the W3C Recommendation of 16 January 2014</h3>

--- a/dcat/index.html
+++ b/dcat/index.html
@@ -4541,6 +4541,11 @@ ga-courts:jc-wms
     <h2>Change history</h2>
     <p>A full change-log is available on <a href="https://github.com/w3c/dxwg/commits/gh-pages/dcat">GitHub</a></p>
     <section id="changes-since-20140116">
+        <h3>Changes since the W3C Recommendation of 4 February 2020</h3>
+        <p>The document has undergone the following changes since the W3C Recommendation of 4 February 2020 [[?VOCAB-DCAT-2-20200204]]:</p>
+
+    </section>
+    <section id="changes-since-20140116">
         <h3>Changes since the W3C Recommendation of 16 January 2014</h3>
         <p>The document has undergone the following changes since the W3C Recommendation of 16 January 2014 [[?VOCAB-DCAT-20140116]]:</p>
 

--- a/dcat/index.html
+++ b/dcat/index.html
@@ -4635,7 +4635,7 @@ ga-courts:jc-wms
 <section id="changes" class="appendix">
     <h2>Change history</h2>
     <p>A full change-log is available on <a href="https://github.com/w3c/dxwg/commits/gh-pages/dcat">GitHub</a></p>
-    <section id="changes-since-20140116">
+    <section id="changes-since-20200204">
         <h3>Changes since the W3C Recommendation of 4 February 2020</h3>
         <p>The document has undergone the following changes since the DCAT 2 W3C Recommendation of 4 February 2020 [[?VOCAB-DCAT-2-20200204]]:</p>
         <ul>

--- a/dcat/index.html
+++ b/dcat/index.html
@@ -4638,6 +4638,7 @@ ga-courts:jc-wms
     <section id="changes-since-20140116">
         <h3>Changes since the W3C Recommendation of 4 February 2020</h3>
         <p>The document has undergone the following changes since the DCAT 2 W3C Recommendation of 4 February 2020 [[?VOCAB-DCAT-2-20200204]]:</p>
+        <ul>
         <li>
         Section <a href="#dataset-versions"></a> was extended with draft guidelines to deal with version delta (<a href="https://github.com/w3c/dxwg/issues/#89">Issue #89</a>), version release date (<a href="https://github.com/w3c/dxwg/issues/#91">Issue #91</a>),  version identifier (<a href="https://github.com/w3c/dxwg/issues/#92">Issue #92</a>),  version compatibility (<a href="https://github.com/w3c/dxwg/issues/#1258">Issue #1258</a>) and resource status (<a href="https://github.com/w3c/dxwg/issues/#1238">Issue #1238</a>). 
         </li>


### PR DESCRIPTION
This pull changes the editor draft title ( now  Data Catalog Vocabulary (DCAT) - Version 3) and adds a section in the appendix to track the changes since the latest DCAT 2 rec.
We have some pull requests which can benefit from these changes, for example, #1244 #1251. 
