### PR TITLE
Remove domain & range indication in dct:hasPart

### DIFF
--- a/dcat/index.html
+++ b/dcat/index.html
@@ -837,7 +837,9 @@
                 <thead><tr><th>RDF Property:</th><th><a href="http://purl.org/dc/terms/hasPart">dct:hasPart</a></th></tr></thead>
                 <tbody>
                 <tr><td class="prop">Definition:</td><td>An item that is listed in the catalog.</td></tr>
+<!--                    
                 <tr><td class="prop">Domain:</td><td><a href="#Class:Catalog"><code>dcat:Catalog</code></a></td></tr>
+-->
                 <tr><td class="prop">Range:</td><td><a href="#Class:Resource"><code>dcat:Resource</code></a></td></tr>
                 <tr><td class="prop">Usage note:</td><td>This is the most general predicate for membership of a catalog. Use of a more specific sub-property is recommended when available. </td></tr>
                 <tr><td class="prop">See also:</td><td>Sub-properties of <code>dct:hasPart</code> in particular <a href="#Property:catalog_dataset"><code>dcat:dataset</code></a>, <a href="#Property:catalog_catalog"><code>dcat:catalog</code></a>, <a href="#Property:catalog_service"><code>dcat:service</code></a>. </td></tr>

--- a/dcat/index.html
+++ b/dcat/index.html
@@ -839,8 +839,8 @@
                 <tr><td class="prop">Definition:</td><td>An item that is listed in the catalog.</td></tr>
 <!--                    
                 <tr><td class="prop">Domain:</td><td><a href="#Class:Catalog"><code>dcat:Catalog</code></a></td></tr>
--->
                 <tr><td class="prop">Range:</td><td><a href="#Class:Resource"><code>dcat:Resource</code></a></td></tr>
+-->
                 <tr><td class="prop">Usage note:</td><td>This is the most general predicate for membership of a catalog. Use of a more specific sub-property is recommended when available. </td></tr>
                 <tr><td class="prop">See also:</td><td>Sub-properties of <code>dct:hasPart</code> in particular <a href="#Property:catalog_dataset"><code>dcat:dataset</code></a>, <a href="#Property:catalog_catalog"><code>dcat:catalog</code></a>, <a href="#Property:catalog_service"><code>dcat:service</code></a>. </td></tr>
                 </tbody>


### PR DESCRIPTION
Relevant issue: https://github.com/w3c/dxwg/issues/1205

Preview:

https://raw.githack.com/w3c/dxwg/andrea-perego-dcat-fix-issue-1205/dcat/index.html#Property:catalog_has_part

Diff:

https://services.w3.org/htmldiff?doc1=https%3A%2F%2Fw3c.github.io%2Fdxwg%2Fdcat%2F&doc2=https%3A%2F%2Fraw.githack.com%2Fw3c%2Fdxwg%2Fandrea-perego-dcat-fix-issue-1205%2Fdcat%2Findex.html%23Property%3Acatalog_has_part#Property:catalog_has_part