### PR TITLE
Dcat editorial adjustment on versioning

### DIFF
--- a/dcat/index.html
+++ b/dcat/index.html
@@ -3337,21 +3337,18 @@ See the wiki page on <a href="https://github.com/w3c/dxwg/wiki/Dataset-versionin
 
 <section id="version-info">
 <h2>Version information</h2>
-
+<aside class="ednote">
+<p>This section addresses the issues:</p>   
 <div class="issue" data-number="89"></div>
 <div class="issue" data-number="91"></div>
 <div class="issue" data-number="92"></div>
+</aside>
     
 <p>Besides the relationships illustrated in the previous section, versioned resources may be associated with additional information, describing, e.g., their differences with the original resource (the version "delta"),  the version identifier, and release date.</p>
 
 <p>Two typical examples are (a) a textual description of the changes between the current and the previous version of a resource, and (b) whether the new version of the resource is backward compatible or not with the previous version (this is particularly relevant when the resource is used by given applications, so it is fundamental to know if the new version can be also used with them).</p>
 
 <div class="issue" data-number="1258"></div>    
-<!--
-<aside class="issue">
-<a href="https://www.w3.org/TR/2012/REC-owl2-syntax-20121211/#Ontology_Annotations">Section 3.5 in  OWL 2 specification</a> suggests <code>owl:backwardCompatibleWith</code> / <code>owl:incompatibleWith</code> properties on entities other than ontologies is discouraged. Should we consider any other valuable alternatives? (see <a href="https://github.com/w3c/dxwg/issues/1258">issue 1258</a>) 
-</aside>
--->
 <p>For these purposes, it is recommended to use, respectively, property <a data-cite="VOCAB-ADMS#adms-versionnotes"><code>adms:versionNotes</code></a> (for a textual description of the changes) and properties <code>owl:backwardCompatibleWith</code> / <code>owl:incompatibleWith</code> (for specifying (in)compatibility).</p>
 
 For indicating the version release date and identifier, the use of, respectively, <code>dct:issued</code> and <code>owl:versionInfo</code> is recommended.
@@ -3359,9 +3356,10 @@ For indicating the version release date and identifier, the use of, respectively
 
 <section id="life-cycle">
 <h2>Resource life-cycle</h2>
-
+<aside class="ednote">
+<p>This section addresses the issue:</p>   
 <div class="issue" data-number="1238"></div>
-
+</aside>
 <p>The life-cycle of a resource is an aspect orthogonal to versioning, and sometimes strictly related. The evolution of a resource along its life-cycle (from its conception, to its creation and publication) may result in new versions, although this is not always the case (e.g., in case an approval workflow is in place, the resource may not undergo any change if no revision is needed). Similarly, the creation of a new version may not necessarily lead to a change in status (e.g., when changes are not substantial, and/or are implemented on resources still in development). Moreover, when a resource is replaced because of a revision (correcting errors, adding new content, etc.), it may be moved to a different life-cycle status (e.g., deprecation or withdrawl).</p>
 
 <p>It is worth noting that the status of a resource with respect to its life-cycle is often an important piece of information by itself, from both the data provider's and data consumers' perspectives. For a data consumer, it is important to know if a resource is still in development or not, as well as if it is deprecated or withdrawn (and, in such cases, if there is a new version to be used). On the other hand, for a data provider, flagging a resource with its status in the life-cycle is fundamental for the correct administration of the data management workflow. E.g., a resource before being published may need to be stable, and possibly flagged as approved and/or registered. Finally, besides the actual status of a resource, another useful piece of information is <em>when</em> the resource moved to a different status (e.g., when it was created, reviewed, accepted, published).</p>

--- a/dcat/index.html
+++ b/dcat/index.html
@@ -3319,8 +3319,7 @@ See the wiki page on <a href="https://github.com/w3c/dxwg/wiki/Dataset-versionin
 </ol>
 
 <aside class="ednote">
-<p>The second type is partially related to the notion of dataset series.</p>
-<div class="issue" data-number="868"></div>
+<p>The second type is partially related to the notion of dataset series (see, <a href="#dataset-series"></a>).</p>
 </aside>
     
 <p>These version types are not necessarily mutually exclusive, and they may overlap - especially, the first and the second ones. So, the relationship(s) used to link resource versions depends on which aspect is relevant for the specific use case. E.g.:</p>


### PR DESCRIPTION
Some changes to how the issues are listed in the versioning section.
We have issues that are already addressed in the candidate FPWD but are not closed as we want to grant the readers the possibility to comment further. 
This PR  encloses such a kind of issue as part of editors' note, saying, "this section addresses issues xxx, yyy, zzz". 
see: https://rawgit.com/w3c/dxwg/dcat-editorialAdjustementOnVersioning/dcat/index.html#dataset-versions