### PR TITLE
replacing occurence of 'in this revision of DCAT' by 'DCAT 2'

### DIFF
--- a/dcat/index.html
+++ b/dcat/index.html
@@ -866,7 +866,7 @@
 
             <aside class="note">
               <p>
-                Property added in  DCAT 2.
+                Property added in DCAT 2.
               </p>
             </aside>
 

--- a/dcat/index.html
+++ b/dcat/index.html
@@ -886,7 +886,7 @@
 
             <aside class="note">
               <p>
-                Property added in  DCAT 2.
+                Property added in DCAT 2.
               </p>
             </aside>
 
@@ -977,7 +977,7 @@
 
             <aside class="note">
               <p>
-                Property added in  DCAT 2.
+                Property added in DCAT 2.
               </p>
             </aside>
 
@@ -998,7 +998,7 @@
             
             <aside class="note">
               <p>
-                Property added in  DCAT 2.
+                Property added in DCAT 2.
               </p>
             </aside>
 
@@ -1044,7 +1044,7 @@
 
             <aside class="note">
               <p>
-                Property added in  DCAT 2, specifically to address data citation requirements.
+                Property added in DCAT 2, specifically to address data citation requirements.
               </p>
             </aside>
             
@@ -1201,7 +1201,7 @@
 
             <aside class="note">
               <p>
-                Property added in  DCAT 2. 
+                Property added in DCAT 2. 
                 See <a href="https://github.com/w3c/dxwg/issues/64">Issue #64</a>.
               </p>
             </aside>
@@ -1231,7 +1231,7 @@
 
             <aside class="note">
               <p>
-                Property added in  DCAT 2.
+                Property added in DCAT 2.
               </p>
             </aside>
 
@@ -1278,7 +1278,7 @@
 
             <aside class="note">
               <p>
-                Property added in  DCAT 2.
+                Property added in DCAT 2.
               </p>
             </aside>
 
@@ -1440,7 +1440,7 @@
 
             <aside class="note">
               <p>
-                Property added in  DCAT 2.
+                Property added in DCAT 2.
               </p>
             </aside>
             
@@ -1461,7 +1461,7 @@
 
             <aside class="note">
               <p>
-                Property added in  DCAT 2.
+                Property added in DCAT 2.
               </p>
             </aside>
 
@@ -1809,7 +1809,7 @@
 
             <aside class="note">
               <p>
-                Property added in  DCAT 2.
+                Property added in DCAT 2.
               </p>
             </aside>
 
@@ -2078,7 +2078,7 @@
 
             <aside class="note">
               <p>
-                Property added in  DCAT 2.
+                Property added in DCAT 2.
               </p>
             </aside>
 
@@ -2131,7 +2131,7 @@
 
             <aside class="note">
               <p>
-                Property added in  DCAT 2.
+                Property added in DCAT 2.
               </p>
             </aside>
 
@@ -2156,7 +2156,7 @@
 
             <aside class="note">
               <p>
-                Property added in  DCAT 2.
+                Property added in DCAT 2.
               </p>
             </aside>
 
@@ -2243,7 +2243,7 @@
 
             <aside class="note">
               <p>
-              Property added in  DCAT 2.
+              Property added in DCAT 2.
               </p>
             </aside>
 
@@ -2506,7 +2506,7 @@
 
             <aside class="note">
               <p>
-              Property added in  DCAT 2.
+              Property added in DCAT 2.
               </p>
             </aside>
 
@@ -2608,7 +2608,7 @@
 
             <aside class="note">
               <p>
-              Property added in  DCAT 2.
+              Property added in DCAT 2.
               </p>
             </aside>
 
@@ -2628,7 +2628,7 @@
 
             <aside class="note">
               <p>
-              Property added in  DCAT 2.
+              Property added in DCAT 2.
               </p>
             </aside>
 
@@ -2772,7 +2772,7 @@
 
             <aside class="note">
               <p>
-              Property added in  DCAT 2.
+              Property added in DCAT 2.
               </p>
             </aside>
 
@@ -2798,7 +2798,7 @@
 
             <aside class="note">
               <p>
-              Property added in  DCAT 2.
+              Property added in DCAT 2.
               </p>
             </aside>
 

--- a/dcat/index.html
+++ b/dcat/index.html
@@ -87,7 +87,7 @@
     <p>
 
     <p>
-        This revision of DCAT has extended the previous version to support further use cases and requirements [[?DCAT-UCR]].
+        DCAT 2 has extended the previous version to support further use cases and requirements [[?DCAT-UCR]].
         These include the possibility of cataloging other resources in addition to
         datasets, such as data services. The revision also supports describing relationships between datasets as well as between
         datasets and other cataloged resources.  Guidance on how to document licenses and rights statements associated with the cataloged items is provided.
@@ -135,8 +135,8 @@
 
 <h2>Motivation for change</h2>
 
-    <p>The original Recommendation [[?VOCAB-DCAT-20140116]] published in January 2014 provided the basic framework for describing datasets. It made an important distinction between a <i>dataset</i> as an abstract idea and a <i>distribution</i> as a manifestation of the dataset. Although DCAT has been widely adopted, it has become clear that the original specification lacked a number of essential features that were added either through the mechanism of a profile, such as the European Commission's DCAT-AP [[?DCAT-AP]], or the development of larger vocabularies that to a greater or lesser extent built upon the base standard, such as the Healthcare and Life Sciences Community Profile [[?HCLS-Dataset]], the Data Tag Suite [[?DATS]] and more. This revision of DCAT has been developed to address the specific shortcomings that have come to light through the experiences of different communities, the aim being to improve interoperability between the outputs of these larger vocabularies.
-    For example, in this new DCAT version we provide classes, properties and guidance to address <a href="#dereferenceable-identifiers">identifiers</a>, <a href="#quality-information">dataset quality information</a>, and <a href="#data-citation">data citation</a> issues.</p>
+    <p>The original Recommendation [[?VOCAB-DCAT-20140116]] published in January 2014 provided the basic framework for describing datasets. It made an important distinction between a <i>dataset</i> as an abstract idea and a <i>distribution</i> as a manifestation of the dataset. Although DCAT has been widely adopted, it has become clear that the original specification lacked a number of essential features that were added either through the mechanism of a profile, such as the European Commission's DCAT-AP [[?DCAT-AP]], or the development of larger vocabularies that to a greater or lesser extent built upon the base standard, such as the Healthcare and Life Sciences Community Profile [[?HCLS-Dataset]], the Data Tag Suite [[?DATS]] and more. DCAT 2 has been developed to address the specific shortcomings that have come to light through the experiences of different communities, the aim being to improve interoperability between the outputs of these larger vocabularies.
+    For example, in DCAT 2 we provide classes, properties and guidance to address <a href="#dereferenceable-identifiers">identifiers</a>, <a href="#quality-information">dataset quality information</a>, and <a href="#data-citation">data citation</a> issues.</p>
     <p>This revision includes re-writing of the specification throughout. Significant changes from the 2014 Recommendation are marked within the text using "Note" sections, as well as being described in <a href="#changes"></a>.</p>
 
 </section>
@@ -312,7 +312,7 @@
         The scope of DCAT 1 [[?VOCAB-DCAT-20140116]] was limited to catalogs of datasets.
         A number of use cases for the revision [[?DCAT-UCR]] involve <b>data services</b> as members of a catalog - see <a data-cite="DCAT-UCR#ID6">&sect;&nbsp;<span class="secno">5.16 </span>DCAT Distribution to describe Web services</a> and
         <a data-cite="DCAT-UCR#ID18">&sect;&nbsp;<span class="secno">5.18 </span>Modeling service-based data access</a>.
-        Hence, the scope of this revision of DCAT includes both datasets and data services to enable these to be part of a DCAT conformant catalog.
+        Hence, the scope of DCAT 2 includes both datasets and data services to enable these to be part of a DCAT conformant catalog.
         Provision for catalogs to be composed of other catalogs is also made.
         See <a href="https://github.com/w3c/dxwg/issues/172">Issue #172</a>.
       </p>
@@ -732,7 +732,7 @@
 
         <aside class="note">
           <p>The scope of DCAT 1 was catalogs of datasets [[?VOCAB-DCAT-20140116]]. This has been generalized, and properties common to all cataloged resources are now associated with a super-class <a href="#Class:Resource"><code>dcat:Resource</code></a>.</p>
-          <p>Moreover, an explicit class for <a href="#Class:Data_Service">data services</a> has been added in this revision of DCAT, to enable these to be part of a catalog.</p>
+          <p>Moreover, an explicit class for <a href="#Class:Data_Service">data services</a> has been added in DCAT 2, to enable these to be part of a catalog.</p>
           <p>Finally, <code>dcat:Catalog</code> has been made a sub-class of <code>dcat:Dataset</code>, and provision for catalogs to be composed of other catalogs is also enabled.</p>
           <p>See <a href="https://github.com/w3c/dxwg/issues/116">Issue #116</a> and <a href="https://github.com/w3c/dxwg/issues/172">Issue #172</a>.</p>
         </aside>
@@ -828,7 +828,7 @@
 
             <aside class="note">
               <p>
-                Property added in this context in this revision of DCAT.
+                Property added in this context in DCAT 2.
               </p>
             </aside>
 
@@ -864,7 +864,7 @@
 
             <aside class="note">
               <p>
-                New property added in this revision of DCAT.
+                Property added in  DCAT 2.
               </p>
             </aside>
 
@@ -884,7 +884,7 @@
 
             <aside class="note">
               <p>
-                New property added in this revision of DCAT.
+                Property added in  DCAT 2.
               </p>
             </aside>
 
@@ -917,7 +917,7 @@
         <h3>Class: Cataloged Resource</h3>
         <aside class="note">
           <p>
-            New class added in this revision of DCAT.
+            Class added in DCAT 2.
           </p>
         </aside>
 
@@ -975,7 +975,7 @@
 
             <aside class="note">
               <p>
-                Property added in this revision of DCAT.
+                Property added in  DCAT 2.
               </p>
             </aside>
 
@@ -996,7 +996,7 @@
             
             <aside class="note">
               <p>
-                Property added in this revision of DCAT.
+                Property added in  DCAT 2.
               </p>
             </aside>
 
@@ -1042,7 +1042,7 @@
 
             <aside class="note">
               <p>
-                Property added in this revision of DCAT, specifically to address data citation requirements.
+                Property added in  DCAT 2, specifically to address data citation requirements.
               </p>
             </aside>
             
@@ -1199,7 +1199,7 @@
 
             <aside class="note">
               <p>
-                Property added in this revision of DCAT. 
+                Property added in  DCAT 2. 
                 See <a href="https://github.com/w3c/dxwg/issues/64">Issue #64</a>.
               </p>
             </aside>
@@ -1229,7 +1229,7 @@
 
             <aside class="note">
               <p>
-                Property added in this revision of DCAT.
+                Property added in  DCAT 2.
               </p>
             </aside>
 
@@ -1276,7 +1276,7 @@
 
             <aside class="note">
               <p>
-                New property added in this revision of DCAT.
+                Property added in  DCAT 2.
               </p>
             </aside>
 
@@ -1373,7 +1373,7 @@
 
             <aside class="note">
               <p>
-                Property added in this context in this revision of DCAT.
+                Property added in this context in DCAT 2.
               </p>
             </aside>
         
@@ -1438,7 +1438,7 @@
 
             <aside class="note">
               <p>
-                Property added in this revision of DCAT.
+                Property added in  DCAT 2.
               </p>
             </aside>
             
@@ -1459,7 +1459,7 @@
 
             <aside class="note">
               <p>
-                Property added in this revision of DCAT.
+                Property added in  DCAT 2.
               </p>
             </aside>
 
@@ -1591,7 +1591,7 @@
 
             <aside class="note">
               <p>
-                Property added in this context in this revision of DCAT.
+                Property added in this context in DCAT 2.
               </p>
             </aside>
 
@@ -1765,7 +1765,7 @@
 
             <aside class="note">
               <p>
-                New property added in this revision of DCAT.
+                Property added in DCAT 2.
               </p>
             </aside>
 
@@ -1807,7 +1807,7 @@
 
             <aside class="note">
               <p>
-                New property added in this revision of DCAT.
+                Property added in  DCAT 2.
               </p>
             </aside>
 
@@ -1834,7 +1834,7 @@
 
             <aside class="note">
               <p>
-                Property added in this context in this revision of DCAT.
+                Property added in this context in DCAT 2.
               </p>
             </aside>
 
@@ -2028,7 +2028,7 @@
 
             <aside class="note">
               <p>
-                Property added in this context in this revision of DCAT.
+                Property added in this context in DCAT 2.
               </p>
             </aside>
         
@@ -2076,7 +2076,7 @@
 
             <aside class="note">
               <p>
-                New property added in this revision of DCAT.
+                Property added in  DCAT 2.
               </p>
             </aside>
 
@@ -2129,7 +2129,7 @@
 
             <aside class="note">
               <p>
-                New property added in this revision of DCAT.
+                Property added in  DCAT 2.
               </p>
             </aside>
 
@@ -2154,7 +2154,7 @@
 
             <aside class="note">
               <p>
-                New property added in this revision of DCAT.
+                Property added in  DCAT 2.
               </p>
             </aside>
 
@@ -2179,7 +2179,7 @@
 
             <aside class="note">
               <p>
-                Property added in this context in this revision of DCAT.
+                Property added in this context in DCAT 2.
               </p>
             </aside>
 
@@ -2205,7 +2205,7 @@
 
             <aside class="note">
               <p>
-                The range of <code>dcat:mediaType</code> has been tightened from <code>dct:MediaTypeOrExtent</code> to <code>dct:MediaType</code> as part of the revision of DCAT.
+                The range of <code>dcat:mediaType</code> has been tightened from <code>dct:MediaTypeOrExtent</code> to <code>dct:MediaType</code> as part of the DCAT 2.
               </p>
             </aside>
 
@@ -2241,7 +2241,7 @@
 
             <aside class="note">
               <p>
-              New property added in this revision of DCAT.
+              Property added in  DCAT 2.
               </p>
             </aside>
 
@@ -2264,7 +2264,7 @@
 
             <aside class="note">
               <p>
-              New property added in this revision of DCAT.
+              Property added in  DCAT 2.
               </p>
             </aside>
 
@@ -2288,7 +2288,7 @@
 
         <aside class="note">
           <p>
-            New class added in this revision of DCAT.
+            Class added in DCAT 2.
           </p>
         </aside>
 
@@ -2443,7 +2443,7 @@
 
         <aside class="note">
           <p>
-            New class added in this revision of DCAT.
+            Class added in DCAT 2.
           </p>
         </aside>
 
@@ -2504,7 +2504,7 @@
 
             <aside class="note">
               <p>
-              New property added in this revision of DCAT.
+              Property added in  DCAT 2.
               </p>
             </aside>
 
@@ -2532,7 +2532,7 @@
 
         <aside class="note">
           <p>
-          New class added in this revision of DCAT.
+          Class added in DCAT 2.
           </p>
         </aside>
 
@@ -2567,7 +2567,7 @@
 
         <aside class="note">
           <p>
-          Class added in this context in this revision of DCAT.
+          Class added in this context in DCAT 2.
           </p>
         </aside>
 
@@ -2606,7 +2606,7 @@
 
             <aside class="note">
               <p>
-              New property added in this revision of DCAT.
+              Property added in  DCAT 2.
               </p>
             </aside>
 
@@ -2626,7 +2626,7 @@
 
             <aside class="note">
               <p>
-              New property added in this revision of DCAT.
+              Property added in  DCAT 2.
               </p>
             </aside>
 
@@ -2646,7 +2646,7 @@
 
             <aside class="note">
               <p>
-              Property added in this context in this revision of DCAT.
+              Property added in this context in DCAT 2.
               </p>
             </aside>
 
@@ -2675,7 +2675,7 @@
 
             <aside class="note">
               <p>
-              Property added in this context in this revision of DCAT.
+              Property added in this context in DCAT 2.
               </p>
             </aside>
 
@@ -2706,7 +2706,7 @@
 
         <aside class="note">
           <p>
-          Class added in this context in this revision of DCAT.
+          Class added in this context in DCAT 2.
           </p>
         </aside>
 
@@ -2744,7 +2744,7 @@
 
             <aside class="note">
               <p>
-              Property added in this context in this revision of DCAT.
+              Property added in this context in DCAT 2.
               </p>
             </aside>
 
@@ -2770,7 +2770,7 @@
 
             <aside class="note">
               <p>
-              New property added in this revision of DCAT.
+              Property added in  DCAT 2.
               </p>
             </aside>
 
@@ -2796,7 +2796,7 @@
 
             <aside class="note">
               <p>
-              New property added in this revision of DCAT.
+              Property added in  DCAT 2.
               </p>
             </aside>
 
@@ -5054,7 +5054,7 @@ See <a href="https://github.com/w3c/dxwg/issues/122">Issue #122</a>.
 </li>
 
 <li><a href="http://vocab.org/vann/#usageNote">Property: <code>vann:usageNote</code></a>:
-DCAT 1 [[?VOCAB-DCAT-20140116]] included documentation captured as text using <a href="http://vocab.org/vann/#usageNote"><code>vann:usageNote</code></a> elements, which is a sub-property of <code>rdfs:seeAlso</code> - an <code>owl:ObjectProperty</code> that cannot have a Literal value. This revision of DCAT has fixed these issues and replaced the use of <code>vann:usageNote</code> with <a href="https://www.w3.org/TR/skos-primer/#secdocumentation"><code>skos:scopeNote</code></a>. 
+DCAT 1 [[?VOCAB-DCAT-20140116]] included documentation captured as text using <a href="http://vocab.org/vann/#usageNote"><code>vann:usageNote</code></a> elements, which is a sub-property of <code>rdfs:seeAlso</code> - an <code>owl:ObjectProperty</code> that cannot have a Literal value. DCAT 2 has fixed these issues and replaced the use of <code>vann:usageNote</code> with <a href="https://www.w3.org/TR/skos-primer/#secdocumentation"><code>skos:scopeNote</code></a>. 
 See <a href="https://github.com/w3c/dxwg/issues/233">Issue #233</a>.
 </li>
 


### PR DESCRIPTION
There are different references to "this version of DCAT" which refer to DCAT 2.  Considered that we are about to deliver the FPWD  for DCAT 3,  I think it is useful to qualify the generic mention explicitly to version DCAT 2  to avoid confusion.

I have replaced  "this version" in "DCAT 2".