### PR TITLE
Fix range of locn:geometry  in rdf

### DIFF
--- a/dcat/rdf/dcat-external.jsonld
+++ b/dcat/rdf/dcat-external.jsonld
@@ -1,1923 +1,1613 @@
-[ {
-  "@id" : "_:genid1",
-  "http://schema.org/affiliation" : [ {
-    "@id" : "_:genid2"
-  } ],
-  "http://xmlns.com/foaf/0.1/name" : [ {
-    "@value" : "David Browning"
-  } ]
-}, {
-  "@id" : "_:genid10",
-  "http://schema.org/affiliation" : [ {
-    "@id" : "http://www.w3.org/data#W3C"
-  } ],
-  "http://www.w3.org/2000/01/rdf-schema#seeAlso" : [ {
-    "@id" : "http://philarcher.org/foaf.rdf#me"
-  } ],
-  "http://xmlns.com/foaf/0.1/homepage" : [ {
-    "@id" : "http://www.w3.org/People/all#phila"
-  } ],
-  "http://xmlns.com/foaf/0.1/name" : [ {
-    "@value" : "Phil Archer"
-  } ]
-}, {
-  "@id" : "_:genid11",
-  "http://xmlns.com/foaf/0.1/name" : [ {
-    "@value" : "Boris Villazón-Terrazas"
-  } ]
-}, {
-  "@id" : "_:genid12",
-  "http://www.w3.org/2000/01/rdf-schema#seeAlso" : [ {
-    "@id" : "http://makxdekkers.com/makxdekkers.rdf#me"
-  } ],
-  "http://xmlns.com/foaf/0.1/homepage" : [ {
-    "@id" : "http://makxdekkers.com/"
-  } ],
-  "http://xmlns.com/foaf/0.1/name" : [ {
-    "@value" : "Makx Dekkers"
-  } ]
-}, {
-  "@id" : "_:genid13",
-  "http://schema.org/affiliation" : [ {
-    "@id" : "_:genid14"
-  } ],
-  "http://xmlns.com/foaf/0.1/name" : [ {
-    "@value" : "Rufus Pollock"
-  } ]
-}, {
-  "@id" : "_:genid14",
-  "http://xmlns.com/foaf/0.1/homepage" : [ {
-    "@id" : "http://okfn.org"
-  } ],
-  "http://xmlns.com/foaf/0.1/name" : [ {
-    "@value" : "Open Knowledge Foundation"
-  } ]
-}, {
-  "@id" : "_:genid15",
-  "http://www.w3.org/2000/01/rdf-schema#seeAlso" : [ {
-    "@id" : "https://orcid.org/0000-0001-9300-2694"
-  } ],
-  "http://xmlns.com/foaf/0.1/homepage" : [ {
-    "@id" : "http://www.andrea-perego.name/foaf/#me"
-  } ],
-  "http://xmlns.com/foaf/0.1/name" : [ {
-    "@value" : "Andrea Perego"
-  } ]
-}, {
-  "@id" : "_:genid16",
-  "http://www.w3.org/2000/01/rdf-schema#seeAlso" : [ {
-    "@id" : "https://orcid.org/0000-0001-5648-2713"
-  } ],
-  "http://xmlns.com/foaf/0.1/homepage" : [ {
-    "@id" : "http://www.imati.cnr.it/index.php/people/8-curricula/178-riccardo-albertoni"
-  }, {
-    "@id" : "https://w3id.org/people/ralbertoni/"
-  } ],
-  "http://xmlns.com/foaf/0.1/name" : [ {
-    "@value" : "Riccardo Albertoni"
-  } ]
-}, {
-  "@id" : "_:genid17",
-  "http://www.w3.org/2000/01/rdf-schema#seeAlso" : [ {
-    "@id" : "http://www.eurecom.fr/~atemezin/gatemezing-foaf.rdf"
-  } ],
-  "http://xmlns.com/foaf/0.1/name" : [ {
-    "@value" : "Ghislain Auguste Atemezing"
-  } ]
-}, {
-  "@id" : "_:genid18",
-  "http://www.w3.org/2000/01/rdf-schema#seeAlso" : [ {
-    "@id" : "https://jakub.klímek.com/#me"
-  } ],
-  "http://xmlns.com/foaf/0.1/homepage" : [ {
-    "@id" : "https://jakub.klímek.com/"
-  } ],
-  "http://xmlns.com/foaf/0.1/name" : [ {
-    "@value" : "Jakub Klímek"
-  } ]
-}, {
-  "@id" : "_:genid19",
-  "http://www.w3.org/2000/01/rdf-schema#seeAlso" : [ {
-    "@id" : "http://fadmaa.me/foaf.ttl"
-  } ],
-  "http://xmlns.com/foaf/0.1/name" : [ {
-    "@value" : "Fadi Maali"
-  } ]
-}, {
-  "@id" : "_:genid2",
-  "http://xmlns.com/foaf/0.1/homepage" : [ {
-    "@id" : "http://www.refinitiv.com"
-  } ],
-  "http://xmlns.com/foaf/0.1/name" : [ {
-    "@value" : "Refinitiv"
-  } ]
-}, {
-  "@id" : "_:genid20",
-  "http://xmlns.com/foaf/0.1/name" : [ {
-    "@value" : "John Erickson"
-  } ]
-}, {
-  "@id" : "_:genid21",
-  "http://xmlns.com/foaf/0.1/homepage" : [ {
-    "@id" : "http://www.asahi-net.or.jp/~ax2s-kmtn/"
-  } ],
-  "http://xmlns.com/foaf/0.1/name" : [ {
-    "@value" : "Shuji Kamitsuna"
-  } ]
-}, {
-  "@id" : "_:genid22",
-  "http://schema.org/affiliation" : [ {
-    "@id" : "_:genid23"
-  } ],
-  "http://xmlns.com/foaf/0.1/name" : [ {
-    "@value" : "Vassilios Peristeras"
-  } ]
-}, {
-  "@id" : "_:genid23",
-  "http://xmlns.com/foaf/0.1/homepage" : [ {
-    "@id" : "http://ec.europa.eu/dgs/informatics/"
-  } ],
-  "http://xmlns.com/foaf/0.1/name" : [ {
-    "@value" : "European Commission, DG DIGIT"
-  } ]
-}, {
-  "@id" : "_:genid24",
-  "http://www.w3.org/2000/01/rdf-schema#seeAlso" : [ {
-    "@id" : "http://fadmaa.me/foaf.ttl"
-  } ],
-  "http://xmlns.com/foaf/0.1/name" : [ {
-    "@value" : "Fadi Maali"
-  } ]
-}, {
-  "@id" : "_:genid25",
-  "http://schema.org/affiliation" : [ {
-    "@id" : "_:genid26"
-  } ],
-  "http://xmlns.com/foaf/0.1/name" : [ {
-    "@value" : "Vassilios Peristeras"
-  } ]
-}, {
-  "@id" : "_:genid26",
-  "http://xmlns.com/foaf/0.1/homepage" : [ {
-    "@id" : "http://ec.europa.eu/dgs/informatics/"
-  } ],
-  "http://xmlns.com/foaf/0.1/name" : [ {
-    "@value" : "European Commission, DG DIGIT"
-  } ]
-}, {
-  "@id" : "_:genid27",
-  "http://xmlns.com/foaf/0.1/homepage" : [ {
-    "@id" : "http://www.asahi-net.or.jp/~ax2s-kmtn/"
-  } ],
-  "http://xmlns.com/foaf/0.1/name" : [ {
-    "@value" : "Shuji Kamitsuna"
-  } ]
-}, {
-  "@id" : "_:genid28",
-  "http://schema.org/affiliation" : [ {
-    "@id" : "_:genid29"
-  } ],
-  "http://xmlns.com/foaf/0.1/name" : [ {
-    "@value" : "Rufus Pollock"
-  } ]
-}, {
-  "@id" : "_:genid29",
-  "http://xmlns.com/foaf/0.1/homepage" : [ {
-    "@id" : "http://okfn.org"
-  } ],
-  "http://xmlns.com/foaf/0.1/name" : [ {
-    "@value" : "Open Knowledge Foundation"
-  } ]
-}, {
-  "@id" : "_:genid3",
-  "http://xmlns.com/foaf/0.1/name" : [ {
-    "@value" : "Martin Alvarez-Espinar"
-  } ]
-}, {
-  "@id" : "_:genid30",
-  "http://www.w3.org/2000/01/rdf-schema#seeAlso" : [ {
-    "@id" : "https://orcid.org/0000-0001-5648-2713"
-  } ],
-  "http://xmlns.com/foaf/0.1/homepage" : [ {
-    "@id" : "http://www.imati.cnr.it/index.php/people/8-curricula/178-riccardo-albertoni"
-  }, {
-    "@id" : "https://w3id.org/people/ralbertoni/"
-  } ],
-  "http://xmlns.com/foaf/0.1/name" : [ {
-    "@value" : "Riccardo Albertoni"
-  } ]
-}, {
-  "@id" : "_:genid31",
-  "http://www.w3.org/2000/01/rdf-schema#seeAlso" : [ {
-    "@id" : "https://orcid.org/0000-0001-9300-2694"
-  } ],
-  "http://xmlns.com/foaf/0.1/homepage" : [ {
-    "@id" : "http://www.andrea-perego.name/foaf/#me"
-  } ],
-  "http://xmlns.com/foaf/0.1/name" : [ {
-    "@value" : "Andrea Perego"
-  } ]
-}, {
-  "@id" : "_:genid32",
-  "http://www.w3.org/2000/01/rdf-schema#seeAlso" : [ {
-    "@id" : "http://www.eurecom.fr/~atemezin/gatemezing-foaf.rdf"
-  } ],
-  "http://xmlns.com/foaf/0.1/name" : [ {
-    "@value" : "Ghislain Auguste Atemezing"
-  } ]
-}, {
-  "@id" : "_:genid33",
-  "http://www.w3.org/2000/01/rdf-schema#seeAlso" : [ {
-    "@id" : "https://jakub.klímek.com/#me"
-  } ],
-  "http://xmlns.com/foaf/0.1/homepage" : [ {
-    "@id" : "https://jakub.klímek.com/"
-  } ],
-  "http://xmlns.com/foaf/0.1/name" : [ {
-    "@value" : "Jakub Klímek"
-  } ]
-}, {
-  "@id" : "_:genid34",
-  "http://schema.org/affiliation" : [ {
-    "@id" : "http://www.w3.org/data#W3C"
-  } ],
-  "http://www.w3.org/2000/01/rdf-schema#seeAlso" : [ {
-    "@id" : "http://philarcher.org/foaf.rdf#me"
-  } ],
-  "http://xmlns.com/foaf/0.1/homepage" : [ {
-    "@id" : "http://www.w3.org/People/all#phila"
-  } ],
-  "http://xmlns.com/foaf/0.1/name" : [ {
-    "@value" : "Phil Archer"
-  } ]
-}, {
-  "@id" : "_:genid35",
-  "http://www.w3.org/2000/01/rdf-schema#seeAlso" : [ {
-    "@id" : "http://makxdekkers.com/makxdekkers.rdf#me"
-  } ],
-  "http://xmlns.com/foaf/0.1/homepage" : [ {
-    "@id" : "http://makxdekkers.com/"
-  } ],
-  "http://xmlns.com/foaf/0.1/name" : [ {
-    "@value" : "Makx Dekkers"
-  } ]
-}, {
-  "@id" : "_:genid36",
-  "http://xmlns.com/foaf/0.1/name" : [ {
-    "@value" : "Boris Villazón-Terrazas"
-  } ]
-}, {
-  "@id" : "_:genid37",
-  "http://xmlns.com/foaf/0.1/name" : [ {
-    "@value" : "Martin Alvarez-Espinar"
-  } ]
-}, {
-  "@id" : "_:genid38",
-  "http://schema.org/affiliation" : [ {
-    "@id" : "_:genid39"
-  } ],
-  "http://xmlns.com/foaf/0.1/name" : [ {
-    "@value" : "David Browning"
-  } ]
-}, {
-  "@id" : "_:genid39",
-  "http://xmlns.com/foaf/0.1/homepage" : [ {
-    "@id" : "http://www.refinitiv.com"
-  } ],
-  "http://xmlns.com/foaf/0.1/name" : [ {
-    "@value" : "Refinitiv"
-  } ]
-}, {
-  "@id" : "_:genid4",
-  "http://schema.org/affiliation" : [ {
-    "@id" : "_:genid5"
-  } ],
-  "http://www.w3.org/2000/01/rdf-schema#seeAlso" : [ {
-    "@id" : "https://orcid.org/0000-0003-3499-8262"
-  } ],
-  "http://xmlns.com/foaf/0.1/homepage" : [ {
-    "@id" : "https://agbeltran.github.io"
-  } ],
-  "http://xmlns.com/foaf/0.1/name" : [ {
-    "@value" : "Alejandra Gonzalez-Beltran"
-  } ]
-}, {
-  "@id" : "_:genid40",
-  "http://xmlns.com/foaf/0.1/name" : [ {
-    "@value" : "Richard Cyganiak"
-  } ]
-}, {
-  "@id" : "_:genid41",
-  "http://schema.org/affiliation" : [ {
-    "@id" : "_:genid42"
-  } ],
-  "http://www.w3.org/2000/01/rdf-schema#seeAlso" : [ {
-    "@id" : "https://orcid.org/0000-0003-3499-8262"
-  } ],
-  "http://xmlns.com/foaf/0.1/homepage" : [ {
-    "@id" : "https://agbeltran.github.io"
-  } ],
-  "http://xmlns.com/foaf/0.1/name" : [ {
-    "@value" : "Alejandra Gonzalez-Beltran"
-  } ]
-}, {
-  "@id" : "_:genid42",
-  "http://xmlns.com/foaf/0.1/homepage" : [ {
-    "@id" : "http://stfc.ac.uk"
-  } ],
-  "http://xmlns.com/foaf/0.1/name" : [ {
-    "@value" : "Science and Technology Facilities Council, UK"
-  } ]
-}, {
-  "@id" : "_:genid43",
-  "http://xmlns.com/foaf/0.1/name" : [ {
-    "@value" : "Marios Meimaris"
-  } ]
-}, {
-  "@id" : "_:genid44",
-  "http://xmlns.com/foaf/0.1/name" : [ {
-    "@value" : "John Erickson"
-  } ]
-}, {
-  "@id" : "_:genid45",
-  "@type" : [ "http://xmlns.com/foaf/0.1/Person" ],
-  "http://schema.org/affiliation" : [ {
-    "@id" : "_:genid46"
-  } ],
-  "http://www.w3.org/2000/01/rdf-schema#seeAlso" : [ {
-    "@id" : "https://orcid.org/0000-0002-3884-3420"
-  } ],
-  "http://xmlns.com/foaf/0.1/name" : [ {
-    "@value" : "Simon J D Cox"
-  } ],
-  "http://xmlns.com/foaf/0.1/workInfoHomepage" : [ {
-    "@id" : "http://people.csiro.au/Simon-Cox"
-  } ]
-}, {
-  "@id" : "_:genid46",
-  "http://xmlns.com/foaf/0.1/homepage" : [ {
-    "@id" : "https://csiro.au"
-  } ],
-  "http://xmlns.com/foaf/0.1/name" : [ {
-    "@value" : "Commonwealth Scientific and Industrial Research Organisation"
-  } ]
-}, {
-  "@id" : "_:genid5",
-  "http://xmlns.com/foaf/0.1/homepage" : [ {
-    "@id" : "http://stfc.ac.uk"
-  } ],
-  "http://xmlns.com/foaf/0.1/name" : [ {
-    "@value" : "Science and Technology Facilities Council, UK"
-  } ]
-}, {
-  "@id" : "_:genid6",
-  "http://xmlns.com/foaf/0.1/name" : [ {
-    "@value" : "Richard Cyganiak"
-  } ]
-}, {
-  "@id" : "_:genid7",
-  "http://xmlns.com/foaf/0.1/name" : [ {
-    "@value" : "Marios Meimaris"
-  } ]
-}, {
-  "@id" : "_:genid8",
-  "@type" : [ "http://xmlns.com/foaf/0.1/Person" ],
-  "http://schema.org/affiliation" : [ {
-    "@id" : "_:genid9"
-  } ],
-  "http://www.w3.org/2000/01/rdf-schema#seeAlso" : [ {
-    "@id" : "https://orcid.org/0000-0002-3884-3420"
-  } ],
-  "http://xmlns.com/foaf/0.1/name" : [ {
-    "@value" : "Simon J D Cox"
-  } ],
-  "http://xmlns.com/foaf/0.1/workInfoHomepage" : [ {
-    "@id" : "http://people.csiro.au/Simon-Cox"
-  } ]
-}, {
-  "@id" : "_:genid9",
-  "http://xmlns.com/foaf/0.1/homepage" : [ {
-    "@id" : "https://csiro.au"
-  } ],
-  "http://xmlns.com/foaf/0.1/name" : [ {
-    "@value" : "Commonwealth Scientific and Industrial Research Organisation"
-  } ]
-}, {
-  "@id" : "http://purl.org/dc/terms/Location",
-  "http://www.w3.org/2004/02/skos/core#changeNote" : [ {
-    "@language" : "cs",
-    "@value" : "Třída v tomto kontextu byla přidána ve verzi DCAT 2.0."
-  }, {
-    "@language" : "en",
-    "@value" : "Class added in this context in DCAT 2.0."
-  }, {
-    "@language" : "es",
-    "@value" : "Esta clase se agregó en este contexto en DCAT 2.0."
-  }, {
-    "@language" : "it",
-    "@value" : "Classe aggiunta in questo contesto in DCAT 2.0."
-  } ],
-  "http://www.w3.org/2004/02/skos/core#definition" : [ {
-    "@language" : "it",
-    "@value" : "Una regione spaziale o un luogo designato."
-  }, {
-    "@language" : "cs",
-    "@value" : "Prostorová oblast či pojmenované místo."
-  }, {
-    "@language" : "en",
-    "@value" : "A spatial region or named place."
-  }, {
-    "@language" : "es",
-    "@value" : "Una región espacial o un lugar con nombre."
-  } ],
-  "http://www.w3.org/2004/02/skos/core#scopeNote" : [ {
-    "@language" : "en",
-    "@value" : "In the context of DCAT 2.0, for an extensive geometry (i.e., a set of coordinates denoting the vertices of the relevant geographic area), the property locn:geometry [[LOCN]] SHOULD be used."
-  }, {
-    "@language" : "cs",
-    "@value" : "En el contexto de DCAT 2.0, pro rozsáhlé geometrie (tj. sady souřadnic určujících relevantní geografickou oblast) BY MĚLA být použita vlastnost locn:geometry [[LOCN]]."
-  }, {
-    "@language" : "cs",
-    "@value" : "En el contexto de DCAT 2.0, pro geografický rámec ohraničující prostorové oblasti BY MĚLA být použita vlastnost dcat:bbox."
-  }, {
-    "@language" : "en",
-    "@value" : "In the context of DCAT 2.0, for the geographic center of a spatial area, or another characteristic point, the property dcat:centroid SHOULD be used."
-  }, {
-    "@language" : "it",
-    "@value" : "Nel contesto del DCAT 2.0, per una geometria estesa (cioè, un insieme di coordinate che indicano i vertici dell'area geografica rilevante), si DOVREBBE usare la  proprietà locn:geometry [[LOCN]]."
-  }, {
-    "@language" : "it",
-    "@value" : "Nel contesto di DCAT 2.0, per il centro geografico di un'area spaziale, o di un altro punto caratteristico, si DOVREBBE utilizzare la proprietà dcat:centroid."
-  }, {
-    "@language" : "es",
-    "@value" : "En el contexto de DCAT 2.0, para un cuadro delimitador geográfico que delimita un área espacial se DEBE usar la propiedad dcat:bbox."
-  }, {
-    "@language" : "es",
-    "@value" : "En el contexto de DCAT 2.0, para el centro geográfico de un área espacial, o algún otro punto característico, se DEBE usar la propriedad dcat:centroid."
-  }, {
-    "@language" : "it",
-    "@value" : "Nel contesto di DCAT 2.0, per un rettangolo di delimitazione geografica che delimita un'area territoriale si DOVREBBE utilizzare la proprietà dcat:bbox."
-  }, {
-    "@language" : "es",
-    "@value" : "En el contexto de DCAT 2.0, para una geometría extensiva (es decir, un conjunto de coordinadas que denotan los vértices de un área geográfica), DEBE usarse la propiedad locn:geometry [[LOCN]]."
-  }, {
-    "@language" : "cs",
-    "@value" : "En el contexto de DCAT 2.0, pro geografický střed prostorové oblasti či jiný charakteristický bod BY MĚLA být použita vlastnost dcat:centroid."
-  }, {
-    "@language" : "en",
-    "@value" : "In the context of DCAT 2.0, for a geographic bounding box delimiting a spatial area the property dcat:bbox SHOULD be used."
-  } ]
-}, {
-  "@id" : "http://purl.org/dc/terms/PeriodOfTime",
-  "http://www.w3.org/2004/02/skos/core#changeNote" : [ {
-    "@language" : "it",
-    "@value" : "Classe aggiunta in questo contesto in DCAT 2.0."
-  }, {
-    "@language" : "cs",
-    "@value" : "Třída v tomto kontextu byla přidána ve verzi DCAT 2.0."
-  }, {
-    "@language" : "en",
-    "@value" : "Class added in this context in DCAT 2.0."
-  }, {
-    "@language" : "es",
-    "@value" : "Esta clase se agregó en este contexto en DCAT 2.0."
-  } ],
-  "http://www.w3.org/2004/02/skos/core#definition" : [ {
-    "@language" : "en",
-    "@value" : "An interval of time that is named or defined by its start and end dates."
-  }, {
-    "@language" : "en",
-    "@value" : "In the context of DCAT 2.0, an interval of time that is named or defined by its start and end."
-  }, {
-    "@language" : "it",
-    "@value" : "Nel contesto di DCAT 2.0, un intervallo di tempo che viene chiamato o definito dal suo inizio e fine."
-  }, {
-    "@language" : "es",
-    "@value" : "En el contexto de DCAT 2.0, un interválo de tiempo que se nombra o define por su principio y fin."
-  }, {
-    "@language" : "cs",
-    "@value" : "En el contexto de DCAT 2.0, časový interval který je pojmenovaný, nebo určený svým začátkem a koncem."
-  } ],
-  "http://www.w3.org/2004/02/skos/core#scopeNote" : [ {
-    "@language" : "es",
-    "@value" : "En el contexto de DCAT 2.0, el comienzo y fin de un intervalo pueden representarse usando las propiedades dcat:startDate o time:hasBeginning, y dcat:endDate o time:hasEnd, respectivamente. El interválo también puede ser un interválo abierto - es decir, puede tener sólo un comienzo o un fin."
-  }, {
-    "@language" : "cs",
-    "@value" : "En el contexto de DCAT 2.0, začátek a konec intervalu může být dán vlastnostmi dcat:startDate či time:hasBeginning a dcat:endDate či time:hasEnd. Interval také může být otevřený, tj. může mít pouze začátek či pouze konec."
-  }, {
-    "@language" : "en",
-    "@value" : "In the context of DCAT 2.0, the start and end of the interval may be given by using properties dcat:startDate or time:hasBeginning, and dcat:endDate or time:hasEnd, respectively. The interval can also be open - i.e., it can have just a start or just an end."
-  }, {
-    "@language" : "it",
-    "@value" : "Nel contesto di DCAT 2.0, l'inizio e la fine dell'intervallo possono essere dati rispettivamente utilizzando le proprietà dcat:startDate o time:hasBeginning, e dcat:endDate o time:hasEnd. L'intervallo può anche essere aperto, cioè può avere solo un inizio o solo una fine."
-  } ]
-}, {
-  "@id" : "http://purl.org/dc/terms/accessRights",
-  "http://www.w3.org/2004/02/skos/core#definition" : [ {
-    "@language" : "it",
-    "@value" : "Informazioni su chi può accedere alla risorsa o un'indicazione del suo stato di sicurezza."
-  }, {
-    "@language" : "en",
-    "@value" : "Information about who can access the resource or an indication of its security status."
-  }, {
-    "@language" : "cs",
-    "@value" : "V kontextu DCAT 2.0 dcat:Distribution, podmínky užití řešící způsob přístupu k distribuci."
-  }, {
-    "@language" : "es",
-    "@value" : "En el contexto de DCAT 2.0 dcat:Distribution, una declaración de derechos sobre cómo se puede acceder la distribución."
-  }, {
-    "@language" : "en",
-    "@value" : "In the context of DCAT 2.0 dcat:Distribution, a rights statement that concerns how the distribution is accessed."
-  }, {
-    "@language" : "it",
-    "@value" : "Nel contesto di DCAT 2.0 dcat:Distribution, una dichiarazione dei diritti che riguarda le modalità di accesso alla distribuzione."
-  } ],
-  "http://www.w3.org/2004/02/skos/core#scopeNote" : [ {
-    "@language" : "en",
-    "@value" : "In the context of DCAT 2.0 dcat:DataService, access Rights MAY include information regarding access or restrictions based on privacy, security, or other policies."
-  }, {
-    "@language" : "es",
-    "@value" : "En el contexto de DCAT 2.0 dcat:Distribution, información sobre licencias y derechos que PUEDE proveerse para una Distribución. Ver también la información en la sección 'License and rights statements'."
-  }, {
-    "@language" : "es",
-    "@value" : "En el contexto de DCAT 2.0 dcat:Resource, información sobre las licencias y derechos que PUEDEN proveerse para un Recurso. Ver también la información en la sección 'License and rights statements'."
-  }, {
-    "@language" : "cs",
-    "@value" : "V kontextu DCAT 2.0 dcat:DataService, podmínky užití MOHOU obsahovat informace o přístupu nebo omezení z hlediska soukromí, bezpečnosti nebo jiných pravidel."
-  }, {
-    "@language" : "cs",
-    "@value" : "V kontextu DCAT 2.0 dcat:Resource, pro Zdroj MŮŽE BÝT uvedena informace o podmínkách užití (licencích a právech). Viz návod v sekci 'License and rights statements'."
-  }, {
-    "@language" : "cs",
-    "@value" : "V kontextu DCAT 2.0 dcat:Distribution, pro Distribuci MŮŽE BÝT uvedena informace o podmínkách užití (licencích a právech). Viz návod v sekci 'License and rights statements'."
-  }, {
-    "@language" : "it",
-    "@value" : "Nel contesto di DCAT 2.0 dcat:DataService, i diritti di accesso POSSONO includere informazioni riguardanti l'accesso o restrizioni basate su privacy, sicurezza o altre policy."
-  }, {
-    "@language" : "en",
-    "@value" : "In the context of DCAT 2.0 dcat:Distribution, information about licenses and rights MAY be provided for the Distribution. See also guidance in the section 'License and rights statements'."
-  }, {
-    "@language" : "it",
-    "@value" : "Nel contesto di DCAT 2.0 dcat:Resource, le informazioni sulle licenze e i diritti POSSONO essere fornite per la risorsa. Si vedano anche le indicazioni nella sezione 'Licenze e dichiarazioni sui diritti'."
-  }, {
-    "@language" : "en",
-    "@value" : "In the context of DCAT 2.0 dcat:Resource, information about licenses and rights MAY be provided for the Resource. See also guidance in the section 'License and rights statements'."
-  }, {
-    "@language" : "es",
-    "@value" : "En el contexto de DCAT 2.0 dcat:DataService, los derechos de acceso PUEDEN incluir información sobre acceso o restricciones basadas en privacidad, seguridad, u otras reglamentaciones."
-  }, {
-    "@language" : "it",
-    "@value" : "Nell'ambito di DCAT 2.0 dcat:Distribution, le informazioni su licenze e diritti POSSONO essere fornite per la distribuzione. Si vedano anche le indicazioni nella sezione 'Licenze e dichiarazioni sui diritti'."
-  } ]
-}, {
-  "@id" : "http://purl.org/dc/terms/accrualPeriodicity",
-  "http://www.w3.org/2004/02/skos/core#definition" : [ {
-    "@language" : "en",
-    "@value" : "In the context of DCAT 2.0, the frequency at which dataset is published."
-  }, {
-    "@language" : "it",
-    "@value" : "La frequenza con cui gli elementi vengono aggiunti a una collezione."
-  }, {
-    "@language" : "it",
-    "@value" : "Nel contesto del DCAT 2.0, la frequenza di pubblicazione dell'insieme di dati."
-  }, {
-    "@language" : "cs",
-    "@value" : "V kontextu DCAT 2.0, frekvence publikace datové sady."
-  }, {
-    "@language" : "en",
-    "@value" : "The frequency with which items are added to a collection."
-  }, {
-    "@language" : "es",
-    "@value" : "En el contexto de DCAT 2.0, la frecuencia con que se publica el conjunto de datos."
-  } ],
-  "http://www.w3.org/2004/02/skos/core#scopeNote" : [ {
-    "@language" : "cs",
-    "@value" : "V kontextu DCAT 2.0, hodnota dct:accrualPeriodicity udává frekvenci, se kterou se aktualizuje datová sada jako celek. Toto může být doplněno vlastností dcat:temporalResolution pro udání času mezi jednotlivými body v časové řadě."
-  }, {
-    "@language" : "en",
-    "@value" : "In the context of DCAT 2.0, the value of dct:accrualPeriodicity gives the rate at which the dataset-as-a-whole is updated. This may be complemented by dcat:temporalResolution to give the time between collected data points in a time series."
-  }, {
-    "@language" : "es",
-    "@value" : "En el contexto de DCAT 2.0, el valor de dct:accrualPeriodicity da la tasa de actualización del conjunto de datos como entidad. Esto puede complementarse con dcat:temporalResolution para dar el tiempo entre los puntos en que se recopilan los datos en una serie temporal."
-  }, {
-    "@language" : "it",
-    "@value" : "Nel contesto di DCAT 2.0, il valore di dct:accrualPeriodicity indica il tasso di aggiornamento del dataset nella sua interezza. Questo può essere completato da dcat:temporalResolution per dare il tempo tra i punti di dati raccolti in una serie temporale."
-  } ]
-}, {
-  "@id" : "http://purl.org/dc/terms/conformsTo",
-  "http://www.w3.org/2004/02/skos/core#changeNote" : [ {
-    "@language" : "it",
-    "@value" : "Proprietà aggiunta in questo contesto in DCAT 2.0."
-  }, {
-    "@language" : "en",
-    "@value" : "Property added in this context in DCAT 2.0."
-  }, {
-    "@language" : "es",
-    "@value" : "Esta propiedad fue agregada en DCAT 2.0."
-  }, {
-    "@language" : "cs",
-    "@value" : "Vlastnost v tomto kontextu byla přidána ve verzi DCAT 2.0."
-  } ],
-  "http://www.w3.org/2004/02/skos/core#definition" : [ {
-    "@language" : "en",
-    "@value" : "In the context of DCAT 2.0 dcat:Distribution, an established standard to which the distribution conforms."
-  }, {
-    "@language" : "it",
-    "@value" : "Nel contesto di DCAT 2.0 dcat:Distribution, uno standard consolidato a cui la distribuzione è conforme."
-  }, {
-    "@language" : "en",
-    "@value" : "An established standard to which the described resource conforms."
-  }, {
-    "@language" : "es",
-    "@value" : "En el contexto de DCAT 2.0 dcat:Distribution, un estándar establecido al cuál se ajusta la distribución."
-  }, {
-    "@language" : "it",
-    "@value" : "Uno standard stabilito al quale la risorsa descritta è conforme."
-  }, {
-    "@language" : "cs",
-    "@value" : "V kontextu DCAT 2.0 dcat:Distribution, uznávaný standard, kterým se popisovaný zdroj řídí."
-  }, {
-    "@language" : "es",
-    "@value" : "Un estándar establecido al cuál se ajusta el recurso descripto."
-  } ],
-  "http://www.w3.org/2004/02/skos/core#scopeNote" : [ {
-    "@language" : "cs",
-    "@value" : "V kontextu DCAT 2.0 dcat:Distribution, tato vlastnost BY MĚLA být použita k udání modelu, schématu, ontologie, pohledu nebo profilu, kterému tato reprezentace datové sady odpovídá. Toto (obvykle) doplňuje typ média či formát."
-  }, {
-    "@language" : "es",
-    "@value" : "En el contexto de DCAT 2.0 dcat:Distribution, esta propiedad DEBERÍA usarse para indicar el modelo, esquema, ontología, vista or perfil al que se ajusta esta representación del conjunto de datos. Este es (generalmente) un asunto complementario al de 'media type' o formato."
-  }, {
-    "@language" : "es",
-    "@value" : "En el contexto de DCAT 2.0 dcat:Resource, esta propiedad DEBERÍA usarse para indicar el modelo, esquema, ontología, vista or perfil al que se ajusta el recurso catalogado."
-  }, {
-    "@language" : "en",
-    "@value" : "In the context of DCAT 2.0 dcat:Distribution, this property SHOULD be used to indicate the model, schema, ontology, view or profile that this representation of a dataset conforms to. This is (generally) a complementary concern to the media-type or format."
-  }, {
-    "@language" : "en",
-    "@value" : "In the context of DCAT 2.0 dcat:Resource, this property SHOULD be used to indicate the model, schema, ontology, view or profile that the cataloged resource content conforms to."
-  }, {
-    "@language" : "cs",
-    "@value" : "V kontextu DCAT 2.0 dcat:Resource, tato vlastnost BY MĚLA být použita k udání modelu, schématu, ontologie, pohledu nebo profilu, kterému katalogizovaný zdroj odpovídá."
-  }, {
-    "@language" : "it",
-    "@value" : "Nel contesto di DCAT 2.0 dcat:Distribution, questa proprietà DEVE essere usata per indicare il modello, lo schema, l'ontologia, la vista o il profilo a cui questa rappresentazione di un dataset è conforme. Questa è (generalmente) una questione complementare al tipo di supporto o formato."
-  }, {
-    "@language" : "it",
-    "@value" : "Nel contesto di DCAT 2.0 dcat:Resource, questa proprietà DEVE essere utilizzata per indicare il modello, lo schema, l'ontologia, la vista o il profilo a cui il contenuto della risorsa catalogata è conforme."
-  } ]
-}, {
-  "@id" : "http://purl.org/dc/terms/creator",
-  "http://www.w3.org/2004/02/skos/core#changeNote" : [ {
-    "@language" : "es",
-    "@value" : "Esta propiedad fue agregada en DCAT 2.0, específicamente para tratar los requerimientos de cita de datos."
-  }, {
-    "@language" : "en",
-    "@value" : "Property added in this context in DCAT 2.0, specifically to address data citation requirements."
-  }, {
-    "@language" : "it",
-    "@value" : "Proprietà aggiunta in questo contesto in DCAT 2.0, in particolare per soddisfare i requisiti di citazione dei dati."
-  }, {
-    "@language" : "cs",
-    "@value" : "Vlastnost v tomto kontextu byla přidána ve verzi DCAT 2.0 zejména za účelem uspokojení požadavků na citace dat."
-  } ],
-  "http://www.w3.org/2004/02/skos/core#definition" : [ {
-    "@language" : "en",
-    "@value" : "An entity primarily responsible for making the resource."
-  }, {
-    "@language" : "es",
-    "@value" : "En el contexto de DCAT 2.0, la entidad responsable de producier el recurso."
-  }, {
-    "@language" : "en",
-    "@value" : "In the context of DCAT 2.0, the entity responsible for producing the resource."
-  }, {
-    "@language" : "it",
-    "@value" : "Nel contesto del DCAT 2.0, l'entità responsabile della produzione della risorsa."
-  }, {
-    "@language" : "it",
-    "@value" : "Un'entità principalmente responsabile della creazione della risorsa."
-  }, {
-    "@language" : "cs",
-    "@value" : "V kontextu DCAT 2.0, entita zodpovědná za tvorbu zdroje."
-  } ],
-  "http://www.w3.org/2004/02/skos/core#scopeNote" : [ {
-    "@language" : "es",
-    "@value" : "En el contexto de DCAT 2.0, se recomienda que los valores de esta propiedad sean recurso de tipo foaf:Agent."
-  }, {
-    "@language" : "en",
-    "@value" : "In the context of DCAT 2.0, resources of type foaf:Agent are recommended as values for this property."
-  }, {
-    "@language" : "it",
-    "@value" : "Nel contesto di DCAT 2.0, si raccomandano come valori per questa proprietà le risorse di tipo foaf:Agent."
-  }, {
-    "@language" : "cs",
-    "@value" : "V kontextu DCAT 2.0, doporučovanou hodnotou této vlastnosti jsou zdroje typu foaf:Agent."
-  } ]
-}, {
-  "@id" : "http://purl.org/dc/terms/description",
-  "http://www.w3.org/2004/02/skos/core#definition" : [ {
-    "@language" : "en",
-    "@value" : "In the context of DCAT 2.0, a free-text account of the item."
-  }, {
-    "@language" : "it",
-    "@value" : "Nel contesto del DCAT 2.0, un resoconto a testo libero dell’ elemento."
-  }, {
-    "@language" : "es",
-    "@value" : "En el contexto de DCAT 2.0, una explicación en texto sobre el ítem."
-  }, {
-    "@language" : "en",
-    "@value" : "An account of the resource."
-  }, {
-    "@language" : "it",
-    "@value" : "Un resoconto della risorsa."
-  }, {
-    "@language" : "cs",
-    "@value" : "V kontextu DCAT 2.0, popis položky pomocí volného textu."
-  } ]
-}, {
-  "@id" : "http://purl.org/dc/terms/format",
-  "http://www.w3.org/2004/02/skos/core#definition" : [ {
-    "@language" : "es",
-    "@value" : "En el contexto de DCAT 2.0, el formato del archivo de la distribución."
-  }, {
-    "@language" : "en",
-    "@value" : "In the context of DCAT 2.0, the file format of the distribution."
-  }, {
-    "@language" : "en",
-    "@value" : "The file format, physical medium, or dimensions of the resource."
-  }, {
-    "@language" : "it",
-    "@value" : "Il formato del file, il supporto fisico o le dimensioni della risorsa."
-  }, {
-    "@language" : "cs",
-    "@value" : "V kontextu DCAT 2.0, formát souboru distribuce."
-  }, {
-    "@language" : "it",
-    "@value" : "Nel contesto di DCAT 2.0, il formato di file della distribuzione."
-  } ],
-  "http://www.w3.org/2004/02/skos/core#scopeNote" : [ {
-    "@language" : "cs",
-    "@value" : "V kontextu DCAT 2.0, pokud je typ distribuce definován IANA [IANA-MEDIA-TYPES], MĚLA BY být použita vlastnost dcat:mediaType."
-  }, {
-    "@language" : "en",
-    "@value" : "In the context of DCAT 2.0, dcat:mediaType SHOULD be used if the type of the distribution is defined by IANA [IANA-MEDIA-TYPES]."
-  }, {
-    "@language" : "es",
-    "@value" : "En el contexto de DCAT 2.0, dcat:mediaType DEBERÍA usarse si el tipo de distribución se define por IANA [IANA-MEDIA-TYPES]."
-  }, {
-    "@language" : "it",
-    "@value" : "Nel contesto di DCAT 2.0, dcat:mediaType DEVE essere usato se il tipo di distribuzione è definito da IANA [IANA-MEDIA-TYPES]."
-  } ]
-}, {
-  "@id" : "http://purl.org/dc/terms/hasPart",
-  "http://www.w3.org/2004/02/skos/core#definition" : [ {
-    "@language" : "en",
-    "@value" : "In the context of DCAT 2.0 dcat:Catalog, an item that is listed in the catalog."
-  }, {
-    "@language" : "it",
-    "@value" : "Nel contesto di DCAT 2.0 dcat:Catalog, un elemento che è elencato nel catalogo."
-  }, {
-    "@language" : "en",
-    "@value" : "A related resource that is included either physically or logically in the described resource."
-  }, {
-    "@language" : "it",
-    "@value" : "Una risorsa correlata che è inclusa fisicamente o logicamente nella risorsa descritta."
-  } ],
-  "http://www.w3.org/2004/02/skos/core#scopeNote" : [ {
-    "@language" : "es",
-    "@value" : "En el contexto de DCAT 2.0, este es el predicado más general para la membresía en un catálogo. Se recomienda usar una sub-propiedad más específica si hay una disponible."
-  }, {
-    "@language" : "cs",
-    "@value" : "V kontextu DCAT 2.0, viz také: Podvlastnosti dct:hasPart; zejména dcat:dataset, dcat:catalog, dcat:service."
-  }, {
-    "@language" : "it",
-    "@value" : "Nel contesto del DCAT 2.0, vedi anche:  le sottoproprietà di dct:hasPart; in particolare dcat:dataset, dcat:catalog, dcat:service."
-  }, {
-    "@language" : "cs",
-    "@value" : "V kontextu DCAT 2.0, toto je nejobecnější predikát pro příslušnost do katalogu. Pokud je to možné, doporučuje se použít konkrétnější vztah."
-  }, {
-    "@language" : "es",
-    "@value" : "En el contexto de DCAT 2.0, vea también: sub-propiedades de dct:hasPart; en particular dcat:dataset, dcat:catalog, dcat:service."
-  }, {
-    "@language" : "en",
-    "@value" : "In the context of DCAT 2.0, this is the most general predicate for membership of a catalog. Use of a more specific sub-property is recommended when available."
-  }, {
-    "@language" : "it",
-    "@value" : "Nel contesto del DCAT 2.0, questo è il predicato più generale per l'appartenenza ad un catalogo. L'uso di una sottoproprietà più specifica è raccomandato se disponibile."
-  }, {
-    "@language" : "en",
-    "@value" : "In the context of DCAT 2.0, see also: Sub-properties of dct:hasPart; in particular dcat:dataset, dcat:catalog, dcat:service."
-  } ]
-}, {
-  "@id" : "http://purl.org/dc/terms/identifier",
-  "http://www.w3.org/2004/02/skos/core#definition" : [ {
-    "@language" : "es",
-    "@value" : "En el contexto de DCAT 2.0, un identificador único para el ítem."
-  }, {
-    "@language" : "en",
-    "@value" : "In the context of DCAT 2.0, a unique identifier of the item."
-  }, {
-    "@language" : "cs",
-    "@value" : "V kontextu DCAT 2.0, unikátní identifikátor položky."
-  }, {
-    "@language" : "it",
-    "@value" : "Un riferimento univoco alla risorsa in un dato contesto."
-  }, {
-    "@language" : "en",
-    "@value" : "An unambiguous reference to the resource within a given context."
-  }, {
-    "@language" : "it",
-    "@value" : "Nel contesto del DCAT 2.0, un identificatore unico dell'elemento."
-  } ],
-  "http://www.w3.org/2004/02/skos/core#scopeNote" : [ {
-    "@language" : "es",
-    "@value" : "En el contexto de DCAT 2.0, el identificador puede usarse como parte de la URI del ítem, pero es útil tenerlo representado de forma explícita."
-  }, {
-    "@language" : "en",
-    "@value" : "In the context of DCAT 2.0, the identifier might be used as part of the URI of the item, but still having it represented explicitly is useful."
-  }, {
-    "@language" : "it",
-    "@value" : "Nel contesto di DCAT 2.0, l'identificatore può essere usato come parte dell'URI dell'elemento, ma comunque è utile averlo rappresentato esplicitamente."
-  }, {
-    "@language" : "cs",
-    "@value" : "V kontextu DCAT 2.0, identifikátor může být použit jako součást IRI položky. I přesto je užitečné mít jeho explicitní reprezentaci."
-  } ]
-}, {
-  "@id" : "http://purl.org/dc/terms/isReferencedBy",
-  "http://www.w3.org/2004/02/skos/core#changeNote" : [ {
-    "@language" : "it",
-    "@value" : "Proprietà aggiunte in questo contesto in DCAT 2.0."
-  }, {
-    "@language" : "es",
-    "@value" : "En el contexto de DCAT 2.0, esta propiedad fue agregada en DCAT 2.0."
-  }, {
-    "@language" : "cs",
-    "@value" : "Vlastnost byla v tomto kontextu přidána ve verzi DCAT 2.0"
-  }, {
-    "@language" : "en",
-    "@value" : "Property added in this context in DCAT 2.0."
-  } ],
-  "http://www.w3.org/2004/02/skos/core#definition" : [ {
-    "@language" : "it",
-    "@value" : "Una risorsa correlata che fa riferimento, cita o indica in altro modo la risorsa descritta."
-  }, {
-    "@language" : "en",
-    "@value" : "A related resource that references, cites, or otherwise points to the described resource."
-  }, {
-    "@language" : "en",
-    "@value" : "In the context of DCAT 2.0, a related resource, such as a publication, that references, cites, or otherwise points to the catalogued resource."
-  }, {
-    "@language" : "cs",
-    "@value" : "V kontextu DCAT 2.0, související zdroj, např. publikace, který se odkazuje, cituje nebo jinak ukazuje na katalogizovaný zdroj."
-  }, {
-    "@language" : "it",
-    "@value" : "Nel contesto del DCAT 2.0, una risorsa correlata, come una pubblicazione, che rimanda, cita o indica in altro modo la risorsa catalogata."
-  }, {
-    "@language" : "es",
-    "@value" : "En el contexto de DCAT 2.0, un recurso relacionado, como por ejemplo una publicación, que referencia, cita, o apunta al recurso del catálogo."
-  } ],
-  "http://www.w3.org/2004/02/skos/core#scopeNote" : [ {
-    "@language" : "en",
-    "@value" : "In the context of DCAT 2.0, this property is used to associate a resource to the catalogued resource (of type dcat:Resource) in question. For other relations to resources not covered with this property, the more generic property dcat:qualifiedRelation can be used. See also the section about § 9. Qualified relations."
-  }, {
-    "@language" : "cs",
-    "@value" : "V kontextu DCAT 2.0,tato vlastnost je použita k přiřazení zdroje ke katalogizovanému zdroji (typu dcat:Resource). Pro jiné typy vztahů ke zdrojům, které nejsou touto vlastností pokryty, může být použita obecnější vlastnost dcat:qualifiedRelation. Viz také sekce 9. 'Qualified relations'."
-  }, {
-    "@language" : "en",
-    "@value" : "In the context of DCAT 2.0, in relation to the use case of data citation, when the catalogued resource is a dataset, the dct:isReferencedBy property allows to relate the dataset to the resources (such as scholarly publications) that cite or point to the dataset. Multiple dct:isReferencedBy properties can be used to indicate the dataset has been referenced by multiple publications, or other resources."
-  }, {
-    "@language" : "it",
-    "@value" : "Nel contesto di DCAT 2.0, questa proprietà viene utilizzata per associare una risorsa alla risorsa catalogata (di tipo dcat:Resource) in questione. Per le altre relazioni con risorse non coperte da questa proprietà, si può utilizzare la proprietà più generica dcat:qualifiedRelation. Si veda anche la sezione relativa al § 9. Relazioni qualificate."
-  }, {
-    "@language" : "es",
-    "@value" : "En el contexto de DCAT 2.0, esta propiedad se usa para asociar un recurso a un elemento del catálogo  (de tipo dcat:Resource). Para representar otro tipo de associaciones a recursos, se puede utilizar la propiedad más genérica dcat:qualifiedRelation. Para más detalle, ver la sección en relaciones calificadas de la especificación."
-  }, {
-    "@language" : "cs",
-    "@value" : "V kontextu DCAT 2.0, ohledně případu užití vztahujícího se k citaci dat, pokud je katalogizovaný zdroj datovou sadou, vlastnost dct:isReferencedBy umožňuje vztáhnout tuto datovou sadu ke zdroji (např. odborné publikaci) která ji cituje nebo na ni odkazuje. dct:isReferencedBy lze užít vícenásobně pro zaznamenání faktu, že datová sada byla odkazována z více publikací nebo jiných zdrojů."
-  }, {
-    "@language" : "it",
-    "@value" : "Nel contesto di DCAT 2.0, in relazione al caso d'uso della citazione dei dati, quando la risorsa catalogata è un dataset, la proprietà dct:isReferencedBy permette di mettere in relazione il dataset con le risorse (come le pubblicazioni scientifiche) che citano o puntano al dataset. Molteplici proprietà dct:isReferencedBy possono essere utilizzate per indicare che il dataset è stato referenziato da più pubblicazioni, o altre risorse."
-  }, {
-    "@language" : "es",
-    "@value" : "En el contexto de DCAT 2.0, en relación al caso de uso sobre cita de datos, cuando el recurso catalogado es un conjunto de datos, la propiedad dct:isReferencedBy permite relacionar el conjunto de datos a publicaciones que citan o apuntan al conjunto de datos. Se pueden utilizar múltiples propiedades dct:isReferencedBy para indicar que el conjunto de datos se ha referenciado en múltiples publicaciones u otros recursos."
-  } ]
-}, {
-  "@id" : "http://purl.org/dc/terms/issued",
-  "http://www.w3.org/2004/02/skos/core#definition" : [ {
-    "@language" : "it",
-    "@value" : "Nel contesto del DCAT 2.0 dcat:Distribution, data di emissione formale (ad esempio, pubblicazione) della distribuzione."
-  }, {
-    "@language" : "es",
-    "@value" : "En el contexto de DCAT 2.0 dcat:CatalogRecord, la fecha en que lista (es decir, se registra formalmente) el conjunto de datos o servicio correspondiente en el catálogo."
-  }, {
-    "@language" : "en",
-    "@value" : "In the context of DCAT 2.0 dcat:Distribution, date of formal issuance (e.g., publication) of the distribution."
-  }, {
-    "@language" : "cs",
-    "@value" : "V kontextu DCAT 2.0 dcat:Distribution, datum formálního vydání distribuce."
-  }, {
-    "@language" : "es",
-    "@value" : "En el contexto de DCAT 2.0 dcat:Distribution, fecha de emisión formal (es decir, publicación) de la distribución."
-  }, {
-    "@language" : "it",
-    "@value" : "Data di emissione formale (ad esempio, pubblicazione) della risorsa."
-  }, {
-    "@language" : "it",
-    "@value" : "Nel contesto del DCAT 2.0 dcat:Resource, data di emissione formale (es. pubblicazione) di questo elemento."
-  }, {
-    "@language" : "cs",
-    "@value" : "V kontextu DCAT 2.0 dcat:CatalogRecord, datum zanesení datové sady nebo služby do katalogu."
-  }, {
-    "@language" : "cs",
-    "@value" : "V kontextu DCAT 2.0 dcat:Resource, datum formálního vydání položky."
-  }, {
-    "@language" : "en",
-    "@value" : "In the context of DCAT 2.0 dcat:CatalogRecord, the date of listing (i.e. formal recording) of the corresponding dataset or service in the catalog."
-  }, {
-    "@language" : "it",
-    "@value" : "Nel contesto di DCAT 2.0 dcat:CatalogRecord, la data di inserimento (cioè la registrazione formale) del corrispondente set di dati o servizio nel catalogo."
-  }, {
-    "@language" : "en",
-    "@value" : "Date of formal issuance (e.g., publication) of the resource."
-  }, {
-    "@language" : "es",
-    "@value" : "En el contexto de DCAT 2.0 dcat:Resource, fecha de emisión formal (es decir, publicación) de un ítem."
-  }, {
-    "@language" : "en",
-    "@value" : "In the context of DCAT 2.0 dcat:Resource, date of formal issuance (e.g., publication) of the item."
-  } ],
-  "http://www.w3.org/2004/02/skos/core#scopeNote" : [ {
-    "@language" : "en",
-    "@value" : "In the context of DCAT 2.0, this property SHOULD be set using the first known date of issuance."
-  }, {
-    "@language" : "it",
-    "@value" : "Nel contesto di DCAT 2.0, questa proprietà DOVREBBE essere impostata utilizzando la prima data nota di emissione."
-  }, {
-    "@language" : "en",
-    "@value" : "In the context of DCAT 2.0 dcat:CatalogRecord, this indicates the date of listing the dataset in the catalog and not the publication date of the dataset itself."
-  }, {
-    "@language" : "es",
-    "@value" : "En el contexto de DCAT 2.0 dcat:CatalogRecord, indica la fecha en que se lista el conjunto de datos en el catálogo, y no la fecha de publicación del propio conjunto de datos."
-  }, {
-    "@language" : "es",
-    "@value" : "En el contexto de DCAT 2.0, esta propiedad DEBERÍA incluir como valor la primer fecha de emisión."
-  }, {
-    "@language" : "cs",
-    "@value" : "V kontextu DCAT 2.0 dcat:CatalogRecord, tato vlastnost indikuje datum zanesení datové sady do katalogu a ne datum vydání datové sady samotné."
-  }, {
-    "@language" : "cs",
-    "@value" : "V kontextu DCAT 2.0, tato vlastnost BY MĚLA obsahovat první známé datum vydání."
-  } ]
-}, {
-  "@id" : "http://purl.org/dc/terms/language",
-  "http://www.w3.org/2004/02/skos/core#definition" : [ {
-    "@language" : "en",
-    "@value" : "A language of the resource."
-  }, {
-    "@language" : "es",
-    "@value" : "En el contexto de DCAT 2.0, el idioma del ítem. Este se refiere al lenguaje natural que se usa para los metadatos textuales (es decir, títulos, descripciones, etc) de un recurso catalogado (como ser un conjunto o servicio de datos) o los valores textuales de las distribuciones de un conjunto de datos."
-  }, {
-    "@language" : "it",
-    "@value" : "Nel contesto del DCAT 2.0, una lingua dell'elemento. Si riferisce al linguaggio naturale utilizzato per i metadati testuali (titoli, descrizioni, ecc.) di una risorsa catalogata (dataset o servizio) o ai valori testuali di una distribuzione di un dataset."
-  }, {
-    "@language" : "cs",
-    "@value" : "V kontextu DCAT 2.0, jazyk položky. Tato vlastnost úvádí přirozený jazyk použitý pro textová metadata, tj. názvy, popisy apod., katalogizovaného zdroje, tj. datové sady nebo služby, nebo textový obsah distribuce datové sady."
-  }, {
-    "@language" : "en",
-    "@value" : "In the context of DCAT 2.0, a language of the item. This refers to the natural language used for textual metadata (i.e. titles, descriptions, etc) of a catalogued resource (i.e. dataset or service) or the textual values of a dataset distribution."
-  }, {
-    "@language" : "it",
-    "@value" : "Una lingua della risorsa."
-  } ],
-  "http://www.w3.org/2004/02/skos/core#scopeNote" : [ {
-    "@language" : "it",
-    "@value" : "Nel contesto del DCAT 2.0, i valori forniti per i membri di un catalogo (cioè set di dati o servizio) sostituiscono i valori forniti per il catalogo in caso di conflitto."
-  }, {
-    "@language" : "en",
-    "@value" : "In the context of DCAT 2.0, if representations of a dataset are available for each language separately, define an instance of dcat:Distribution for each language and describe the specific language of each distribution using dct:language (i.e. the dataset will have multiple dct:language values and each distribution will have just one as the value of its dct:language property)."
-  }, {
-    "@language" : "cs",
-    "@value" : "V kontextu DCAT 2.0, pokud jsou reprezentace datové sady k dispozici pro každý jazyk zvlášť, definujte pro každý jazyk jednu instanci dcat:Distribution a popište jazyk dané distribuce pomocí dct:language. (tj. datová sada bude mít více hodnot dct:language a každá distribuce bude mít pouze jednu hodnotu její vlastnosti dct:language)."
-  }, {
-    "@language" : "es",
-    "@value" : "En el contexto de DCAT 2.0, repetir esta propiedad si el recurso está disponible un múltiples idiomas."
-  }, {
-    "@language" : "en",
-    "@value" : "In the context of DCAT 2.0, repeat this property if the resource is available in multiple languages."
-  }, {
-    "@language" : "it",
-    "@value" : "Nel contesto di DCAT 2.0, ripetere questa proprietà se la risorsa è disponibile in più lingue."
-  }, {
-    "@language" : "en",
-    "@value" : "In the context of DCAT 2.0, the value(s) provided for members of a catalog (i.e. dataset or service) override the value(s) provided for the catalog if they conflict."
-  }, {
-    "@language" : "cs",
-    "@value" : "V kontextu DCAT 2.0, tuto vlastnost opakujte, pokud je zdroj k dispozici ve více jazycích."
-  }, {
-    "@language" : "it",
-    "@value" : "Nel contesto di DCAT 2.0, se le rappresentazioni di un dataset sono disponibili separatamente per ogni lingua, definire un'istanza di dcat:Distribution per ogni lingua e descrivere la lingua specifica di ogni distribuzione usando dct:language (cioè il dataset avrà valori multipli di dct:language e ogni distribuzione avrà uno solo come valore della sua proprietà dct:language)."
-  }, {
-    "@language" : "es",
-    "@value" : "En el contexto de DCAT 2.0, en el caso de conflictos, el valor (o los valores) datos para miembros del catálogo (es decir, conjunto de datos o servicios) sobreescribe el valor (o los valores) dados apra el catálogo."
-  }, {
-    "@language" : "es",
-    "@value" : "En el contexto de DCAT 2.0, si las representaciones de un conjunto de datos están disponibles por separado para cada idioma, defina una instancia de dcat:Distribution para cada idioma y describa el lenguaje específico de cada distribución usando dct:language (es decir, el conjunto de datos tendrá múltiples valores para dct:language y cada distribución tendrá sólo un valor de la propiedad dct:language)."
-  }, {
-    "@language" : "cs",
-    "@value" : "V kontextu DCAT 2.0, hodnoty uvedené pro katalogizované položky, tj. datové sady či služby, mají přednost před hodnotami uvedenými pro katalog, pokud jsou ve sporu."
-  } ]
-}, {
-  "@id" : "http://purl.org/dc/terms/license",
-  "http://www.w3.org/2004/02/skos/core#definition" : [ {
-    "@language" : "en",
-    "@value" : "A legal document giving official permission to do something with the resource."
-  }, {
-    "@language" : "es",
-    "@value" : "En el contexto de DCAT 2.0 dcat:DataService, uh documento legal bajo el cuál se hace disponible el servicio."
-  }, {
-    "@language" : "es",
-    "@value" : "En el contexto de DCAT 2.0 dcat:Distribution, uh documento legal bajo el cuál se hace disponible la distribución."
-  }, {
-    "@language" : "es",
-    "@value" : "En el contexto de DCAT 2.0 dcat:Resource, uh documento legal bajo el cuál se hace disponible el recurso."
-  }, {
-    "@language" : "en",
-    "@value" : "In the context of DCAT 2.0 dcat:DataService, a legal document under which the service is made available."
-  }, {
-    "@language" : "en",
-    "@value" : "In the context of DCAT 2.0 dcat:Distribution, a legal document under which the distribution is made available."
-  }, {
-    "@language" : "en",
-    "@value" : "In the context of DCAT 2.0 dcat:Resource, a legal document under which the resource is made available."
-  }, {
-    "@language" : "it",
-    "@value" : "Nel contesto di DCAT 2.0 dcat:Distribution, un documento legale in base al quale viene resa disponibile la distribuzione."
-  }, {
-    "@language" : "it",
-    "@value" : "Nel contesto di DCAT 2.0 dcat:Resource, un documento legale in base al quale la risorsa è resa disponibile."
-  }, {
-    "@language" : "it",
-    "@value" : "Nell'ambito di DCAT 2.0 dcat:DataService, un documento legale in base al quale il servizio è reso disponibile."
-  }, {
-    "@language" : "it",
-    "@value" : "Un documento legale che dà il permesso ufficiale di fare qualcosa con la risorsa."
-  }, {
-    "@language" : "cs",
-    "@value" : "V kontextu DCAT 2.0 dcat:DataService, právní dokument popisující podmínky užití služby."
-  }, {
-    "@language" : "cs",
-    "@value" : "V kontextu DCAT 2.0 dcat:Distribution, právní dokument popisující podmínky užití distribuce."
-  }, {
-    "@language" : "cs",
-    "@value" : "V kontextu DCAT 2.0 dcat:Resource, právní dokument popisující podmínky užití zdroje."
-  } ],
-  "http://www.w3.org/2004/02/skos/core#scopeNote" : [ {
-    "@language" : "es",
-    "@value" : "En el contexto de DCAT 2.0 dcat:Resource, PUEDE proveerse información sobre licencias y derechos para el Recurso. Vea también información en la sección 'License and rights statements'."
-  }, {
-    "@language" : "es",
-    "@value" : "En el contexto de DCAT 2.0, la información sobre licencias y derechos DEBERÍA darse a nivel de la Distribución. La información sobre licencias y derechos PUEDE proveerse también para un conjunto de datos pero no en lugar de la información para la distribución del conjunto de datos. Se DEBERÍA evitar dar información de licencia o derechos para un conjunto de datos que es diferente de la de su distribución ya que en este caso puede haber conflictos legales. Ver más información en la sección 'License and rights statements'."
-  }, {
-    "@language" : "en",
-    "@value" : "In the context of DCAT 2.0 dcat:Resource, information about licenses and rights MAY be provided for the Resource. See also guidance in the section 'License and rights statements'."
-  }, {
-    "@language" : "en",
-    "@value" : "In the context of DCAT 2.0, information about licenses and rights SHOULD be provided on the level of Distribution. Information about licenses and rights MAY be provided for a Dataset in addition to but not instead of the information provided for the Distributions of that Dataset. Providing license or rights information for a Dataset that is different from information provided for a Distribution of that Dataset SHOULD be avoided as this can create legal conflicts. See also guidance in the section 'License and rights statements'."
-  }, {
-    "@language" : "it",
-    "@value" : "Nel contesto di DCAT 2.0 dcat:Resource, le informazioni sulle licenze e i diritti POSSONO essere fornite per la risorsa. Si veda anche la guida nella sezione 'Licenze e dichiarazioni dei diritti'."
-  }, {
-    "@language" : "it",
-    "@value" : "Nell'ambito del DCAT 2.0, le informazioni su licenze e diritti dovrebbero essere fornite a livello di distribuzione. Le informazioni su licenze e diritti POSSONO essere fornite per un set di dati in aggiunta ma non in alternativa alle informazioni fornite per le distribuzioni di tale set di dati. La fornitura di informazioni sulla licenza o sui diritti per un set di dati che è diverso dalle informazioni fornite per una distribuzione di quel set di dati DOVREBBBE essere evitato in quanto ciò può creare conflitti legali. Si veda anche la guida nella sezione 'Licenze e dichiarazioni dei diritti'."
-  }, {
-    "@language" : "cs",
-    "@value" : "V kontextu DCAT 2.0 dcat:Resource, pro Zdroj MŮŽE BÝT uvedena informace o podmínkách užití (licencích a právech). Viz návod v sekci 'License and rights statements'."
-  }, {
-    "@language" : "cs",
-    "@value" : "V kontextu DCAT 2.0, informace o podmínkách užití (licencích a právech) BY MĚLY být poskytnuty na úrovni distribuce. Navíc, nikoliv místo, MOHOU BÝT informace o podmínkách užití (licencích a právech) poskytnuty na úrovni datové sady. NEMĚLY BY SE poskytnout různé podmínky užití pro datovou sadu a pro její distribuci, jelikož to může vést ke sporům v právním výkladu. Viz také návod v sekci 'License and rights statements'."
-  } ]
-}, {
-  "@id" : "http://purl.org/dc/terms/modified",
-  "http://www.w3.org/2004/02/skos/core#definition" : [ {
-    "@language" : "it",
-    "@value" : "Data in cui la risorsa è stata cambiata."
-  }, {
-    "@language" : "en",
-    "@value" : "Date on which the resource was changed."
-  }, {
-    "@language" : "es",
-    "@value" : "En el contexto de DCAT 2.0 dcat:CatalogRecord, la fecha más reciente en la que se modificó o actualizó la entrada del catálogo."
-  }, {
-    "@language" : "es",
-    "@value" : "En el contexto de DCAT 2.0 dcat:Distribution, la fecha más reciente en la que se modificó o actualizó la distribución."
-  }, {
-    "@language" : "es",
-    "@value" : "En el contexto de DCAT 2.0 dcat:Resource, la fecha más reciente en la que se modificó o actualizó el ítem del catálogo."
-  }, {
-    "@language" : "en",
-    "@value" : "In the context of DCAT 2.0 dcat:CatalogRecord, most recent date on which the catalog entry was changed, updated or modified."
-  }, {
-    "@language" : "en",
-    "@value" : "In the context of DCAT 2.0 dcat:Distribution, most recent date on which the distribution  was changed, updated or modified."
-  }, {
-    "@language" : "en",
-    "@value" : "In the context of DCAT 2.0 dcat:Resource, most recent date on which the item was changed, updated or modified."
-  }, {
-    "@language" : "it",
-    "@value" : "Nel contesto di DCAT 2.0 dcat:CatalogRecord, la data più recente in cui la voce di catalogo è stata cambiata, aggiornata o modificata."
-  }, {
-    "@language" : "it",
-    "@value" : "Nel contesto di DCAT 2.0 dcat:Distribution, la data più recente in cui la distribuzione è stata cambiata, aggiornata o modificata."
-  }, {
-    "@language" : "it",
-    "@value" : "Nel contesto di DCAT 2.0 dcat:Resource, la data più recente in cui l'elemento è stato cambiato, aggiornato o modificato."
-  }, {
-    "@language" : "cs",
-    "@value" : "V kontextu DCAT 2.0 dcat:CatalogRecord, poslední datum kdy byl katalogizační záznam změněn či aktualizován."
-  }, {
-    "@language" : "cs",
-    "@value" : "V kontextu DCAT 2.0 dcat:Distribution, poslední datum kdy byla distribuce změněna či aktualizována."
-  }, {
-    "@language" : "cs",
-    "@value" : "V kontextu DCAT 2.0 dcat:Resource, poslední datum kdy byla položka změněna či aktualizována."
-  } ],
-  "http://www.w3.org/2004/02/skos/core#scopeNote" : [ {
-    "@language" : "es",
-    "@value" : "En el contexto de DCAT 2.0 dcat:CatalogRecord, indica la fecha en que se hizo la última modificación a la entrada del catálogo, es decir, de los metadatos en el catálogo sobre el conjunto de datos, y no sobre el mismo conjunto de datos."
-  }, {
-    "@language" : "es",
-    "@value" : "En el contexto de DCAT 2.0 dcat:Resource, el valor de esta propiedad indica un cambio del ítem, no un cambio en el registro del catálogo. La ausencia de valor PUEDE indicar que el ítem nunca se modificó después de su publicación inicial, o que no se conoce la fecha de su última modificación, o que el ítem se actualiza contínuamente."
-  }, {
-    "@language" : "en",
-    "@value" : "In the context of DCAT 2.0 dcat:CatalogRecord, this indicates the date of last change of a catalog entry, i.e. the catalog metadata description of the dataset, and not the date of the dataset itself."
-  }, {
-    "@language" : "en",
-    "@value" : "In the context of DCAT 2.0 dcat:Resource, the value of this property indicates a change to the actual item, not a change to the catalog record. An absent value MAY indicate that the item has never changed after its initial publication, or that the date of last modification is not known, or that the item is continuously updated."
-  }, {
-    "@language" : "it",
-    "@value" : "Nel contesto di DCAT 2.0 dcat:CatalogRecord, indica la data dell'ultima modifica di una voce di catalogo, cioè la descrizione dei metadati di catalogo del dataset, e non la data del dataset stesso."
-  }, {
-    "@language" : "it",
-    "@value" : "Nel contesto di DCAT 2.0 dcat:Resource, il valore di questa proprietà indica una modifica all'elemento effettivo, non una modifica al record del catalogo. Un valore assente PUÒ indicare che l'articolo non è mai cambiato dopo la sua pubblicazione iniziale, o che la data dell'ultima modifica non è nota, o che l'articolo viene continuamente aggiornato."
-  }, {
-    "@language" : "cs",
-    "@value" : "V kontextu DCAT 2.0 dcat:CatalogRecord, tato vlastnost indikuje datum poslední změny katalogizačního záznamu, nikoliv datum změny datové sady samotné."
-  }, {
-    "@language" : "cs",
-    "@value" : "V kontextu DCAT 2.0 dcat:Resource, hodnota této vlastnosti udává změnu položky, nikoliv změnu jejího katalogizačního záznamu. Pokud hodnota chybí, MŮŽE to znamenat, že po publikaci položka již nebyla měněna, že datum změny není známo, nebo že je položka aktualizována neustále."
-  } ]
-}, {
-  "@id" : "http://purl.org/dc/terms/publisher",
-  "http://www.w3.org/2004/02/skos/core#definition" : [ {
-    "@language" : "it",
-    "@value" : "Un'entità responsabile della messa a disposizione della risorsa."
-  }, {
-    "@language" : "es",
-    "@value" : "En el contexto de DCAT 2.0, la entidad responsable de hacer el item disponible."
-  }, {
-    "@language" : "cs",
-    "@value" : "V kontextu DCAT 2.0, entita zodpovědná za zpřístupnění položky."
-  }, {
-    "@language" : "en",
-    "@value" : "An entity responsible for making the resource available."
-  }, {
-    "@language" : "it",
-    "@value" : "Nell'ambito del DCAT 2.0, l'entità responsabile della messa a disposizione dell'elemento."
-  }, {
-    "@language" : "en",
-    "@value" : "In the context of DCAT 2.0, the entity responsible for making the item available."
-  } ],
-  "http://www.w3.org/2004/02/skos/core#scopeNote" : [ {
-    "@language" : "cs",
-    "@value" : "V kontextu DCAT 2.0, doporučovanou hodnotou této vlastnosti jsou zdroje typu foaf:Agent."
-  }, {
-    "@language" : "es",
-    "@value" : "En el contexto de DCAT 2.0, se recomienda usar recursos del tipo foaf:Agent para los valores de esta propiedad."
-  }, {
-    "@language" : "it",
-    "@value" : "Nel contesto di DCAT 2.0, si raccomandano risorse di tipo foaf:Agent come valori per questa proprietà."
-  }, {
-    "@language" : "en",
-    "@value" : "In the context of DCAT 2.0, resources of type foaf:Agent are recommended as values for this property."
-  } ]
-}, {
-  "@id" : "http://purl.org/dc/terms/relation",
-  "@type" : [ "http://www.w3.org/2002/07/owl#ObjectProperty" ],
-  "http://www.w3.org/2004/02/skos/core#definition" : [ {
-    "@language" : "en",
-    "@value" : "A related resource."
-  }, {
-    "@language" : "es",
-    "@value" : "En el contexto de DCAT 2.0 dcat:Relationship, el recurso relacionado con el recurso que se está describiendo."
-  }, {
-    "@language" : "es",
-    "@value" : "En el contexto de DCAT 2.0 dcat:Resource, un recurso con una relación no especificada con el recurso catalogado que se está describiendo."
-  }, {
-    "@language" : "en",
-    "@value" : "In the context of DCAT 2.0 dcat:Relationship, the resource related to the source resource."
-  }, {
-    "@language" : "en",
-    "@value" : "In the context of DCAT 2.0 dcat:Resource, a resource with an unspecified relationship to the catalogued item."
-  }, {
-    "@language" : "it",
-    "@value" : "Nel contesto di DCAT 2.0 dcat:Relationship, la risorsa relativa alla risorsa di origine."
-  }, {
-    "@language" : "it",
-    "@value" : "Nel contesto di DCAT 2.0 dcat:Resource, una risorsa con una relazione non specificata con l'elemento catalogato."
-  }, {
-    "@language" : "it",
-    "@value" : "Una risorsa correlata."
-  }, {
-    "@language" : "cs",
-    "@value" : "V kontextu DCAT 2.0 dcat:Relationship, Zdroj ve vztahu se popisovaným zdrojem."
-  }, {
-    "@language" : "cs",
-    "@value" : "V kontextu DCAT 2.0 dcat:Resource, Zdroj s nespecifikovaným vztahem ke katalogizované položce."
-  } ],
-  "http://www.w3.org/2004/02/skos/core#scopeNote" : [ {
-    "@language" : "en",
-    "@value" : "In the context of DCAT 2.0, dct:relation SHOULD be used where the nature of the relationship between a catalogued item and related resources is not known. A more specific sub-property SHOULD be used if the nature of the relationship of the link is known. The property dcat:distribution SHOULD be used to link from a dcat:Dataset to a representation of the dataset, described as a dcat:Distribution."
-  }, {
-    "@language" : "en",
-    "@value" : "In the context of DCAT 2.0, see also: Sub-properties of dct:relation in particular dcat:distribution, dct:hasPart, dct:isPartOf, dct:conformsTo, dct:isFormatOf, dct:hasFormat, dct:isVersionOf, dct:hasVersion, dct:replaces, dct:isReplacedBy, dct:references, dct:isReferencedBy, dct:requires, dct:isRequiredBy."
-  }, {
-    "@language" : "en",
-    "@value" : "In the context of a DCAT 2.0 dcat:Relationship this is expected to point to another dcat:Dataset or other catalogued resource."
-  }, {
-    "@language" : "it",
-    "@value" : "Nel contesto del DCAT 2.0, vedi anche: le sottoproprietà di dct:relation in particolare dct:hasPart, dct:hasPart, dct:isPartOf, dct:isPartOf, dct:isFormatOf, dct:isFormat, dct:isVersionOf, dct:hasVersion, dct:hasVersion, dct:replaces, dct:isReplacedBy, dct:references, dct:isReferencedBy, dct:requires, dct:isRequiredBy."
-  }, {
-    "@language" : "it",
-    "@value" : "Nel contesto di DCAT 2.0, dct:relation DOVREBBE essere utilizzato quando la natura della relazione tra un articolo catalogato e le risorse correlate non è nota. Una sottoproprietà più specifica DOVREBBE essere utilizzata se la natura della relazione del collegamento è nota. La proprietà dcat:distribution DEVE essere usata per collegare da un dcat:Dataset ad una rappresentazione del dataset, descritto come dcat:Distribution."
-  }, {
-    "@language" : "it",
-    "@value" : "Nel contesto di un DCAT 2.0, dcat:Relationship ci si aspetta che punti ad un altro dcat:Dataset o altra risorsa catalogata."
-  }, {
-    "@language" : "cs",
-    "@value" : "V kontextu DCAT 2.0 dcat:Relationship se očekává, že tato vlastnost bude ukazovat na jiný dcat:Dataset nebo jiný katalogizovaný zdroj."
-  }, {
-    "@language" : "cs",
-    "@value" : "V kontextu DCAT 2.0, dct:relation BY MĚLA být použita tam, kde není znám typ vztahu mezi katalogizovanou položkou a vztaženým zdrojem. Pokud typ vztahu znám je, MĚLA BY být použita konkrétnější podvlastnost. Pro propojení datové sady dcat:Dataset a reprezentaci datové sady dcat:Distribution BY MĚLA BÝT použita vlastnost dcat:distribution."
-  }, {
-    "@language" : "cs",
-    "@value" : "V kontextu DCAT 2.0, viz také: Podvlastnosti dct:relation, zejména dcat:distribution, dct:hasPart, dct:isPartOf, dct:conformsTo, dct:isFormatOf, dct:hasFormat, dct:isVersionOf, dct:hasVersion, dct:replaces, dct:isReplacedBy, dct:references, dct:isReferencedBy, dct:requires, dct:isRequiredBy."
-  } ]
-}, {
-  "@id" : "http://purl.org/dc/terms/rights",
-  "http://www.w3.org/2004/02/skos/core#definition" : [ {
-    "@language" : "es",
-    "@value" : "En el contexto de DCAT 2.0 dcat:Resource, una declaración que tiene que ver con todos los derechos no representados con dct:license o dct:accessRights, como por ejemplo declaraciones de derechos de autor."
-  }, {
-    "@language" : "en",
-    "@value" : "In the context of DCAT 2.0 dcat:Distribution, information about rights held in and over the distribution."
-  }, {
-    "@language" : "cs",
-    "@value" : "V kontextu DCAT 2.0 dcat:Distribution, informace o právech vztahujících se na distribuci."
-  }, {
-    "@language" : "cs",
-    "@value" : "V kontextu DCAT 2.0 dcat:Resource, dokument zabývající se všemi právy, které nejsou ošetřeny v dct:license či dct:rights, jako je například copyright."
-  }, {
-    "@language" : "en",
-    "@value" : "In the context of DCAT 2.0 dcat:Resource, a statement that concerns all rights not addressed with dct:license or dct:accessRights, such as copyright statements."
-  }, {
-    "@language" : "en",
-    "@value" : "Information about rights held in and over the resource."
-  }, {
-    "@language" : "it",
-    "@value" : "Informazioni sui diritti inerenti alla risorsa e su di essa."
-  }, {
-    "@language" : "es",
-    "@value" : "En el contexto de DCAT 2.0 dcat:Distribution, información sobre los derechos mantenido por las distribuciones."
-  }, {
-    "@language" : "it",
-    "@value" : "Nel contesto di DCAT 2.0 dcat:Resource, una dichiarazione che riguarda tutti i diritti non trattati con dct:license o dct:accessRights, come le dichiarazioni di copyright."
-  }, {
-    "@language" : "it",
-    "@value" : "Nel contesto di DCAT 2.0 dcat:Distribution, informazioni sui diritti relativi alla distribuzione."
-  } ],
-  "http://www.w3.org/2004/02/skos/core#scopeNote" : [ {
-    "@language" : "en",
-    "@value" : "In the context of DCAT 2.0 dcat:Distribution, dct:license, which is a sub-property of dct:rights, can be used to link a distribution to a license document. However, dct:rights allows linking to a rights statement that can include licensing information as well as other information that supplements the license such as attribution. Information about licenses and rights SHOULD be provided on the level of Distribution. Information about licenses and rights MAY be provided for a Dataset in addition to but not instead of the information provided for the Distributions of that Dataset. Providing license or rights information for a Dataset that is different from information provided for a Distribution of that Dataset SHOULD be avoided as this can create legal conflicts. See also guidance in the secion on 'License and rights statements'."
-  }, {
-    "@language" : "cs",
-    "@value" : "V kontextu DCAT 2.0 dcat:Distribution, dct:license, což je podvlastnost dct:rights, může být použita k propojení distribuce a licenčního dokumentu. dct:rights ale umožňuje odkazovat na podmínky užití, které také mohou obsahovat licenční informace, které mohou licenci upřesňovat například nutností citace. Informace o podmínkách užití (licencích a právech) BY MĚLY být poskytnuty na úrovni distribuce. Navíc, nikoliv místo, MOHOU BÝT informace o podmínkách užití (licencích a právech) poskytnuty na úrovni datové sady. NEMĚLY BY SE poskytnout různé podmínky užití pro datovou sadu a pro její distribuci, jelikož to může vést ke sporům v právním výkladu. Viz také návod v sekci 'License and rights statements'."
-  }, {
-    "@language" : "cs",
-    "@value" : "V kontextu DCAT 2.0, pro Zdroj MŮŽE BÝT uvedena informace o podmínkách užití (licencích a právech). Viz návod v sekci 'License and rights statements'."
-  }, {
-    "@language" : "es",
-    "@value" : "En el contexto de DCAT 2.0 dcat:Distribution, dct:license, que es una sub-propertiedad de dct:rights, puede usarse para asociar una distribución a un documento de licencia. Sin embargo, dct:rights permite asociar a una declaración de derechos que incluya información de licencias así como también otra información que suplementa la licencia, como atribución. La información sobre las licencias y derechos DEBERÍA proveerse a nivel de la Distribución. La información sobre licencias y derechos PUEDE proveerse también para un conjunto de datos pero no en lugar de la información provista para las Distribuciones del conjunto de datos. Se DEBERÍA evitar brindar información sobre licencias y derechos de un conjunto de datos que difiere de aquella de la Distribución del conjunto de datos ya que se crean conflictos legales. Ver también la sección 'License and rights statements' para más información."
-  }, {
-    "@language" : "es",
-    "@value" : "En el contexto de DCAT 2.0, información sobre licencias y derechos PUEDE proveerse para un Recurso. Ver también la sección 'License and rights statements' para más información."
-  }, {
-    "@language" : "it",
-    "@value" : "Nel contesto di DCAT 2.0 dcat:Distribution, dct:license, che è una sottoproprietà di dct:rights, può essere utilizzata per collegare una distribuzione ad un documento di licenza. Tuttavia, dct:rights permette il collegamento ad una definizione dei diritti che può includere informazioni sulla licenza e altre informazioni che integrano la licenza, come l'attribuzione. Le informazioni su licenze e diritti DEVONO essere fornite a livello di distribuzione. Inoltre,  le informazioni su licenze e diritti POSSONO essere fornite per un set di dati  ma non al posto delle informazioni fornite per le distribuzioni di quel set di dati. La fornitura di informazioni sulla licenza o sui diritti per un set di dati diverso dalle informazioni fornite per una distribuzione di quel set di dati DOVREBBBE essere evitata in quanto ciò può creare conflitti legali. Si veda anche la guida nella sezione 'Licenze e dichiarazioni sui diritti'."
-  }, {
-    "@language" : "it",
-    "@value" : "Nell'ambito del DCAT 2.0, possono essere fornite informazioni su licenze e diritti per la risorsa. Si veda anche la guida nella sezione 'Licenze e dichiarazioni sui diritti'."
-  }, {
-    "@language" : "en",
-    "@value" : "In the context of DCAT 2.0, information about licenses and rights MAY be provided for the Resource. See also guidance in the section 'License and rights statements'."
-  } ]
-}, {
-  "@id" : "http://purl.org/dc/terms/spatial",
-  "http://www.w3.org/2004/02/skos/core#definition" : [ {
-    "@language" : "en",
-    "@value" : "In the context of DCAT 2.0 dcat:Dataset, the geographical area covered by the dataset."
-  }, {
-    "@language" : "cs",
-    "@value" : "V kontextu DCAT 2.0 dcat:Dataset, geografické území pokryté datovou sadou."
-  }, {
-    "@language" : "it",
-    "@value" : "Nel contesto di DCAT 2.0 dcat:Dataset, l'area geografica coperta dal set di dati."
-  }, {
-    "@language" : "it",
-    "@value" : "Caratteristiche spaziali della risorsa."
-  }, {
-    "@language" : "es",
-    "@value" : "En el contexto de DCAT 2.0 dcat:Dataset, el área geográfica cubierta por el conjunto de datos."
-  }, {
-    "@language" : "en",
-    "@value" : "Spatial characteristics of the resource."
-  } ],
-  "http://www.w3.org/2004/02/skos/core#scopeNote" : [ {
-    "@language" : "en",
-    "@value" : "In the context of DCAT 2.0 dcat:Dataset, the spatial coverage of a dataset may be encoded as an instance of dct:Location, or may be indicated using a URI reference (link) to a resource describing a location. It is recommended that links are to entries in a well maintained gazetteer such as Geonames."
-  }, {
-    "@language" : "es",
-    "@value" : "En el contexto de DCAT 2.0 dcat:Dataset, la cobertura espacial de un conjunto de datos puede codificarse como una instancia de dct:Location, o puede indicarse usando una referencia URI (es decir, un enlace) a un recurso que describa la posición. Se recomienda que los enlaces sean a entradas en un diccionario geográfico bien mantenido como Geonames."
-  }, {
-    "@language" : "cs",
-    "@value" : "V kontextu DCAT 2.0 dcat:Dataset, územní pokrytí datové sady může být zaznamenáno jako instance dct:Location, nebo může být indikováno jako IRI odkazující na zdroj popisující území. Je doporučeno se odkazovat na udržovaný zdroj dat jako například Geonames."
-  }, {
-    "@language" : "it",
-    "@value" : "Nel contesto di DCAT 2.0 dcat:Dataset, la copertura spaziale di un set di dati può essere codificata come istanza di dct:Location, o può essere indicata utilizzando un riferimento URI (link) a una risorsa che descrive una locazione. Si raccomanda che i collegamenti siano a delle voci in un gazetteer ben mantenuto come Geonames."
-  } ]
-}, {
-  "@id" : "http://purl.org/dc/terms/temporal",
-  "http://www.w3.org/2004/02/skos/core#definition" : [ {
-    "@language" : "it",
-    "@value" : "Nel contesto di DCAT 2.0 dcat:Dataset, il periodo temporale coperto dal set di dati."
-  }, {
-    "@language" : "it",
-    "@value" : "Caratteristiche temporali della risorsa."
-  }, {
-    "@language" : "es",
-    "@value" : "En el contexto de DCAT 2.0 dcat:Dataset, el período temporal cubierto por el conjunto de datos."
-  }, {
-    "@language" : "cs",
-    "@value" : "V kontextu DCAT 2.0 dcat:Dataset, časové pokrytí datové sady."
-  }, {
-    "@language" : "en",
-    "@value" : "Temporal characteristics of the resource."
-  }, {
-    "@language" : "en",
-    "@value" : "In the context of DCAT 2.0 dcat:Dataset, the temporal period that the dataset covers."
-  } ],
-  "http://www.w3.org/2004/02/skos/core#scopeNote" : [ {
-    "@language" : "it",
-    "@value" : "Nel contesto di DCAT 2.0 dcat:Dataset, la copertura temporale di un dataset può essere codificata come istanza di dct:PeriodOfTime, o può essere indicata utilizzando un riferimento URI (link) ad una risorsa che descrive un periodo o intervallo di tempo."
-  }, {
-    "@language" : "es",
-    "@value" : "En el contexto de DCAT 2.0 dcat:Dataset, la cobertura temporal del conjunto de datos puede codificarse como una instancia de dct:PeriodOfTime, o puede indicarse usando una referencia URI (es decir, un enlace) a un recurso que describa el período o interválo de tiempo."
-  }, {
-    "@language" : "cs",
-    "@value" : "V kontextu DCAT 2.0 dcat:Dataset, časové pokrytí datové sady může být zaznamenáno jako instance dct:PeriodOfTime, nebo může být indikováno jako IRI odkazující na zdroj popisující či časový interval."
-  }, {
-    "@language" : "en",
-    "@value" : "In the context of DCAT 2.0 dcat:Dataset, the temporal coverage of a dataset may be encoded as an instance of dct:PeriodOfTime, or may be indicated using a URI reference (link) to a resource describing a time period or interval."
-  } ]
-}, {
-  "@id" : "http://purl.org/dc/terms/title",
-  "http://www.w3.org/2004/02/skos/core#definition" : [ {
-    "@language" : "it",
-    "@value" : "Nel contesto di DCAT 2.0 dcat:Resource, un nome dato alla elemento."
-  }, {
-    "@language" : "it",
-    "@value" : "Un nome dato alla risorsa."
-  }, {
-    "@language" : "cs",
-    "@value" : "V kontextu DCAT 2.0 dcat:Distribution, název distribuce"
-  }, {
-    "@language" : "es",
-    "@value" : "En el contexto de DCAT 2.0 dcat:Resource, un nombre o título dado al elemento del catálogo."
-  }, {
-    "@language" : "es",
-    "@value" : "En el contexto de DCAT 2.0 dcat:Distribution, un nombre o título dado a la distribución."
-  }, {
-    "@language" : "en",
-    "@value" : "In the context of DCAT 2.0 dcat:Resource, a name given to the item."
-  }, {
-    "@language" : "it",
-    "@value" : "Nel contesto di DCAT 2.0 dcat:Distribution, un nome o titolo dato alla distribuzione."
-  }, {
-    "@language" : "cs",
-    "@value" : "V kontextu DCAT 2.0 dcat:Resource, název položky"
-  }, {
-    "@language" : "en",
-    "@value" : "A name given to the resource."
-  }, {
-    "@language" : "en",
-    "@value" : "In the context of DCAT 2.0 dcat:Distribution, a name given to the distribution."
-  } ]
-}, {
-  "@id" : "http://purl.org/dc/terms/type",
-  "http://www.w3.org/2004/02/skos/core#definition" : [ {
-    "@language" : "en",
-    "@value" : "The nature or genre of the resource."
-  }, {
-    "@language" : "es",
-    "@value" : "La naturaleza, género o tipo del recurso."
-  }, {
-    "@language" : "it",
-    "@value" : "La natura o il tipo di risorsa."
-  }, {
-    "@language" : "cs",
-    "@value" : "Podstata či žánr zdroje."
-  } ],
-  "http://www.w3.org/2004/02/skos/core#scopeNote" : [ {
-    "@language" : "es",
-    "@value" : "En el contexto de DCAT 2.0, el valor DEBERÍA tomarse de un vocabulario controlado bien gobernado y ampliamente reconocido, como por ejemplo: 1. DCMI Type vocabulary [DCTERMS]; 2. códigos de alcance de ISO 19115 [ISO-19115-1]; 3. tipos de recursos de Datacite [DataCite]; 4. tipos de contenido de PARSE.Insight usados por re3data.org [RE3DATA-SCHEMA] (see item 15 contentType); 5. tipos de recurso intelectual de MARC. Algunos elementos de estos vocabularios controlados son estrictamente no apropiados para conjuntos de datos o servicios de datos (por ejemplo: DCMI Type Event, PhysicalObject; ISO 19115 CollectionHardware, CollectionSession, Initiative, Sample, Repository), pero pueden usarse en este contexto para otros tipos de catálogos definidos en perfiles de DCAT o aplicaciones."
-  }, {
-    "@language" : "en",
-    "@value" : "In the context of DCAT 2.0, the value SHOULD be taken from a well governed and broadly recognised controlled vocabulary, such as: 1. DCMI Type vocabulary [DCTERMS]; 2. ISO 19115 scope codes [ISO-19115-1]; 3. Datacite resource types [DataCite]; 4. PARSE.Insight content-types used by re3data.org [RE3DATA-SCHEMA] (see item 15 contentType); 5. MARC intellectual resource types ; Some members of these controlled vocabularies are not strictly suitable for datasets or data services (e.g. DCMI Type Event, PhysicalObject; ISO 19115 CollectionHardware, CollectionSession, Initiative, Sample, Repository), but might be used in the context of other kinds of catalogs defined in DCAT profiles or applications."
-  }, {
-    "@language" : "es",
-    "@value" : "Usa el elemento dct:format para describir el formato del archivo, el medio físico, o las dimensiones del recurso."
-  }, {
-    "@language" : "cs",
-    "@value" : "Pro popis formátu souboru, fyzického média či dimenzí zdroje použijte dct:format."
-  }, {
-    "@language" : "cs",
-    "@value" : "V kontextu DCAT 2.0, hodnota BY MĚLA být z dobře řízeného a široce uznávaného slovníku, např.: 1. Slovník DCMI Type [DCTERMS]; 2. Kódy ISO 19115 [ISO-19115-1]; 3. Typy zdrojů Datacite [DataCite]; 4. Typy obsahu PARSE.Insight, které jsou používány re3data.org [RE3DATA-SCHEMA] (viz položka 15 contentType); 5. Typy duševních zdrojů MARC; Některé položky těchto slovníků nejsou zcela vhodné pro datové sady nebo datové služby (např. DCMI Type Event, PhysicalObject; ISO 19115 CollectionHardware, CollectionSession, Initiative, Sample, Repository), ale mohou být použity v kontextu jiných typů katalogů, které jsou definovány v profilech či aplikacích DCAT."
-  }, {
-    "@language" : "it",
-    "@value" : "Per descrivere il formato del file, il supporto fisico o le dimensioni della risorsa, utilizzare l'elemento dct:format."
-  }, {
-    "@language" : "en",
-    "@value" : "To describe the file format, physical medium, or dimensions of the resource, use the dct:format element."
-  }, {
-    "@language" : "it",
-    "@value" : "Il valore DOVREBBE essere tratto da un vocabolario ben governato e ampiamente riconosciuto e controllato, come ad esempio: 1. Vocabolario dei  DCMI Type [DCTERMS]; 2. Codici di scopo ISO 19115 [ISO-19115-1];  3. Tipi di risorse del Datacite [DataCite]. 4. PARSE.Insight content-type utilizzati da re3data.org [RE3DATA-SCHEMA] (vedi punto 15 contentType); 5. Tipi di risorse intellettuali del MARC. Alcuni membri di questi vocabolari controllati non sono strettamente adatti a insiemi di dati o servizi di dati (ad es. DCMI Type Event, PhysicalObject; ISO 19115 CollectionHardware, CollectionSession, Initiative, Sample, Repository), ma possono essere utilizzati nel contesto di altri tipi di cataloghi definiti in profili o applicazioni DCAT."
-  } ]
-}, {
-  "@id" : "http://schema.org/affiliation",
-  "@type" : [ "http://www.w3.org/2002/07/owl#AnnotationProperty" ]
-}, {
-  "@id" : "http://www.w3.org/2006/time#hasBeginning",
-  "http://www.w3.org/2004/02/skos/core#changeNote" : [ {
-    "@language" : "es",
-    "@value" : "Esta propiedad fue agregada en DCAT 2.0."
-  }, {
-    "@language" : "en",
-    "@value" : "Property added in this context in DCAT 2.0."
-  }, {
-    "@language" : "it",
-    "@value" : "Proprietà aggiunte in questo contesto in DCAT 2.0."
-  }, {
-    "@language" : "cs",
-    "@value" : "Vlastnost v tomto kontextu byla přidána ve verzi DCAT 2.0."
-  } ],
-  "http://www.w3.org/2004/02/skos/core#definition" : [ {
-    "@language" : "it",
-    "@value" : "Inizio di un'entità temporale."
-  }, {
-    "@language" : "en",
-    "@value" : "In the context of DCAT 2.0, beginning of a period or interval."
-  }, {
-    "@language" : "en",
-    "@value" : "Beginning of a temporal entity."
-  } ],
-  "http://www.w3.org/2004/02/skos/core#scopeNote" : [ {
-    "@language" : "cs",
-    "@value" : "V kontextu DCAT 2.0, použití vlastnosti time:hasBeginning znamená, že hodnota vlastnosti dct:temporal je instancí třídy time:TemporalEntity ze slovníku [OWL-TIME]. V tomto kontextu to může znamenat, že dct:PeriodOfTime je ekvivalentní podtřídě time:ProperInterval"
-  }, {
-    "@language" : "it",
-    "@value" : "Nel contesto di DCAT 2.0, l'uso della proprietà time:hasBeginning comporta che il valore della proprietà dct:temporal  è un membro della classe time:TemporalEntity di [OWL-TIME]. In questo contesto ciò potrebbe essere interpretato nel senso che dct:PeriodOfTime è equivalente alla sottoclasse time:ProperInterval."
-  }, {
-    "@language" : "en",
-    "@value" : "In the context of DCAT 2.0, use of the property time:hasBeginning entails that value of the dct:temporal property is a member of the time:TemporalEntity class from [OWL-TIME]. In this context this could be taken to imply that dct:PeriodOfTime is equivalent to the subclass time:ProperInterval."
-  }, {
-    "@language" : "es",
-    "@value" : "En el contexto de DCAT 2.0, el uso de la propiedad time:hasBeginning implica que el valor de la propiedad dct:temporal es un miembro de la clase time:TemporalEntity de [OWL-TIME]. En este contexto, esto puede interpretarse como que implica que dct:PeriodOfTime es equivalente a la subclase time:ProperInterval."
-  } ]
-}, {
-  "@id" : "http://www.w3.org/2006/time#hasEnd",
-  "http://www.w3.org/2004/02/skos/core#changeNote" : [ {
-    "@language" : "es",
-    "@value" : "Esta propiedad fue agregada en DCAT 2.0."
-  }, {
-    "@language" : "en",
-    "@value" : "Property added in this context in DCAT 2.0."
-  }, {
-    "@language" : "it",
-    "@value" : "Proprietà aggiunte in questo contesto in DCAT 2.0."
-  }, {
-    "@language" : "cs",
-    "@value" : "Vlastnost v tomto kontextu byla přidána ve verzi DCAT 2.0"
-  } ],
-  "http://www.w3.org/2004/02/skos/core#definition" : [ {
-    "@language" : "en",
-    "@value" : "In the context of DCAT 2.0, end of a period or interval."
-  }, {
-    "@language" : "en",
-    "@value" : "End of a temporal entity."
-  }, {
-    "@language" : "it",
-    "@value" : "Nel contesto del DCAT 2.0, fine di un periodo o intervallo."
-  }, {
-    "@language" : "it",
-    "@value" : "Fine di un'entità temporale."
-  } ],
-  "http://www.w3.org/2004/02/skos/core#scopeNote" : [ {
-    "@language" : "es",
-    "@value" : "En el contexto de DCAT 2.0, el uso de la propiedad time:hasEnd implica que el valor de la propiedad dct:temporal es un miembro de la clase time:TemporalEntity de [OWL-TIME]. En este contexto, esto puede interpretarse como que implica que dct:PeriodOfTime es equivalente a la subclase time:ProperInterval."
-  }, {
-    "@language" : "it",
-    "@value" : "Nel contesto di DCAT 2.0, l'uso della proprietà time:hasEnd comporta che il valore della proprietà dct:temporal è un membro della classe time:TemporalEntity di [OWL-TIME]. In questo contesto ciò potrebbe essere interpretato nel senso che dct:PeriodOfTime è equivalente alla sottoclasse time:ProperInterval."
-  }, {
-    "@language" : "en",
-    "@value" : "In the context of DCAT 2.0, use of the property time:hasEnd entails that value of the dct:temporal property is a member of the time:TemporalEntity class from [OWL-TIME]. In this context this could be taken to imply that dct:PeriodOfTime is equivalent to the subclass time:ProperInterval."
-  }, {
-    "@language" : "cs",
-    "@value" : "V kontextu DCAT 2.0, použití vlastnosti time:hasEnd znamená, že hodnota vlastnosti dct:temporal je instancí třídy time:TemporalEntity ze slovníku [OWL-TIME]. V tomto kontextu to může znamenat, že dct:PeriodOfTime je ekvivalentní podtřídě time:ProperInterval."
-  } ]
-}, {
-  "@id" : "http://www.w3.org/ns/dcat/external",
-  "@type" : [ "http://www.w3.org/2002/07/owl#Ontology" ],
-  "http://purl.org/dc/terms/contributor" : [ {
-    "@id" : "_:genid1"
-  }, {
-    "@id" : "_:genid3"
-  }, {
-    "@id" : "_:genid4"
-  }, {
-    "@id" : "_:genid6"
-  }, {
-    "@id" : "_:genid7"
-  }, {
-    "@id" : "_:genid8"
-  }, {
-    "@id" : "_:genid10"
-  }, {
-    "@id" : "_:genid11"
-  }, {
-    "@id" : "_:genid12"
-  }, {
-    "@id" : "_:genid13"
-  }, {
-    "@id" : "_:genid15"
-  }, {
-    "@id" : "_:genid16"
-  }, {
-    "@id" : "_:genid17"
-  }, {
-    "@id" : "_:genid18"
-  }, {
-    "@id" : "_:genid21"
-  }, {
-    "@id" : "_:genid22"
-  } ],
-  "http://purl.org/dc/terms/creator" : [ {
-    "@id" : "_:genid19"
-  }, {
-    "@id" : "_:genid20"
-  } ],
-  "http://purl.org/dc/terms/license" : [ {
-    "@id" : "https://creativecommons.org/licenses/by/4.0/"
-  } ],
-  "http://purl.org/dc/terms/modified" : [ {
-    "@type" : "http://www.w3.org/2001/XMLSchema#date",
-    "@value" : "2012-04-24"
-  }, {
-    "@type" : "http://www.w3.org/2001/XMLSchema#date",
-    "@value" : "2013-11-28"
-  }, {
-    "@type" : "http://www.w3.org/2001/XMLSchema#date",
-    "@value" : "2019-09-09"
-  }, {
-    "@type" : "http://www.w3.org/2001/XMLSchema#date",
-    "@value" : "2017-12-19"
-  }, {
-    "@type" : "http://www.w3.org/2001/XMLSchema#date",
-    "@value" : "2013-09-20"
-  } ],
-  "http://www.w3.org/2000/01/rdf-schema#comment" : [ {
-    "@language" : "en",
-    "@value" : "This RDF graph contains partial descriptions of elements from external vocabularies that are used by DCAT. The primary definitions for these terms are in the original specifications and standards. In the context of DCAT some additional axioms (sub-class and sub-property relationships) are introduced, and some more specific usage notes are added."
-  } ],
-  "http://www.w3.org/2000/01/rdf-schema#label" : [ {
-    "@language" : "en",
-    "@value" : "External terms used in the data catalog vocabulary."
-  } ],
-  "http://www.w3.org/2002/07/owl#imports" : [ {
-    "@id" : "http://www.w3.org/ns/odrl/2/"
-  }, {
-    "@id" : "http://www.w3.org/ns/prov-o#"
-  }, {
-    "@id" : "http://purl.org/dc/terms/"
-  }, {
-    "@id" : "http://www.w3.org/2004/02/skos/core"
-  } ]
-}, {
-  "@id" : "http://www.w3.org/ns/locn#geometry",
-  "@type" : [ "http://www.w3.org/2002/07/owl#ObjectProperty" ],
-  "http://www.w3.org/2000/01/rdf-schema#range" : [ {
-    "@id" : "http://www.w3.org/2000/01/rdf-schema#Literal"
-  } ],
-  "http://www.w3.org/2004/02/skos/core#changeNote" : [ {
-    "@language" : "es",
-    "@value" : "Esta propiedad fue agregada en DCAT 2.0."
-  }, {
-    "@language" : "en",
-    "@value" : "Property added in this context in DCAT 2.0."
-  }, {
-    "@language" : "it",
-    "@value" : "Proprietà aggiunta in questo contesto in DCAT 2.0."
-  }, {
-    "@language" : "cs",
-    "@value" : "Vlastnost v tomto kontextu byla přidána ve verzi DCAT 2.0."
-  } ],
-  "http://www.w3.org/2004/02/skos/core#definition" : [ {
-    "@language" : "es",
-    "@value" : "Asocia cualquier recurso con la geometría correspondiente."
-  }, {
-    "@language" : "it",
-    "@value" : "Associa qualsiasi risorsa alla geometria corrispondente."
-  }, {
-    "@language" : "en",
-    "@value" : "Associates any resource with the corresponding geometry."
-  }, {
-    "@language" : "cs",
-    "@value" : "Přiřazuje geometrii jakémukoliv zdroji."
-  } ],
-  "http://www.w3.org/2004/02/skos/core#scopeNote" : [ {
-    "@language" : "es",
-    "@value" : " el contexto de DCAT 2.0, el rango de esta propiedad es intencionalmente genérico con el propósito de permitir distintas codificaciones de la geometría. Por ejemplo, la geometría puede codificarse como WKT (geosparql:wktLiteral [GeoSPARQL])."
-  }, {
-    "@language" : "en",
-    "@value" : "In the context of DCAT 2.0, the range of this property is intentionally generic, with the purpose of allowing different geometry encodings. E.g., the geometry could be encoded as WKT (geosparql:wktLiteral [GeoSPARQL])."
-  }, {
-    "@language" : "it",
-    "@value" : "Nel contesto del DCAT 2.0, il range di questa proprietà è volutamente generico, con lo scopo di consentire diverse codifiche geometriche. Ad esempio, la geometria potrebbe essere codificata come WKT (geosparql:wktLiteral [GeoSPARQL])."
-  }, {
-    "@language" : "cs",
-    "@value" : "V kontextu DCAT 2.0, obor hodnot této vlastnosti je úmyslně obecný, aby umožnil různé kódování geometrií. Geometrie by kupříkladu mohla být kódována jako WKT (geosparql:wktLiteral [GeoSPARQL])."
-  } ]
-}, {
-  "@id" : "http://www.w3.org/ns/odrl/2/hasPolicy",
-  "http://www.w3.org/2004/02/skos/core#definition" : [ {
-    "@language" : "es",
-    "@value" : "En el contexto de DCAT 2.0 dcat:Resource, una reglamentación conforme a ODRL expresando los derechos asociados con el recurso [ODRL-VOCAB]."
-  }, {
-    "@language" : "it",
-    "@value" : "Nel contesto di DCAT 2.0 dcat:Distribution, una policy conforme all'ODRL che esprime i diritti associati alla distribuzione."
-  }, {
-    "@language" : "cs",
-    "@value" : "V kontextu DCAT 2.0 dcat:Resource, pravidlo vyjadřující práva spojená se zdrojem, pokud je použit slovník ODRL [ODRL-VOCAB]."
-  }, {
-    "@language" : "en",
-    "@value" : "Identifies an ODRL Policy for which the identified Asset is the target Asset to all the Rules."
-  }, {
-    "@language" : "it",
-    "@value" : "Nel contesto di DCAT 2.0 dcat:Resource, una policy conforme all'ODRL che esprime i diritti associati alla risorsa."
-  }, {
-    "@language" : "en",
-    "@value" : "In the context of DCAT 2.0 dcat:Resource, an ODRL conformant policy expressing the rights associated with the resource."
-  }, {
-    "@language" : "en",
-    "@value" : "In the context of DCAT 2.0 dcat:Distribution, an ODRL conformant policy expressing the rights associated with the distribution."
-  }, {
-    "@language" : "cs",
-    "@value" : "V kontextu DCAT 2.0 dcat:Distribution, pravidlo vyjadřující práva spojená s distribucí, pokud je použit slovník ODRL [ODRL-VOCAB]."
-  }, {
-    "@language" : "es",
-    "@value" : "En el contexto de DCAT 2.0 dcat:Distribution, una reglamentación conforme a ODRL expresando los derechos asociados con la distribución [ODRL-VOCAB]."
-  } ],
-  "http://www.w3.org/2004/02/skos/core#editorialNote" : [ {
-    "@language" : "en",
-    "@value" : "Czech translation to be updated."
-  } ],
-  "http://www.w3.org/2004/02/skos/core#scopeNote" : [ {
-    "@language" : "it",
-    "@value" : "Nel contesto di DCAT 2.0 dcat:Distribution, le informazioni sui diritti espressi come policy ODRL [ODRL-MODEL] utilizzando il vocabolario ODRL [ODRL-VOCAB] POSSONO essere fornite per la distribuzione. Si veda anche la guida alla sezione 'Licenza e dichiarazioni sui diritti'."
-  }, {
-    "@language" : "en",
-    "@value" : "In the context of DCAT 2.0 dcat:Resource, information about rights expressed as an ODRL policy [ODRL-MODEL] using the ODRL vocabulary [ODRL-VOCAB] MAY be provided for the resource. See also guidance at the section 'License and rights statements'."
-  }, {
-    "@language" : "en",
-    "@value" : "In the context of DCAT 2.0 dcat:Distribution, information about rights expressed as an ODRL policy [ODRL-MODEL] using the ODRL vocabulary [ODRL-VOCAB] MAY be provided for the distribution. See also guidance at the section 'License and rights statements'."
-  }, {
-    "@language" : "cs",
-    "@value" : "V kontextu DCAT 2.0 dcat:Distribution, pro distribuci MŮŽE BÝT uvedena informace o právech vyjádřená pomocí pravidel slovníku ODRL [ODRL-VOCAB]. Viz také návod v sekci 10. 'License and rights statements'."
-  }, {
-    "@language" : "it",
-    "@value" : "Nel contesto DCAT 2.0 dcat:Resource, le informazioni sui diritti espressi come policy ODRL [ODRL-MODEL] utilizzando il vocabolario ODRL [ODRL-VOCAB] POSSONO essere fornite per la risorsa. Si veda anche la guida alla sezione 'Licenza e dichiarazioni sui diritti'."
-  }, {
-    "@language" : "cs",
-    "@value" : "V kontextu DCAT 2.0 dcat:Resource, pro zdroj MŮŽE BÝT uvedena informace o právech vyjádřená pomocí pravidel slovníku ODRL [ODRL-VOCAB]. Viz také návod v sekci 'License and rights statements'."
-  }, {
-    "@language" : "es",
-    "@value" : "En el contexto de DCAT 2.0 dcat:Resource, información sobre los derechos expresados como reglamentación ODRL [ODRL-MODEL] usando el vocabulario ODRL [ODRL-VOCAB] PUEDE proveerse para el Recurso. Ver también la información en la sección 'License and rights statements'."
-  }, {
-    "@language" : "es",
-    "@value" : "En el contexto de DCAT 2.0 dcat:Distribution, información sobre los derechos expresados como reglamentación ODRL [ODRL-MODEL] using the ODRL vocabulary [ODRL-VOCAB] PUEDE proveerse para el Distribución. Ver también la información en la sección 'License and rights statements.'"
-  } ]
-}, {
-  "@id" : "http://www.w3.org/ns/prov#alternateOf",
-  "http://www.w3.org/2000/01/rdf-schema#subPropertyOf" : [ {
-    "@id" : "http://purl.org/dc/terms/relation"
-  } ]
-}, {
-  "@id" : "http://www.w3.org/ns/prov#hadPrimarySource",
-  "http://www.w3.org/2000/01/rdf-schema#subPropertyOf" : [ {
-    "@id" : "http://purl.org/dc/terms/relation"
-  } ]
-}, {
-  "@id" : "http://www.w3.org/ns/prov#qualifiedAttribution",
-  "http://www.w3.org/2004/02/skos/core#changeNote" : [ {
-    "@language" : "en",
-    "@value" : "Property added in this context in DCAT 2.0."
-  }, {
-    "@language" : "it",
-    "@value" : "Proprietà aggiunta in questo contesto in DCAT 2.0."
-  }, {
-    "@language" : "cs",
-    "@value" : "Vlastnost v tomto kontextu byla přidána ve verzi DCAT 2.0."
-  }, {
-    "@language" : "es",
-    "@value" : "Esta propiedad fue agregada en DCAT 2.0."
-  } ],
-  "http://www.w3.org/2004/02/skos/core#definition" : [ {
-    "@language" : "cs",
-    "@value" : "V kontextu DCAT 2.0, odkaz na Agenta, který má nějaký typ odpovědnosti za zdroj."
-  }, {
-    "@language" : "en",
-    "@value" : "In the context of DCAT 2.0, link to an Agent having some form of responsibility for the resource."
-  }, {
-    "@language" : "it",
-    "@value" : "Nel contesto di DCAT 2.0, collegamento a un agente che ha una qualche forma di responsabilità per la risorsa."
-  }, {
-    "@language" : "es",
-    "@value" : "En el contexto de DCAT 2.0, enlace a un Agente que tiene alguna forma de responsabilidad con el recurso."
-  } ],
-  "http://www.w3.org/2004/02/skos/core#scopeNote" : [ {
-    "@language" : "en",
-    "@value" : "In the context of DCAT 2.0, used to link to an Agent where the nature of the relationship is known but does not match one of the standard Dublin Core properties (dct:creator, dct:publisher). Use dcat:hadRole on the prov:Attribution to capture the responsibility of the Agent with respect to the Resource. See https://w3c.github.io/dxwg/dcat/#qualified-attribution for usage examples."
-  }, {
-    "@language" : "es",
-    "@value" : "En el contexto de DCAT 2.0, se usa para asociar un Agente cuando la naturaleza de la relación es conocida pero no es ninguna de las asociaciones estándares descriptas con propiedades de Dublin Core (dct:creator, dct:publisher). Se usa dcat:hadRole en la prov:Attribution para capturar la responsabilidad del Agente con respecto al Recurso. Ver https://w3c.github.io/dxwg/dcat/#qualified-attribution para más ejemplos de uso."
-  }, {
-    "@language" : "cs",
-    "@value" : "V kontextu DCAT 2.0, vlastnost se používá pro odkaz na Agenta tam, kde typ vztahu je znám, ale neodpovídá žádné ze standardních vlastností Dublin Core (dct:creator, dct:publisher). Pro reprezentaci vztahu Agenta ke zdroji použijte vlastnost dcat:hadRole na třídě prov:Attribution. Viz  https://w3c.github.io/dxwg/dcat/#qualified-attribution pro příklady užití."
-  }, {
-    "@language" : "it",
-    "@value" : "Nel contesto di DCAT 2.0, utilizzato per collegarsi a un agente in cui la natura della relazione è nota ma non corrisponde a una delle proprietà Dublin Core standard (dct: creatore, dct: editore). Si usi dcat:hadRole su prov:Attribution per rappresentare la responsabilità dell'Agente in relazione alla Risorsa. Si veda https://w3c.github.io/dxwg/dcat/#qualified-attribution per gli esempi di utilizzo."
-  } ]
-}, {
-  "@id" : "http://www.w3.org/ns/prov#specializationOf",
-  "http://www.w3.org/2000/01/rdf-schema#subPropertyOf" : [ {
-    "@id" : "http://purl.org/dc/terms/relation"
-  } ]
-}, {
-  "@id" : "http://www.w3.org/ns/prov#wasAttributedTo",
-  "http://www.w3.org/2000/01/rdf-schema#subPropertyOf" : [ {
-    "@id" : "http://purl.org/dc/terms/relation"
-  } ]
-}, {
-  "@id" : "http://www.w3.org/ns/prov#wasDerivedFrom",
-  "http://www.w3.org/2000/01/rdf-schema#subPropertyOf" : [ {
-    "@id" : "http://purl.org/dc/terms/relation"
-  } ]
-}, {
-  "@id" : "http://www.w3.org/ns/prov#wasGeneratedBy",
-  "http://www.w3.org/2000/01/rdf-schema#subPropertyOf" : [ {
-    "@id" : "http://purl.org/dc/terms/relation"
-  } ],
-  "http://www.w3.org/2004/02/skos/core#changeNote" : [ {
-    "@language" : "es",
-    "@value" : "Esta propiedad fue agregada en DCAT 2.0."
-  }, {
-    "@language" : "en",
-    "@value" : "Property added in this context in DCAT 2.0."
-  }, {
-    "@language" : "it",
-    "@value" : "Proprietà aggiunta in questo contesto in DCAT 2.0."
-  }, {
-    "@language" : "cs",
-    "@value" : "Vlastnost v tomto kontextu byla přidána ve verzi DCAT 2.0"
-  } ],
-  "http://www.w3.org/2004/02/skos/core#definition" : [ {
-    "@language" : "en",
-    "@value" : "In the context of DCAT 2.0 dcat:Dataset, an activity that generated, or provides the business context for, the creation of the dataset."
-  } ],
-  "http://www.w3.org/2004/02/skos/core#scopeNote" : [ {
-    "@language" : "es",
-    "@value" : "En el contexto de DCAT 2.0 dcat:Dataset, la actividad asociada con la generación de un conjunto de datos. Típicamente es una iniciativa, proyecto, misión, encuensta, una actividad contínua (la actividad usual) etc. Se pueden usar múltiples propiedades  prov:wasGeneratedBy para indicar el contexto de producción del conjunto de datos en disintos niveles de granularidad."
-  }, {
-    "@language" : "es",
-    "@value" : "En el contexto de DCAT 2.0 dcat:Dataset, utiliza prov:qualifiedGeneration para adjuntar detalles adicionales sobre la relación entre el conjunto de datos y la actividad activity, por ejemplo, el tiempo exacto en el que se produjo el conjunto de datose durante la vida de un proyecto."
-  }, {
-    "@language" : "en",
-    "@value" : "In the context of DCAT 2.0 dcat:Dataset, the activity associated with generation of a dataset will typically be an initiative, project, mission, survey, on-going activity ('business as usual') etc. Multiple prov:wasGeneratedBy properties can be used to indicate the dataset production context at various levels of granularity."
-  }, {
-    "@language" : "en",
-    "@value" : "In the context of DCAT 2.0 dcat:Dataset, use prov:qualifiedGeneration to attach additional details about the relationship between the dataset and the activity, e.g. the exact time that the dataset was produced during the lifetime of a project."
-  }, {
-    "@language" : "it",
-    "@value" : "Nel contesto di DCAT 2.0 dcat:Dataset, l'attività associata alla generazione di un dataset sarà tipicamente un'iniziativa, progetto, missione, indagine, attività in corso ('business as usual'), ecc. Multiple prov:wasGeneratedBy  possono essere utilizzate per indicare il contesto di produzione del dataset a vari livelli di granularità."
-  }, {
-    "@language" : "it",
-    "@value" : "Nel contesto di DCAT 2.0 dcat:Dataset, utilizzare prov:qualifiedGeneration per allegare ulteriori dettagli sulla relazione tra il dataset e l'attività, ad esempio l'ora esatta in cui il dataset è stato prodotto durante la vita di un progetto."
-  }, {
-    "@language" : "cs",
-    "@value" : "V kontextu DCAT 2.0 dcat:Dataset, aktivitou spojenou s tvorbou datové sady typicky bývá iniciativa, projekt, mise, rešerše, průběžná aktivita (běžný chod podniku) apod. Pro zaznamenání kontextu datové sady na více úrovních granulariy lze použít více hodnot vlastnosti prov:wasGeneratedBy."
-  }, {
-    "@language" : "cs",
-    "@value" : "V kontextu DCAT 2.0 dcat:Dataset, pro připojení podrobností o vztahu mezi datovou sadou a aktivitou, např. přesný čas kdy byla datová sada vyprodukována během životního cyklu projektu, použijte prov:qualifiedGeneration."
-  } ]
-}, {
-  "@id" : "http://www.w3.org/ns/prov#wasInfluencedBy",
-  "http://www.w3.org/2000/01/rdf-schema#subPropertyOf" : [ {
-    "@id" : "http://purl.org/dc/terms/relation"
-  } ]
-}, {
-  "@id" : "http://www.w3.org/ns/prov#wasQuotedFrom",
-  "http://www.w3.org/2000/01/rdf-schema#subPropertyOf" : [ {
-    "@id" : "http://purl.org/dc/terms/relation"
-  } ]
-}, {
-  "@id" : "http://www.w3.org/ns/prov#wasRevisionOf",
-  "http://www.w3.org/2000/01/rdf-schema#subPropertyOf" : [ {
-    "@id" : "http://purl.org/dc/terms/relation"
-  } ]
-}, {
-  "@id" : "http://xmlns.com/foaf/0.1/homepage",
-  "@type" : [ "http://www.w3.org/2002/07/owl#AnnotationProperty" ],
-  "http://www.w3.org/2004/02/skos/core#definition" : [ {
-    "@language" : "en",
-    "@value" : "A homepage for some thing."
-  }, {
-    "@language" : "en",
-    "@value" : "In the context of DCAT 2.0 dcat:Catalog, a homepage of the catalog (a public Web document usually available in HTML)."
-  }, {
-    "@language" : "it",
-    "@value" : "Nel contesto di DCAT 2.0 dcat:Catalog, una homepage del catalogo (un documento Web pubblico solitamente disponibile in HTML)."
-  }, {
-    "@language" : "it",
-    "@value" : "Una homepage per qualche cosa."
-  } ],
-  "http://www.w3.org/2004/02/skos/core#scopeNote" : [ {
-    "@language" : "es",
-    "@value" : "foaf:homepage es la propiedad funcional inversa (IFP por sus siglas en inglés), lo que significa que DEBE ser única y identificar la página web del recurso percisamente. En el contexto de DCAT 2.0, esta propiedad indica la página web canónica, que pude ser útil en casos en los que hay más de una página web para el recurso."
-  }, {
-    "@language" : "en",
-    "@value" : "foaf:homepage is an inverse functional property (IFP), which means that it MUST be unique and precisely identify the web-page for the resource. In the context of DCAT 2.0, this property indicates the canonical web-page, which might be helpful in cases where there is more than one web-page about the resource."
-  }, {
-    "@language" : "cs",
-    "@value" : "foaf:homepage je inverzní funkčí vlastnost, což znamená, že MUSÍ být unikátní a MUSÍ přesně označovat webovou stránku zdroje. V kontextu DCAT 2.0, označuje hlavní webovou stránku, což se může hodit v případě, že webových stránek o zdroji existuje více."
-  }, {
-    "@language" : "it",
-    "@value" : "foaf:homepage è una proprietà funzionale inversa (IFP), il che significa che DEVE essere unica e identificare con precisione la pagina web della risorsa. Nel contesto di DCAT 2.0, questa proprietà indica la pagina web canonica, che potrebbe essere utile nei casi in cui ci sia più di una pagina web sulla risorsa."
-  } ]
-}, {
-  "@id" : "http://xmlns.com/foaf/0.1/name",
-  "@type" : [ "http://www.w3.org/2002/07/owl#AnnotationProperty" ]
-}, {
-  "@id" : "http://xmlns.com/foaf/0.1/primaryTopic",
-  "http://www.w3.org/2004/02/skos/core#definition" : [ {
-    "@language" : "cs",
-    "@value" : "V kontextu DCAT 2.0 dcat:CatalogRecord, dcat:Resource (datová sada či služba) popsaná katalogizačním záznamem."
-  }, {
-    "@language" : "en",
-    "@value" : "The primary topic of some page or document."
-  }, {
-    "@language" : "es",
-    "@value" : "En el contexto de DCAT 2.0 dcat:CatalogRecord, el dcat:Resource (conjunto de datos o servicio) descripto en el registro."
-  }, {
-    "@language" : "it",
-    "@value" : "Nel contesto di DCAT 2.0 dcat:CatalogRecord, il dcat:Resource (set di dati o servizio) descritto nel record."
-  }, {
-    "@language" : "it",
-    "@value" : "L'argomento principale di qualche pagina o documento."
-  }, {
-    "@language" : "en",
-    "@value" : "In the context of DCAT 2.0 dcat:CatalogRecord, the dcat:Resource (dataset or service) described in the record."
-  } ],
-  "http://www.w3.org/2004/02/skos/core#scopeNote" : [ {
-    "@language" : "it",
-    "@value" : "foaf:primaryTopic property è funzionale: nel contesto di DCAT 2.0, ogni record di catalogo può avere al massimo un argomento primario, cioè descrive un set di dati o un servizio."
-  }, {
-    "@language" : "cs",
-    "@value" : "Vlastnost foaf:primaryTopic je funkce: v kontextu DCAT 2.0, každý katalogizační záznam může mít nejvýše jednu hodnotu foaf:primaryTopic, tj. popisuje nejvýše jednu datovou sadu či službu."
-  }, {
-    "@language" : "es",
-    "@value" : "La propiedad foaf:primaryTopic es funcional: en el contexto de DCAT 2.0,  cada registro del catálogo puede tener a lo sumo un tópico principal, es decir un tópico que describa el conjunto de datos o servicio."
-  }, {
-    "@language" : "en",
-    "@value" : "foaf:primaryTopic property is functional: in the context of DCAT 2.0, each catalog record can have at most one primary topic i.e. describes one dataset or service."
-  } ]
-}, {
-  "@id" : "http://xmlns.com/foaf/0.1/workInfoHomepage",
-  "@type" : [ "http://www.w3.org/2002/07/owl#AnnotationProperty" ]
-} ]
+{
+  "@graph" : [ {
+    "@id" : "_:b0",
+    "homepage" : "https://csiro.au",
+    "foaf:name" : "Commonwealth Scientific and Industrial Research Organisation"
+  }, {
+    "@id" : "_:b1",
+    "foaf:name" : "Richard Cyganiak"
+  }, {
+    "@id" : "_:b10",
+    "@type" : "foaf:Person",
+    "affiliation" : "_:b0",
+    "seeAlso" : "https://orcid.org/0000-0002-3884-3420",
+    "foaf:name" : "Simon J D Cox",
+    "workInfoHomepage" : "http://people.csiro.au/Simon-Cox"
+  }, {
+    "@id" : "_:b11",
+    "affiliation" : "_:b22",
+    "foaf:name" : "David Browning"
+  }, {
+    "@id" : "_:b12",
+    "seeAlso" : "http://www.eurecom.fr/~atemezin/gatemezing-foaf.rdf",
+    "foaf:name" : "Ghislain Auguste Atemezing"
+  }, {
+    "@id" : "_:b13",
+    "seeAlso" : "https://orcid.org/0000-0001-9300-2694",
+    "homepage" : "http://www.andrea-perego.name/foaf/#me",
+    "foaf:name" : "Andrea Perego"
+  }, {
+    "@id" : "_:b14",
+    "affiliation" : "_:b21",
+    "foaf:name" : "Rufus Pollock"
+  }, {
+    "@id" : "_:b15",
+    "seeAlso" : "https://jakub.klímek.com/#me",
+    "homepage" : "https://jakub.klímek.com/",
+    "foaf:name" : "Jakub Klímek"
+  }, {
+    "@id" : "_:b16",
+    "seeAlso" : "https://orcid.org/0000-0001-5648-2713",
+    "homepage" : [ "https://w3id.org/people/ralbertoni/", "http://www.imati.cnr.it/index.php/people/8-curricula/178-riccardo-albertoni" ],
+    "foaf:name" : "Riccardo Albertoni"
+  }, {
+    "@id" : "_:b17",
+    "seeAlso" : "http://makxdekkers.com/makxdekkers.rdf#me",
+    "homepage" : "http://makxdekkers.com/",
+    "foaf:name" : "Makx Dekkers"
+  }, {
+    "@id" : "_:b18",
+    "affiliation" : "_:b20",
+    "seeAlso" : "https://orcid.org/0000-0003-3499-8262",
+    "homepage" : "https://agbeltran.github.io",
+    "foaf:name" : "Alejandra Gonzalez-Beltran"
+  }, {
+    "@id" : "_:b19",
+    "homepage" : "http://ec.europa.eu/dgs/informatics/",
+    "foaf:name" : "European Commission, DG DIGIT"
+  }, {
+    "@id" : "_:b2",
+    "seeAlso" : "http://fadmaa.me/foaf.ttl",
+    "foaf:name" : "Fadi Maali"
+  }, {
+    "@id" : "_:b20",
+    "homepage" : "http://stfc.ac.uk",
+    "foaf:name" : "Science and Technology Facilities Council, UK"
+  }, {
+    "@id" : "_:b21",
+    "homepage" : "http://okfn.org",
+    "foaf:name" : "Open Knowledge Foundation"
+  }, {
+    "@id" : "_:b22",
+    "homepage" : "http://www.refinitiv.com",
+    "foaf:name" : "Refinitiv"
+  }, {
+    "@id" : "_:b3",
+    "foaf:name" : "Marios Meimaris"
+  }, {
+    "@id" : "_:b4",
+    "foaf:name" : "Boris Villazón-Terrazas"
+  }, {
+    "@id" : "_:b5",
+    "foaf:name" : "John Erickson"
+  }, {
+    "@id" : "_:b6",
+    "affiliation" : "http://www.w3.org/data#W3C",
+    "seeAlso" : "http://philarcher.org/foaf.rdf#me",
+    "homepage" : "http://www.w3.org/People/all#phila",
+    "foaf:name" : "Phil Archer"
+  }, {
+    "@id" : "_:b7",
+    "affiliation" : "_:b19",
+    "foaf:name" : "Vassilios Peristeras"
+  }, {
+    "@id" : "_:b8",
+    "homepage" : "http://www.asahi-net.or.jp/~ax2s-kmtn/",
+    "foaf:name" : "Shuji Kamitsuna"
+  }, {
+    "@id" : "_:b9",
+    "foaf:name" : "Martin Alvarez-Espinar"
+  }, {
+    "@id" : "dct:Location",
+    "skos:changeNote" : [ {
+      "@language" : "es",
+      "@value" : "Esta clase se agregó en este contexto en DCAT 2.0."
+    }, {
+      "@language" : "en",
+      "@value" : "Class added in this context in DCAT 2.0."
+    }, {
+      "@language" : "cs",
+      "@value" : "Třída v tomto kontextu byla přidána ve verzi DCAT 2.0."
+    }, {
+      "@language" : "it",
+      "@value" : "Classe aggiunta in questo contesto in DCAT 2.0."
+    } ],
+    "skos:definition" : [ {
+      "@language" : "en",
+      "@value" : "A spatial region or named place."
+    }, {
+      "@language" : "es",
+      "@value" : "Una región espacial o un lugar con nombre."
+    }, {
+      "@language" : "cs",
+      "@value" : "Prostorová oblast či pojmenované místo."
+    }, {
+      "@language" : "it",
+      "@value" : "Una regione spaziale o un luogo designato."
+    } ],
+    "skos:scopeNote" : [ {
+      "@language" : "en",
+      "@value" : "In the context of DCAT 2.0, for the geographic center of a spatial area, or another characteristic point, the property dcat:centroid SHOULD be used."
+    }, {
+      "@language" : "en",
+      "@value" : "In the context of DCAT 2.0, for an extensive geometry (i.e., a set of coordinates denoting the vertices of the relevant geographic area), the property locn:geometry [[LOCN]] SHOULD be used."
+    }, {
+      "@language" : "es",
+      "@value" : "En el contexto de DCAT 2.0, para el centro geográfico de un área espacial, o algún otro punto característico, se DEBE usar la propriedad dcat:centroid."
+    }, {
+      "@language" : "es",
+      "@value" : "En el contexto de DCAT 2.0, para un cuadro delimitador geográfico que delimita un área espacial se DEBE usar la propiedad dcat:bbox."
+    }, {
+      "@language" : "cs",
+      "@value" : "En el contexto de DCAT 2.0, pro geografický rámec ohraničující prostorové oblasti BY MĚLA být použita vlastnost dcat:bbox."
+    }, {
+      "@language" : "es",
+      "@value" : "En el contexto de DCAT 2.0, para una geometría extensiva (es decir, un conjunto de coordinadas que denotan los vértices de un área geográfica), DEBE usarse la propiedad locn:geometry [[LOCN]]."
+    }, {
+      "@language" : "it",
+      "@value" : "Nel contesto del DCAT 2.0, per una geometria estesa (cioè, un insieme di coordinate che indicano i vertici dell'area geografica rilevante), si DOVREBBE usare la  proprietà locn:geometry [[LOCN]]."
+    }, {
+      "@language" : "it",
+      "@value" : "Nel contesto di DCAT 2.0, per un rettangolo di delimitazione geografica che delimita un'area territoriale si DOVREBBE utilizzare la proprietà dcat:bbox."
+    }, {
+      "@language" : "it",
+      "@value" : "Nel contesto di DCAT 2.0, per il centro geografico di un'area spaziale, o di un altro punto caratteristico, si DOVREBBE utilizzare la proprietà dcat:centroid."
+    }, {
+      "@language" : "en",
+      "@value" : "In the context of DCAT 2.0, for a geographic bounding box delimiting a spatial area the property dcat:bbox SHOULD be used."
+    }, {
+      "@language" : "cs",
+      "@value" : "En el contexto de DCAT 2.0, pro geografický střed prostorové oblasti či jiný charakteristický bod BY MĚLA být použita vlastnost dcat:centroid."
+    }, {
+      "@language" : "cs",
+      "@value" : "En el contexto de DCAT 2.0, pro rozsáhlé geometrie (tj. sady souřadnic určujících relevantní geografickou oblast) BY MĚLA být použita vlastnost locn:geometry [[LOCN]]."
+    } ]
+  }, {
+    "@id" : "dct:PeriodOfTime",
+    "skos:changeNote" : [ {
+      "@language" : "en",
+      "@value" : "Class added in this context in DCAT 2.0."
+    }, {
+      "@language" : "es",
+      "@value" : "Esta clase se agregó en este contexto en DCAT 2.0."
+    }, {
+      "@language" : "it",
+      "@value" : "Classe aggiunta in questo contesto in DCAT 2.0."
+    }, {
+      "@language" : "cs",
+      "@value" : "Třída v tomto kontextu byla přidána ve verzi DCAT 2.0."
+    } ],
+    "skos:definition" : [ {
+      "@language" : "en",
+      "@value" : "An interval of time that is named or defined by its start and end dates."
+    }, {
+      "@language" : "it",
+      "@value" : "Nel contesto di DCAT 2.0, un intervallo di tempo che viene chiamato o definito dal suo inizio e fine."
+    }, {
+      "@language" : "es",
+      "@value" : "En el contexto de DCAT 2.0, un interválo de tiempo que se nombra o define por su principio y fin."
+    }, {
+      "@language" : "cs",
+      "@value" : "En el contexto de DCAT 2.0, časový interval který je pojmenovaný, nebo určený svým začátkem a koncem."
+    }, {
+      "@language" : "en",
+      "@value" : "In the context of DCAT 2.0, an interval of time that is named or defined by its start and end."
+    } ],
+    "skos:scopeNote" : [ {
+      "@language" : "en",
+      "@value" : "In the context of DCAT 2.0, the start and end of the interval may be given by using properties dcat:startDate or time:hasBeginning, and dcat:endDate or time:hasEnd, respectively. The interval can also be open - i.e., it can have just a start or just an end."
+    }, {
+      "@language" : "it",
+      "@value" : "Nel contesto di DCAT 2.0, l'inizio e la fine dell'intervallo possono essere dati rispettivamente utilizzando le proprietà dcat:startDate o time:hasBeginning, e dcat:endDate o time:hasEnd. L'intervallo può anche essere aperto, cioè può avere solo un inizio o solo una fine."
+    }, {
+      "@language" : "cs",
+      "@value" : "En el contexto de DCAT 2.0, začátek a konec intervalu může být dán vlastnostmi dcat:startDate či time:hasBeginning a dcat:endDate či time:hasEnd. Interval také může být otevřený, tj. může mít pouze začátek či pouze konec."
+    }, {
+      "@language" : "es",
+      "@value" : "En el contexto de DCAT 2.0, el comienzo y fin de un intervalo pueden representarse usando las propiedades dcat:startDate o time:hasBeginning, y dcat:endDate o time:hasEnd, respectivamente. El interválo también puede ser un interválo abierto - es decir, puede tener sólo un comienzo o un fin."
+    } ]
+  }, {
+    "@id" : "dct:accessRights",
+    "skos:definition" : [ {
+      "@language" : "en",
+      "@value" : "Information about who can access the resource or an indication of its security status."
+    }, {
+      "@language" : "it",
+      "@value" : "Informazioni su chi può accedere alla risorsa o un'indicazione del suo stato di sicurezza."
+    }, {
+      "@language" : "cs",
+      "@value" : "V kontextu DCAT 2.0 dcat:Distribution, podmínky užití řešící způsob přístupu k distribuci."
+    }, {
+      "@language" : "en",
+      "@value" : "In the context of DCAT 2.0 dcat:Distribution, a rights statement that concerns how the distribution is accessed."
+    }, {
+      "@language" : "it",
+      "@value" : "Nel contesto di DCAT 2.0 dcat:Distribution, una dichiarazione dei diritti che riguarda le modalità di accesso alla distribuzione."
+    }, {
+      "@language" : "es",
+      "@value" : "En el contexto de DCAT 2.0 dcat:Distribution, una declaración de derechos sobre cómo se puede acceder la distribución."
+    } ],
+    "skos:scopeNote" : [ {
+      "@language" : "en",
+      "@value" : "In the context of DCAT 2.0 dcat:Resource, information about licenses and rights MAY be provided for the Resource. See also guidance in the section 'License and rights statements'."
+    }, {
+      "@language" : "it",
+      "@value" : "Nell'ambito di DCAT 2.0 dcat:Distribution, le informazioni su licenze e diritti POSSONO essere fornite per la distribuzione. Si vedano anche le indicazioni nella sezione 'Licenze e dichiarazioni sui diritti'."
+    }, {
+      "@language" : "es",
+      "@value" : "En el contexto de DCAT 2.0 dcat:Resource, información sobre las licencias y derechos que PUEDEN proveerse para un Recurso. Ver también la información en la sección 'License and rights statements'."
+    }, {
+      "@language" : "it",
+      "@value" : "Nel contesto di DCAT 2.0 dcat:Resource, le informazioni sulle licenze e i diritti POSSONO essere fornite per la risorsa. Si vedano anche le indicazioni nella sezione 'Licenze e dichiarazioni sui diritti'."
+    }, {
+      "@language" : "it",
+      "@value" : "Nel contesto di DCAT 2.0 dcat:DataService, i diritti di accesso POSSONO includere informazioni riguardanti l'accesso o restrizioni basate su privacy, sicurezza o altre policy."
+    }, {
+      "@language" : "es",
+      "@value" : "En el contexto de DCAT 2.0 dcat:Distribution, información sobre licencias y derechos que PUEDE proveerse para una Distribución. Ver también la información en la sección 'License and rights statements'."
+    }, {
+      "@language" : "en",
+      "@value" : "In the context of DCAT 2.0 dcat:DataService, access Rights MAY include information regarding access or restrictions based on privacy, security, or other policies."
+    }, {
+      "@language" : "cs",
+      "@value" : "V kontextu DCAT 2.0 dcat:DataService, podmínky užití MOHOU obsahovat informace o přístupu nebo omezení z hlediska soukromí, bezpečnosti nebo jiných pravidel."
+    }, {
+      "@language" : "cs",
+      "@value" : "V kontextu DCAT 2.0 dcat:Distribution, pro Distribuci MŮŽE BÝT uvedena informace o podmínkách užití (licencích a právech). Viz návod v sekci 'License and rights statements'."
+    }, {
+      "@language" : "cs",
+      "@value" : "V kontextu DCAT 2.0 dcat:Resource, pro Zdroj MŮŽE BÝT uvedena informace o podmínkách užití (licencích a právech). Viz návod v sekci 'License and rights statements'."
+    }, {
+      "@language" : "en",
+      "@value" : "In the context of DCAT 2.0 dcat:Distribution, information about licenses and rights MAY be provided for the Distribution. See also guidance in the section 'License and rights statements'."
+    }, {
+      "@language" : "es",
+      "@value" : "En el contexto de DCAT 2.0 dcat:DataService, los derechos de acceso PUEDEN incluir información sobre acceso o restricciones basadas en privacidad, seguridad, u otras reglamentaciones."
+    } ]
+  }, {
+    "@id" : "dct:accrualPeriodicity",
+    "skos:definition" : [ {
+      "@language" : "it",
+      "@value" : "Nel contesto del DCAT 2.0, la frequenza di pubblicazione dell'insieme di dati."
+    }, {
+      "@language" : "it",
+      "@value" : "La frequenza con cui gli elementi vengono aggiunti a una collezione."
+    }, {
+      "@language" : "es",
+      "@value" : "En el contexto de DCAT 2.0, la frecuencia con que se publica el conjunto de datos."
+    }, {
+      "@language" : "en",
+      "@value" : "The frequency with which items are added to a collection."
+    }, {
+      "@language" : "en",
+      "@value" : "In the context of DCAT 2.0, the frequency at which dataset is published."
+    }, {
+      "@language" : "cs",
+      "@value" : "V kontextu DCAT 2.0, frekvence publikace datové sady."
+    } ],
+    "skos:scopeNote" : [ {
+      "@language" : "it",
+      "@value" : "Nel contesto di DCAT 2.0, il valore di dct:accrualPeriodicity indica il tasso di aggiornamento del dataset nella sua interezza. Questo può essere completato da dcat:temporalResolution per dare il tempo tra i punti di dati raccolti in una serie temporale."
+    }, {
+      "@language" : "es",
+      "@value" : "En el contexto de DCAT 2.0, el valor de dct:accrualPeriodicity da la tasa de actualización del conjunto de datos como entidad. Esto puede complementarse con dcat:temporalResolution para dar el tiempo entre los puntos en que se recopilan los datos en una serie temporal."
+    }, {
+      "@language" : "en",
+      "@value" : "In the context of DCAT 2.0, the value of dct:accrualPeriodicity gives the rate at which the dataset-as-a-whole is updated. This may be complemented by dcat:temporalResolution to give the time between collected data points in a time series."
+    }, {
+      "@language" : "cs",
+      "@value" : "V kontextu DCAT 2.0, hodnota dct:accrualPeriodicity udává frekvenci, se kterou se aktualizuje datová sada jako celek. Toto může být doplněno vlastností dcat:temporalResolution pro udání času mezi jednotlivými body v časové řadě."
+    } ]
+  }, {
+    "@id" : "dct:conformsTo",
+    "skos:changeNote" : [ {
+      "@language" : "en",
+      "@value" : "Property added in this context in DCAT 2.0."
+    }, {
+      "@language" : "it",
+      "@value" : "Proprietà aggiunta in questo contesto in DCAT 2.0."
+    }, {
+      "@language" : "es",
+      "@value" : "Esta propiedad fue agregada en DCAT 2.0."
+    }, {
+      "@language" : "cs",
+      "@value" : "Vlastnost v tomto kontextu byla přidána ve verzi DCAT 2.0."
+    } ],
+    "skos:definition" : [ {
+      "@language" : "en",
+      "@value" : "In the context of DCAT 2.0 dcat:Distribution, an established standard to which the distribution conforms."
+    }, {
+      "@language" : "it",
+      "@value" : "Nel contesto di DCAT 2.0 dcat:Distribution, uno standard consolidato a cui la distribuzione è conforme."
+    }, {
+      "@language" : "es",
+      "@value" : "En el contexto de DCAT 2.0 dcat:Distribution, un estándar establecido al cuál se ajusta la distribución."
+    }, {
+      "@language" : "en",
+      "@value" : "An established standard to which the described resource conforms."
+    }, {
+      "@language" : "cs",
+      "@value" : "V kontextu DCAT 2.0 dcat:Distribution, uznávaný standard, kterým se popisovaný zdroj řídí."
+    }, {
+      "@language" : "es",
+      "@value" : "Un estándar establecido al cuál se ajusta el recurso descripto."
+    }, {
+      "@language" : "it",
+      "@value" : "Uno standard stabilito al quale la risorsa descritta è conforme."
+    } ],
+    "skos:scopeNote" : [ {
+      "@language" : "it",
+      "@value" : "Nel contesto di DCAT 2.0 dcat:Distribution, questa proprietà DEVE essere usata per indicare il modello, lo schema, l'ontologia, la vista o il profilo a cui questa rappresentazione di un dataset è conforme. Questa è (generalmente) una questione complementare al tipo di supporto o formato."
+    }, {
+      "@language" : "en",
+      "@value" : "In the context of DCAT 2.0 dcat:Distribution, this property SHOULD be used to indicate the model, schema, ontology, view or profile that this representation of a dataset conforms to. This is (generally) a complementary concern to the media-type or format."
+    }, {
+      "@language" : "es",
+      "@value" : "En el contexto de DCAT 2.0 dcat:Distribution, esta propiedad DEBERÍA usarse para indicar el modelo, esquema, ontología, vista or perfil al que se ajusta esta representación del conjunto de datos. Este es (generalmente) un asunto complementario al de 'media type' o formato."
+    }, {
+      "@language" : "cs",
+      "@value" : "V kontextu DCAT 2.0 dcat:Resource, tato vlastnost BY MĚLA být použita k udání modelu, schématu, ontologie, pohledu nebo profilu, kterému katalogizovaný zdroj odpovídá."
+    }, {
+      "@language" : "it",
+      "@value" : "Nel contesto di DCAT 2.0 dcat:Resource, questa proprietà DEVE essere utilizzata per indicare il modello, lo schema, l'ontologia, la vista o il profilo a cui il contenuto della risorsa catalogata è conforme."
+    }, {
+      "@language" : "es",
+      "@value" : "En el contexto de DCAT 2.0 dcat:Resource, esta propiedad DEBERÍA usarse para indicar el modelo, esquema, ontología, vista or perfil al que se ajusta el recurso catalogado."
+    }, {
+      "@language" : "en",
+      "@value" : "In the context of DCAT 2.0 dcat:Resource, this property SHOULD be used to indicate the model, schema, ontology, view or profile that the cataloged resource content conforms to."
+    }, {
+      "@language" : "cs",
+      "@value" : "V kontextu DCAT 2.0 dcat:Distribution, tato vlastnost BY MĚLA být použita k udání modelu, schématu, ontologie, pohledu nebo profilu, kterému tato reprezentace datové sady odpovídá. Toto (obvykle) doplňuje typ média či formát."
+    } ]
+  }, {
+    "@id" : "dct:creator",
+    "skos:changeNote" : [ {
+      "@language" : "it",
+      "@value" : "Proprietà aggiunta in questo contesto in DCAT 2.0, in particolare per soddisfare i requisiti di citazione dei dati."
+    }, {
+      "@language" : "es",
+      "@value" : "Esta propiedad fue agregada en DCAT 2.0, específicamente para tratar los requerimientos de cita de datos."
+    }, {
+      "@language" : "en",
+      "@value" : "Property added in this context in DCAT 2.0, specifically to address data citation requirements."
+    }, {
+      "@language" : "cs",
+      "@value" : "Vlastnost v tomto kontextu byla přidána ve verzi DCAT 2.0 zejména za účelem uspokojení požadavků na citace dat."
+    } ],
+    "skos:definition" : [ {
+      "@language" : "en",
+      "@value" : "An entity primarily responsible for making the resource."
+    }, {
+      "@language" : "it",
+      "@value" : "Nel contesto del DCAT 2.0, l'entità responsabile della produzione della risorsa."
+    }, {
+      "@language" : "cs",
+      "@value" : "V kontextu DCAT 2.0, entita zodpovědná za tvorbu zdroje."
+    }, {
+      "@language" : "it",
+      "@value" : "Un'entità principalmente responsabile della creazione della risorsa."
+    }, {
+      "@language" : "es",
+      "@value" : "En el contexto de DCAT 2.0, la entidad responsable de producier el recurso."
+    }, {
+      "@language" : "en",
+      "@value" : "In the context of DCAT 2.0, the entity responsible for producing the resource."
+    } ],
+    "skos:scopeNote" : [ {
+      "@language" : "cs",
+      "@value" : "V kontextu DCAT 2.0, doporučovanou hodnotou této vlastnosti jsou zdroje typu foaf:Agent."
+    }, {
+      "@language" : "it",
+      "@value" : "Nel contesto di DCAT 2.0, si raccomandano come valori per questa proprietà le risorse di tipo foaf:Agent."
+    }, {
+      "@language" : "en",
+      "@value" : "In the context of DCAT 2.0, resources of type foaf:Agent are recommended as values for this property."
+    }, {
+      "@language" : "es",
+      "@value" : "En el contexto de DCAT 2.0, se recomienda que los valores de esta propiedad sean recurso de tipo foaf:Agent."
+    } ]
+  }, {
+    "@id" : "dct:description",
+    "skos:definition" : [ {
+      "@language" : "cs",
+      "@value" : "V kontextu DCAT 2.0, popis položky pomocí volného textu."
+    }, {
+      "@language" : "it",
+      "@value" : "Un resoconto della risorsa."
+    }, {
+      "@language" : "it",
+      "@value" : "Nel contesto del DCAT 2.0, un resoconto a testo libero dell’ elemento."
+    }, {
+      "@language" : "en",
+      "@value" : "In the context of DCAT 2.0, a free-text account of the item."
+    }, {
+      "@language" : "es",
+      "@value" : "En el contexto de DCAT 2.0, una explicación en texto sobre el ítem."
+    }, {
+      "@language" : "en",
+      "@value" : "An account of the resource."
+    } ]
+  }, {
+    "@id" : "dct:format",
+    "skos:definition" : [ {
+      "@language" : "es",
+      "@value" : "En el contexto de DCAT 2.0, el formato del archivo de la distribución."
+    }, {
+      "@language" : "en",
+      "@value" : "The file format, physical medium, or dimensions of the resource."
+    }, {
+      "@language" : "cs",
+      "@value" : "V kontextu DCAT 2.0, formát souboru distribuce."
+    }, {
+      "@language" : "it",
+      "@value" : "Il formato del file, il supporto fisico o le dimensioni della risorsa."
+    }, {
+      "@language" : "it",
+      "@value" : "Nel contesto di DCAT 2.0, il formato di file della distribuzione."
+    }, {
+      "@language" : "en",
+      "@value" : "In the context of DCAT 2.0, the file format of the distribution."
+    } ],
+    "skos:scopeNote" : [ {
+      "@language" : "es",
+      "@value" : "En el contexto de DCAT 2.0, dcat:mediaType DEBERÍA usarse si el tipo de distribución se define por IANA [IANA-MEDIA-TYPES]."
+    }, {
+      "@language" : "en",
+      "@value" : "In the context of DCAT 2.0, dcat:mediaType SHOULD be used if the type of the distribution is defined by IANA [IANA-MEDIA-TYPES]."
+    }, {
+      "@language" : "it",
+      "@value" : "Nel contesto di DCAT 2.0, dcat:mediaType DEVE essere usato se il tipo di distribuzione è definito da IANA [IANA-MEDIA-TYPES]."
+    }, {
+      "@language" : "cs",
+      "@value" : "V kontextu DCAT 2.0, pokud je typ distribuce definován IANA [IANA-MEDIA-TYPES], MĚLA BY být použita vlastnost dcat:mediaType."
+    } ]
+  }, {
+    "@id" : "dct:hasPart",
+    "skos:definition" : [ {
+      "@language" : "en",
+      "@value" : "In the context of DCAT 2.0 dcat:Catalog, an item that is listed in the catalog."
+    }, {
+      "@language" : "it",
+      "@value" : "Nel contesto di DCAT 2.0 dcat:Catalog, un elemento che è elencato nel catalogo."
+    }, {
+      "@language" : "it",
+      "@value" : "Una risorsa correlata che è inclusa fisicamente o logicamente nella risorsa descritta."
+    }, {
+      "@language" : "en",
+      "@value" : "A related resource that is included either physically or logically in the described resource."
+    } ],
+    "skos:scopeNote" : [ {
+      "@language" : "es",
+      "@value" : "En el contexto de DCAT 2.0, este es el predicado más general para la membresía en un catálogo. Se recomienda usar una sub-propiedad más específica si hay una disponible."
+    }, {
+      "@language" : "cs",
+      "@value" : "V kontextu DCAT 2.0, viz také: Podvlastnosti dct:hasPart; zejména dcat:dataset, dcat:catalog, dcat:service."
+    }, {
+      "@language" : "es",
+      "@value" : "En el contexto de DCAT 2.0, vea también: sub-propiedades de dct:hasPart; en particular dcat:dataset, dcat:catalog, dcat:service."
+    }, {
+      "@language" : "it",
+      "@value" : "Nel contesto del DCAT 2.0, vedi anche:  le sottoproprietà di dct:hasPart; in particolare dcat:dataset, dcat:catalog, dcat:service."
+    }, {
+      "@language" : "en",
+      "@value" : "In the context of DCAT 2.0, this is the most general predicate for membership of a catalog. Use of a more specific sub-property is recommended when available."
+    }, {
+      "@language" : "en",
+      "@value" : "In the context of DCAT 2.0, see also: Sub-properties of dct:hasPart; in particular dcat:dataset, dcat:catalog, dcat:service."
+    }, {
+      "@language" : "cs",
+      "@value" : "V kontextu DCAT 2.0, toto je nejobecnější predikát pro příslušnost do katalogu. Pokud je to možné, doporučuje se použít konkrétnější vztah."
+    }, {
+      "@language" : "it",
+      "@value" : "Nel contesto del DCAT 2.0, questo è il predicato più generale per l'appartenenza ad un catalogo. L'uso di una sottoproprietà più specifica è raccomandato se disponibile."
+    } ]
+  }, {
+    "@id" : "dct:identifier",
+    "skos:definition" : [ {
+      "@language" : "it",
+      "@value" : "Nel contesto del DCAT 2.0, un identificatore unico dell'elemento."
+    }, {
+      "@language" : "it",
+      "@value" : "Un riferimento univoco alla risorsa in un dato contesto."
+    }, {
+      "@language" : "cs",
+      "@value" : "V kontextu DCAT 2.0, unikátní identifikátor položky."
+    }, {
+      "@language" : "en",
+      "@value" : "In the context of DCAT 2.0, a unique identifier of the item."
+    }, {
+      "@language" : "en",
+      "@value" : "An unambiguous reference to the resource within a given context."
+    }, {
+      "@language" : "es",
+      "@value" : "En el contexto de DCAT 2.0, un identificador único para el ítem."
+    } ],
+    "skos:scopeNote" : [ {
+      "@language" : "it",
+      "@value" : "Nel contesto di DCAT 2.0, l'identificatore può essere usato come parte dell'URI dell'elemento, ma comunque è utile averlo rappresentato esplicitamente."
+    }, {
+      "@language" : "en",
+      "@value" : "In the context of DCAT 2.0, the identifier might be used as part of the URI of the item, but still having it represented explicitly is useful."
+    }, {
+      "@language" : "es",
+      "@value" : "En el contexto de DCAT 2.0, el identificador puede usarse como parte de la URI del ítem, pero es útil tenerlo representado de forma explícita."
+    }, {
+      "@language" : "cs",
+      "@value" : "V kontextu DCAT 2.0, identifikátor může být použit jako součást IRI položky. I přesto je užitečné mít jeho explicitní reprezentaci."
+    } ]
+  }, {
+    "@id" : "dct:isReferencedBy",
+    "skos:changeNote" : [ {
+      "@language" : "es",
+      "@value" : "En el contexto de DCAT 2.0, esta propiedad fue agregada en DCAT 2.0."
+    }, {
+      "@language" : "en",
+      "@value" : "Property added in this context in DCAT 2.0."
+    }, {
+      "@language" : "cs",
+      "@value" : "Vlastnost byla v tomto kontextu přidána ve verzi DCAT 2.0"
+    }, {
+      "@language" : "it",
+      "@value" : "Proprietà aggiunte in questo contesto in DCAT 2.0."
+    } ],
+    "skos:definition" : [ {
+      "@language" : "en",
+      "@value" : "In the context of DCAT 2.0, a related resource, such as a publication, that references, cites, or otherwise points to the catalogued resource."
+    }, {
+      "@language" : "es",
+      "@value" : "En el contexto de DCAT 2.0, un recurso relacionado, como por ejemplo una publicación, que referencia, cita, o apunta al recurso del catálogo."
+    }, {
+      "@language" : "it",
+      "@value" : "Una risorsa correlata che fa riferimento, cita o indica in altro modo la risorsa descritta."
+    }, {
+      "@language" : "en",
+      "@value" : "A related resource that references, cites, or otherwise points to the described resource."
+    }, {
+      "@language" : "cs",
+      "@value" : "V kontextu DCAT 2.0, související zdroj, např. publikace, který se odkazuje, cituje nebo jinak ukazuje na katalogizovaný zdroj."
+    }, {
+      "@language" : "it",
+      "@value" : "Nel contesto del DCAT 2.0, una risorsa correlata, come una pubblicazione, che rimanda, cita o indica in altro modo la risorsa catalogata."
+    } ],
+    "skos:scopeNote" : [ {
+      "@language" : "en",
+      "@value" : "In the context of DCAT 2.0, in relation to the use case of data citation, when the catalogued resource is a dataset, the dct:isReferencedBy property allows to relate the dataset to the resources (such as scholarly publications) that cite or point to the dataset. Multiple dct:isReferencedBy properties can be used to indicate the dataset has been referenced by multiple publications, or other resources."
+    }, {
+      "@language" : "en",
+      "@value" : "In the context of DCAT 2.0, this property is used to associate a resource to the catalogued resource (of type dcat:Resource) in question. For other relations to resources not covered with this property, the more generic property dcat:qualifiedRelation can be used. See also the section about § 9. Qualified relations."
+    }, {
+      "@language" : "cs",
+      "@value" : "V kontextu DCAT 2.0,tato vlastnost je použita k přiřazení zdroje ke katalogizovanému zdroji (typu dcat:Resource). Pro jiné typy vztahů ke zdrojům, které nejsou touto vlastností pokryty, může být použita obecnější vlastnost dcat:qualifiedRelation. Viz také sekce 9. 'Qualified relations'."
+    }, {
+      "@language" : "es",
+      "@value" : "En el contexto de DCAT 2.0, esta propiedad se usa para asociar un recurso a un elemento del catálogo  (de tipo dcat:Resource). Para representar otro tipo de associaciones a recursos, se puede utilizar la propiedad más genérica dcat:qualifiedRelation. Para más detalle, ver la sección en relaciones calificadas de la especificación."
+    }, {
+      "@language" : "it",
+      "@value" : "Nel contesto di DCAT 2.0, in relazione al caso d'uso della citazione dei dati, quando la risorsa catalogata è un dataset, la proprietà dct:isReferencedBy permette di mettere in relazione il dataset con le risorse (come le pubblicazioni scientifiche) che citano o puntano al dataset. Molteplici proprietà dct:isReferencedBy possono essere utilizzate per indicare che il dataset è stato referenziato da più pubblicazioni, o altre risorse."
+    }, {
+      "@language" : "it",
+      "@value" : "Nel contesto di DCAT 2.0, questa proprietà viene utilizzata per associare una risorsa alla risorsa catalogata (di tipo dcat:Resource) in questione. Per le altre relazioni con risorse non coperte da questa proprietà, si può utilizzare la proprietà più generica dcat:qualifiedRelation. Si veda anche la sezione relativa al § 9. Relazioni qualificate."
+    }, {
+      "@language" : "es",
+      "@value" : "En el contexto de DCAT 2.0, en relación al caso de uso sobre cita de datos, cuando el recurso catalogado es un conjunto de datos, la propiedad dct:isReferencedBy permite relacionar el conjunto de datos a publicaciones que citan o apuntan al conjunto de datos. Se pueden utilizar múltiples propiedades dct:isReferencedBy para indicar que el conjunto de datos se ha referenciado en múltiples publicaciones u otros recursos."
+    }, {
+      "@language" : "cs",
+      "@value" : "V kontextu DCAT 2.0, ohledně případu užití vztahujícího se k citaci dat, pokud je katalogizovaný zdroj datovou sadou, vlastnost dct:isReferencedBy umožňuje vztáhnout tuto datovou sadu ke zdroji (např. odborné publikaci) která ji cituje nebo na ni odkazuje. dct:isReferencedBy lze užít vícenásobně pro zaznamenání faktu, že datová sada byla odkazována z více publikací nebo jiných zdrojů."
+    } ]
+  }, {
+    "@id" : "dct:issued",
+    "skos:definition" : [ {
+      "@language" : "cs",
+      "@value" : "V kontextu DCAT 2.0 dcat:Resource, datum formálního vydání položky."
+    }, {
+      "@language" : "es",
+      "@value" : "En el contexto de DCAT 2.0 dcat:Distribution, fecha de emisión formal (es decir, publicación) de la distribución."
+    }, {
+      "@language" : "it",
+      "@value" : "Nel contesto del DCAT 2.0 dcat:Distribution, data di emissione formale (ad esempio, pubblicazione) della distribuzione."
+    }, {
+      "@language" : "en",
+      "@value" : "In the context of DCAT 2.0 dcat:Distribution, date of formal issuance (e.g., publication) of the distribution."
+    }, {
+      "@language" : "en",
+      "@value" : "In the context of DCAT 2.0 dcat:CatalogRecord, the date of listing (i.e. formal recording) of the corresponding dataset or service in the catalog."
+    }, {
+      "@language" : "es",
+      "@value" : "En el contexto de DCAT 2.0 dcat:Resource, fecha de emisión formal (es decir, publicación) de un ítem."
+    }, {
+      "@language" : "it",
+      "@value" : "Nel contesto di DCAT 2.0 dcat:CatalogRecord, la data di inserimento (cioè la registrazione formale) del corrispondente set di dati o servizio nel catalogo."
+    }, {
+      "@language" : "es",
+      "@value" : "En el contexto de DCAT 2.0 dcat:CatalogRecord, la fecha en que lista (es decir, se registra formalmente) el conjunto de datos o servicio correspondiente en el catálogo."
+    }, {
+      "@language" : "cs",
+      "@value" : "V kontextu DCAT 2.0 dcat:CatalogRecord, datum zanesení datové sady nebo služby do katalogu."
+    }, {
+      "@language" : "en",
+      "@value" : "Date of formal issuance (e.g., publication) of the resource."
+    }, {
+      "@language" : "it",
+      "@value" : "Nel contesto del DCAT 2.0 dcat:Resource, data di emissione formale (es. pubblicazione) di questo elemento."
+    }, {
+      "@language" : "it",
+      "@value" : "Data di emissione formale (ad esempio, pubblicazione) della risorsa."
+    }, {
+      "@language" : "en",
+      "@value" : "In the context of DCAT 2.0 dcat:Resource, date of formal issuance (e.g., publication) of the item."
+    }, {
+      "@language" : "cs",
+      "@value" : "V kontextu DCAT 2.0 dcat:Distribution, datum formálního vydání distribuce."
+    } ],
+    "skos:scopeNote" : [ {
+      "@language" : "cs",
+      "@value" : "V kontextu DCAT 2.0, tato vlastnost BY MĚLA obsahovat první známé datum vydání."
+    }, {
+      "@language" : "es",
+      "@value" : "En el contexto de DCAT 2.0 dcat:CatalogRecord, indica la fecha en que se lista el conjunto de datos en el catálogo, y no la fecha de publicación del propio conjunto de datos."
+    }, {
+      "@language" : "it",
+      "@value" : "Nel contesto di DCAT 2.0, questa proprietà DOVREBBE essere impostata utilizzando la prima data nota di emissione."
+    }, {
+      "@language" : "es",
+      "@value" : "En el contexto de DCAT 2.0, esta propiedad DEBERÍA incluir como valor la primer fecha de emisión."
+    }, {
+      "@language" : "en",
+      "@value" : "In the context of DCAT 2.0 dcat:CatalogRecord, this indicates the date of listing the dataset in the catalog and not the publication date of the dataset itself."
+    }, {
+      "@language" : "cs",
+      "@value" : "V kontextu DCAT 2.0 dcat:CatalogRecord, tato vlastnost indikuje datum zanesení datové sady do katalogu a ne datum vydání datové sady samotné."
+    }, {
+      "@language" : "en",
+      "@value" : "In the context of DCAT 2.0, this property SHOULD be set using the first known date of issuance."
+    } ]
+  }, {
+    "@id" : "dct:language",
+    "skos:definition" : [ {
+      "@language" : "cs",
+      "@value" : "V kontextu DCAT 2.0, jazyk položky. Tato vlastnost úvádí přirozený jazyk použitý pro textová metadata, tj. názvy, popisy apod., katalogizovaného zdroje, tj. datové sady nebo služby, nebo textový obsah distribuce datové sady."
+    }, {
+      "@language" : "it",
+      "@value" : "Una lingua della risorsa."
+    }, {
+      "@language" : "es",
+      "@value" : "En el contexto de DCAT 2.0, el idioma del ítem. Este se refiere al lenguaje natural que se usa para los metadatos textuales (es decir, títulos, descripciones, etc) de un recurso catalogado (como ser un conjunto o servicio de datos) o los valores textuales de las distribuciones de un conjunto de datos."
+    }, {
+      "@language" : "en",
+      "@value" : "In the context of DCAT 2.0, a language of the item. This refers to the natural language used for textual metadata (i.e. titles, descriptions, etc) of a catalogued resource (i.e. dataset or service) or the textual values of a dataset distribution."
+    }, {
+      "@language" : "it",
+      "@value" : "Nel contesto del DCAT 2.0, una lingua dell'elemento. Si riferisce al linguaggio naturale utilizzato per i metadati testuali (titoli, descrizioni, ecc.) di una risorsa catalogata (dataset o servizio) o ai valori testuali di una distribuzione di un dataset."
+    }, {
+      "@language" : "en",
+      "@value" : "A language of the resource."
+    } ],
+    "skos:scopeNote" : [ {
+      "@language" : "es",
+      "@value" : "En el contexto de DCAT 2.0, si las representaciones de un conjunto de datos están disponibles por separado para cada idioma, defina una instancia de dcat:Distribution para cada idioma y describa el lenguaje específico de cada distribución usando dct:language (es decir, el conjunto de datos tendrá múltiples valores para dct:language y cada distribución tendrá sólo un valor de la propiedad dct:language)."
+    }, {
+      "@language" : "en",
+      "@value" : "In the context of DCAT 2.0, repeat this property if the resource is available in multiple languages."
+    }, {
+      "@language" : "cs",
+      "@value" : "V kontextu DCAT 2.0, pokud jsou reprezentace datové sady k dispozici pro každý jazyk zvlášť, definujte pro každý jazyk jednu instanci dcat:Distribution a popište jazyk dané distribuce pomocí dct:language. (tj. datová sada bude mít více hodnot dct:language a každá distribuce bude mít pouze jednu hodnotu její vlastnosti dct:language)."
+    }, {
+      "@language" : "it",
+      "@value" : "Nel contesto di DCAT 2.0, ripetere questa proprietà se la risorsa è disponibile in più lingue."
+    }, {
+      "@language" : "en",
+      "@value" : "In the context of DCAT 2.0, the value(s) provided for members of a catalog (i.e. dataset or service) override the value(s) provided for the catalog if they conflict."
+    }, {
+      "@language" : "en",
+      "@value" : "In the context of DCAT 2.0, if representations of a dataset are available for each language separately, define an instance of dcat:Distribution for each language and describe the specific language of each distribution using dct:language (i.e. the dataset will have multiple dct:language values and each distribution will have just one as the value of its dct:language property)."
+    }, {
+      "@language" : "cs",
+      "@value" : "V kontextu DCAT 2.0, tuto vlastnost opakujte, pokud je zdroj k dispozici ve více jazycích."
+    }, {
+      "@language" : "cs",
+      "@value" : "V kontextu DCAT 2.0, hodnoty uvedené pro katalogizované položky, tj. datové sady či služby, mají přednost před hodnotami uvedenými pro katalog, pokud jsou ve sporu."
+    }, {
+      "@language" : "it",
+      "@value" : "Nel contesto del DCAT 2.0, i valori forniti per i membri di un catalogo (cioè set di dati o servizio) sostituiscono i valori forniti per il catalogo in caso di conflitto."
+    }, {
+      "@language" : "es",
+      "@value" : "En el contexto de DCAT 2.0, repetir esta propiedad si el recurso está disponible un múltiples idiomas."
+    }, {
+      "@language" : "it",
+      "@value" : "Nel contesto di DCAT 2.0, se le rappresentazioni di un dataset sono disponibili separatamente per ogni lingua, definire un'istanza di dcat:Distribution per ogni lingua e descrivere la lingua specifica di ogni distribuzione usando dct:language (cioè il dataset avrà valori multipli di dct:language e ogni distribuzione avrà uno solo come valore della sua proprietà dct:language)."
+    }, {
+      "@language" : "es",
+      "@value" : "En el contexto de DCAT 2.0, en el caso de conflictos, el valor (o los valores) datos para miembros del catálogo (es decir, conjunto de datos o servicios) sobreescribe el valor (o los valores) dados apra el catálogo."
+    } ]
+  }, {
+    "@id" : "dct:license",
+    "skos:definition" : [ {
+      "@language" : "it",
+      "@value" : "Nell'ambito di DCAT 2.0 dcat:DataService, un documento legale in base al quale il servizio è reso disponibile."
+    }, {
+      "@language" : "it",
+      "@value" : "Un documento legale che dà il permesso ufficiale di fare qualcosa con la risorsa."
+    }, {
+      "@language" : "es",
+      "@value" : "En el contexto de DCAT 2.0 dcat:Resource, uh documento legal bajo el cuál se hace disponible el recurso."
+    }, {
+      "@language" : "cs",
+      "@value" : "V kontextu DCAT 2.0 dcat:Distribution, právní dokument popisující podmínky užití distribuce."
+    }, {
+      "@language" : "en",
+      "@value" : "In the context of DCAT 2.0 dcat:Resource, a legal document under which the resource is made available."
+    }, {
+      "@language" : "es",
+      "@value" : "En el contexto de DCAT 2.0 dcat:DataService, uh documento legal bajo el cuál se hace disponible el servicio."
+    }, {
+      "@language" : "en",
+      "@value" : "In the context of DCAT 2.0 dcat:DataService, a legal document under which the service is made available."
+    }, {
+      "@language" : "it",
+      "@value" : "Nel contesto di DCAT 2.0 dcat:Distribution, un documento legale in base al quale viene resa disponibile la distribuzione."
+    }, {
+      "@language" : "en",
+      "@value" : "A legal document giving official permission to do something with the resource."
+    }, {
+      "@language" : "cs",
+      "@value" : "V kontextu DCAT 2.0 dcat:Resource, právní dokument popisující podmínky užití zdroje."
+    }, {
+      "@language" : "en",
+      "@value" : "In the context of DCAT 2.0 dcat:Distribution, a legal document under which the distribution is made available."
+    }, {
+      "@language" : "cs",
+      "@value" : "V kontextu DCAT 2.0 dcat:DataService, právní dokument popisující podmínky užití služby."
+    }, {
+      "@language" : "it",
+      "@value" : "Nel contesto di DCAT 2.0 dcat:Resource, un documento legale in base al quale la risorsa è resa disponibile."
+    }, {
+      "@language" : "es",
+      "@value" : "En el contexto de DCAT 2.0 dcat:Distribution, uh documento legal bajo el cuál se hace disponible la distribución."
+    } ],
+    "skos:scopeNote" : [ {
+      "@language" : "en",
+      "@value" : "In the context of DCAT 2.0, information about licenses and rights SHOULD be provided on the level of Distribution. Information about licenses and rights MAY be provided for a Dataset in addition to but not instead of the information provided for the Distributions of that Dataset. Providing license or rights information for a Dataset that is different from information provided for a Distribution of that Dataset SHOULD be avoided as this can create legal conflicts. See also guidance in the section 'License and rights statements'."
+    }, {
+      "@language" : "en",
+      "@value" : "In the context of DCAT 2.0 dcat:Resource, information about licenses and rights MAY be provided for the Resource. See also guidance in the section 'License and rights statements'."
+    }, {
+      "@language" : "it",
+      "@value" : "Nel contesto di DCAT 2.0 dcat:Resource, le informazioni sulle licenze e i diritti POSSONO essere fornite per la risorsa. Si veda anche la guida nella sezione 'Licenze e dichiarazioni dei diritti'."
+    }, {
+      "@language" : "it",
+      "@value" : "Nell'ambito del DCAT 2.0, le informazioni su licenze e diritti dovrebbero essere fornite a livello di distribuzione. Le informazioni su licenze e diritti POSSONO essere fornite per un set di dati in aggiunta ma non in alternativa alle informazioni fornite per le distribuzioni di tale set di dati. La fornitura di informazioni sulla licenza o sui diritti per un set di dati che è diverso dalle informazioni fornite per una distribuzione di quel set di dati DOVREBBBE essere evitato in quanto ciò può creare conflitti legali. Si veda anche la guida nella sezione 'Licenze e dichiarazioni dei diritti'."
+    }, {
+      "@language" : "cs",
+      "@value" : "V kontextu DCAT 2.0, informace o podmínkách užití (licencích a právech) BY MĚLY být poskytnuty na úrovni distribuce. Navíc, nikoliv místo, MOHOU BÝT informace o podmínkách užití (licencích a právech) poskytnuty na úrovni datové sady. NEMĚLY BY SE poskytnout různé podmínky užití pro datovou sadu a pro její distribuci, jelikož to může vést ke sporům v právním výkladu. Viz také návod v sekci 'License and rights statements'."
+    }, {
+      "@language" : "es",
+      "@value" : "En el contexto de DCAT 2.0, la información sobre licencias y derechos DEBERÍA darse a nivel de la Distribución. La información sobre licencias y derechos PUEDE proveerse también para un conjunto de datos pero no en lugar de la información para la distribución del conjunto de datos. Se DEBERÍA evitar dar información de licencia o derechos para un conjunto de datos que es diferente de la de su distribución ya que en este caso puede haber conflictos legales. Ver más información en la sección 'License and rights statements'."
+    }, {
+      "@language" : "cs",
+      "@value" : "V kontextu DCAT 2.0 dcat:Resource, pro Zdroj MŮŽE BÝT uvedena informace o podmínkách užití (licencích a právech). Viz návod v sekci 'License and rights statements'."
+    }, {
+      "@language" : "es",
+      "@value" : "En el contexto de DCAT 2.0 dcat:Resource, PUEDE proveerse información sobre licencias y derechos para el Recurso. Vea también información en la sección 'License and rights statements'."
+    } ]
+  }, {
+    "@id" : "dct:modified",
+    "skos:definition" : [ {
+      "@language" : "it",
+      "@value" : "Nel contesto di DCAT 2.0 dcat:Distribution, la data più recente in cui la distribuzione è stata cambiata, aggiornata o modificata."
+    }, {
+      "@language" : "en",
+      "@value" : "Date on which the resource was changed."
+    }, {
+      "@language" : "cs",
+      "@value" : "V kontextu DCAT 2.0 dcat:Distribution, poslední datum kdy byla distribuce změněna či aktualizována."
+    }, {
+      "@language" : "en",
+      "@value" : "In the context of DCAT 2.0 dcat:CatalogRecord, most recent date on which the catalog entry was changed, updated or modified."
+    }, {
+      "@language" : "it",
+      "@value" : "Data in cui la risorsa è stata cambiata."
+    }, {
+      "@language" : "es",
+      "@value" : "En el contexto de DCAT 2.0 dcat:Distribution, la fecha más reciente en la que se modificó o actualizó la distribución."
+    }, {
+      "@language" : "en",
+      "@value" : "In the context of DCAT 2.0 dcat:Distribution, most recent date on which the distribution  was changed, updated or modified."
+    }, {
+      "@language" : "es",
+      "@value" : "En el contexto de DCAT 2.0 dcat:CatalogRecord, la fecha más reciente en la que se modificó o actualizó la entrada del catálogo."
+    }, {
+      "@language" : "cs",
+      "@value" : "V kontextu DCAT 2.0 dcat:Resource, poslední datum kdy byla položka změněna či aktualizována."
+    }, {
+      "@language" : "es",
+      "@value" : "En el contexto de DCAT 2.0 dcat:Resource, la fecha más reciente en la que se modificó o actualizó el ítem del catálogo."
+    }, {
+      "@language" : "en",
+      "@value" : "In the context of DCAT 2.0 dcat:Resource, most recent date on which the item was changed, updated or modified."
+    }, {
+      "@language" : "it",
+      "@value" : "Nel contesto di DCAT 2.0 dcat:Resource, la data più recente in cui l'elemento è stato cambiato, aggiornato o modificato."
+    }, {
+      "@language" : "cs",
+      "@value" : "V kontextu DCAT 2.0 dcat:CatalogRecord, poslední datum kdy byl katalogizační záznam změněn či aktualizován."
+    }, {
+      "@language" : "it",
+      "@value" : "Nel contesto di DCAT 2.0 dcat:CatalogRecord, la data più recente in cui la voce di catalogo è stata cambiata, aggiornata o modificata."
+    } ],
+    "skos:scopeNote" : [ {
+      "@language" : "it",
+      "@value" : "Nel contesto di DCAT 2.0 dcat:CatalogRecord, indica la data dell'ultima modifica di una voce di catalogo, cioè la descrizione dei metadati di catalogo del dataset, e non la data del dataset stesso."
+    }, {
+      "@language" : "en",
+      "@value" : "In the context of DCAT 2.0 dcat:CatalogRecord, this indicates the date of last change of a catalog entry, i.e. the catalog metadata description of the dataset, and not the date of the dataset itself."
+    }, {
+      "@language" : "es",
+      "@value" : "En el contexto de DCAT 2.0 dcat:Resource, el valor de esta propiedad indica un cambio del ítem, no un cambio en el registro del catálogo. La ausencia de valor PUEDE indicar que el ítem nunca se modificó después de su publicación inicial, o que no se conoce la fecha de su última modificación, o que el ítem se actualiza contínuamente."
+    }, {
+      "@language" : "es",
+      "@value" : "En el contexto de DCAT 2.0 dcat:CatalogRecord, indica la fecha en que se hizo la última modificación a la entrada del catálogo, es decir, de los metadatos en el catálogo sobre el conjunto de datos, y no sobre el mismo conjunto de datos."
+    }, {
+      "@language" : "cs",
+      "@value" : "V kontextu DCAT 2.0 dcat:Resource, hodnota této vlastnosti udává změnu položky, nikoliv změnu jejího katalogizačního záznamu. Pokud hodnota chybí, MŮŽE to znamenat, že po publikaci položka již nebyla měněna, že datum změny není známo, nebo že je položka aktualizována neustále."
+    }, {
+      "@language" : "en",
+      "@value" : "In the context of DCAT 2.0 dcat:Resource, the value of this property indicates a change to the actual item, not a change to the catalog record. An absent value MAY indicate that the item has never changed after its initial publication, or that the date of last modification is not known, or that the item is continuously updated."
+    }, {
+      "@language" : "it",
+      "@value" : "Nel contesto di DCAT 2.0 dcat:Resource, il valore di questa proprietà indica una modifica all'elemento effettivo, non una modifica al record del catalogo. Un valore assente PUÒ indicare che l'articolo non è mai cambiato dopo la sua pubblicazione iniziale, o che la data dell'ultima modifica non è nota, o che l'articolo viene continuamente aggiornato."
+    }, {
+      "@language" : "cs",
+      "@value" : "V kontextu DCAT 2.0 dcat:CatalogRecord, tato vlastnost indikuje datum poslední změny katalogizačního záznamu, nikoliv datum změny datové sady samotné."
+    } ]
+  }, {
+    "@id" : "dct:publisher",
+    "skos:definition" : [ {
+      "@language" : "es",
+      "@value" : "En el contexto de DCAT 2.0, la entidad responsable de hacer el item disponible."
+    }, {
+      "@language" : "cs",
+      "@value" : "V kontextu DCAT 2.0, entita zodpovědná za zpřístupnění položky."
+    }, {
+      "@language" : "en",
+      "@value" : "An entity responsible for making the resource available."
+    }, {
+      "@language" : "en",
+      "@value" : "In the context of DCAT 2.0, the entity responsible for making the item available."
+    }, {
+      "@language" : "it",
+      "@value" : "Nell'ambito del DCAT 2.0, l'entità responsabile della messa a disposizione dell'elemento."
+    }, {
+      "@language" : "it",
+      "@value" : "Un'entità responsabile della messa a disposizione della risorsa."
+    } ],
+    "skos:scopeNote" : [ {
+      "@language" : "cs",
+      "@value" : "V kontextu DCAT 2.0, doporučovanou hodnotou této vlastnosti jsou zdroje typu foaf:Agent."
+    }, {
+      "@language" : "es",
+      "@value" : "En el contexto de DCAT 2.0, se recomienda usar recursos del tipo foaf:Agent para los valores de esta propiedad."
+    }, {
+      "@language" : "it",
+      "@value" : "Nel contesto di DCAT 2.0, si raccomandano risorse di tipo foaf:Agent come valori per questa proprietà."
+    }, {
+      "@language" : "en",
+      "@value" : "In the context of DCAT 2.0, resources of type foaf:Agent are recommended as values for this property."
+    } ]
+  }, {
+    "@id" : "dct:relation",
+    "skos:definition" : [ {
+      "@language" : "es",
+      "@value" : "En el contexto de DCAT 2.0 dcat:Relationship, el recurso relacionado con el recurso que se está describiendo."
+    }, {
+      "@language" : "es",
+      "@value" : "En el contexto de DCAT 2.0 dcat:Resource, un recurso con una relación no especificada con el recurso catalogado que se está describiendo."
+    }, {
+      "@language" : "cs",
+      "@value" : "V kontextu DCAT 2.0 dcat:Relationship, Zdroj ve vztahu se popisovaným zdrojem."
+    }, {
+      "@language" : "it",
+      "@value" : "Nel contesto di DCAT 2.0 dcat:Relationship, la risorsa relativa alla risorsa di origine."
+    }, {
+      "@language" : "it",
+      "@value" : "Nel contesto di DCAT 2.0 dcat:Resource, una risorsa con una relazione non specificata con l'elemento catalogato."
+    }, {
+      "@language" : "en",
+      "@value" : "In the context of DCAT 2.0 dcat:Relationship, the resource related to the source resource."
+    }, {
+      "@language" : "en",
+      "@value" : "A related resource."
+    }, {
+      "@language" : "it",
+      "@value" : "Una risorsa correlata."
+    }, {
+      "@language" : "en",
+      "@value" : "In the context of DCAT 2.0 dcat:Resource, a resource with an unspecified relationship to the catalogued item."
+    }, {
+      "@language" : "cs",
+      "@value" : "V kontextu DCAT 2.0 dcat:Resource, Zdroj s nespecifikovaným vztahem ke katalogizované položce."
+    } ],
+    "skos:scopeNote" : [ {
+      "@language" : "it",
+      "@value" : "Nel contesto del DCAT 2.0, vedi anche: le sottoproprietà di dct:relation in particolare dct:hasPart, dct:hasPart, dct:isPartOf, dct:isPartOf, dct:isFormatOf, dct:isFormat, dct:isVersionOf, dct:hasVersion, dct:hasVersion, dct:replaces, dct:isReplacedBy, dct:references, dct:isReferencedBy, dct:requires, dct:isRequiredBy."
+    }, {
+      "@language" : "en",
+      "@value" : "In the context of a DCAT 2.0 dcat:Relationship this is expected to point to another dcat:Dataset or other catalogued resource."
+    }, {
+      "@language" : "en",
+      "@value" : "In the context of DCAT 2.0, see also: Sub-properties of dct:relation in particular dcat:distribution, dct:hasPart, dct:isPartOf, dct:conformsTo, dct:isFormatOf, dct:hasFormat, dct:isVersionOf, dct:hasVersion, dct:replaces, dct:isReplacedBy, dct:references, dct:isReferencedBy, dct:requires, dct:isRequiredBy."
+    }, {
+      "@language" : "en",
+      "@value" : "In the context of DCAT 2.0, dct:relation SHOULD be used where the nature of the relationship between a catalogued item and related resources is not known. A more specific sub-property SHOULD be used if the nature of the relationship of the link is known. The property dcat:distribution SHOULD be used to link from a dcat:Dataset to a representation of the dataset, described as a dcat:Distribution."
+    }, {
+      "@language" : "cs",
+      "@value" : "V kontextu DCAT 2.0, dct:relation BY MĚLA být použita tam, kde není znám typ vztahu mezi katalogizovanou položkou a vztaženým zdrojem. Pokud typ vztahu znám je, MĚLA BY být použita konkrétnější podvlastnost. Pro propojení datové sady dcat:Dataset a reprezentaci datové sady dcat:Distribution BY MĚLA BÝT použita vlastnost dcat:distribution."
+    }, {
+      "@language" : "cs",
+      "@value" : "V kontextu DCAT 2.0 dcat:Relationship se očekává, že tato vlastnost bude ukazovat na jiný dcat:Dataset nebo jiný katalogizovaný zdroj."
+    }, {
+      "@language" : "it",
+      "@value" : "Nel contesto di DCAT 2.0, dct:relation DOVREBBE essere utilizzato quando la natura della relazione tra un articolo catalogato e le risorse correlate non è nota. Una sottoproprietà più specifica DOVREBBE essere utilizzata se la natura della relazione del collegamento è nota. La proprietà dcat:distribution DEVE essere usata per collegare da un dcat:Dataset ad una rappresentazione del dataset, descritto come dcat:Distribution."
+    }, {
+      "@language" : "cs",
+      "@value" : "V kontextu DCAT 2.0, viz také: Podvlastnosti dct:relation, zejména dcat:distribution, dct:hasPart, dct:isPartOf, dct:conformsTo, dct:isFormatOf, dct:hasFormat, dct:isVersionOf, dct:hasVersion, dct:replaces, dct:isReplacedBy, dct:references, dct:isReferencedBy, dct:requires, dct:isRequiredBy."
+    }, {
+      "@language" : "it",
+      "@value" : "Nel contesto di un DCAT 2.0, dcat:Relationship ci si aspetta che punti ad un altro dcat:Dataset o altra risorsa catalogata."
+    } ]
+  }, {
+    "@id" : "dct:rights",
+    "skos:definition" : [ {
+      "@language" : "it",
+      "@value" : "Informazioni sui diritti inerenti alla risorsa e su di essa."
+    }, {
+      "@language" : "es",
+      "@value" : "En el contexto de DCAT 2.0 dcat:Distribution, información sobre los derechos mantenido por las distribuciones."
+    }, {
+      "@language" : "es",
+      "@value" : "En el contexto de DCAT 2.0 dcat:Resource, una declaración que tiene que ver con todos los derechos no representados con dct:license o dct:accessRights, como por ejemplo declaraciones de derechos de autor."
+    }, {
+      "@language" : "cs",
+      "@value" : "V kontextu DCAT 2.0 dcat:Distribution, informace o právech vztahujících se na distribuci."
+    }, {
+      "@language" : "en",
+      "@value" : "In the context of DCAT 2.0 dcat:Resource, a statement that concerns all rights not addressed with dct:license or dct:accessRights, such as copyright statements."
+    }, {
+      "@language" : "en",
+      "@value" : "In the context of DCAT 2.0 dcat:Distribution, information about rights held in and over the distribution."
+    }, {
+      "@language" : "cs",
+      "@value" : "V kontextu DCAT 2.0 dcat:Resource, dokument zabývající se všemi právy, které nejsou ošetřeny v dct:license či dct:rights, jako je například copyright."
+    }, {
+      "@language" : "it",
+      "@value" : "Nel contesto di DCAT 2.0 dcat:Resource, una dichiarazione che riguarda tutti i diritti non trattati con dct:license o dct:accessRights, come le dichiarazioni di copyright."
+    }, {
+      "@language" : "en",
+      "@value" : "Information about rights held in and over the resource."
+    }, {
+      "@language" : "it",
+      "@value" : "Nel contesto di DCAT 2.0 dcat:Distribution, informazioni sui diritti relativi alla distribuzione."
+    } ],
+    "skos:scopeNote" : [ {
+      "@language" : "cs",
+      "@value" : "V kontextu DCAT 2.0 dcat:Distribution, dct:license, což je podvlastnost dct:rights, může být použita k propojení distribuce a licenčního dokumentu. dct:rights ale umožňuje odkazovat na podmínky užití, které také mohou obsahovat licenční informace, které mohou licenci upřesňovat například nutností citace. Informace o podmínkách užití (licencích a právech) BY MĚLY být poskytnuty na úrovni distribuce. Navíc, nikoliv místo, MOHOU BÝT informace o podmínkách užití (licencích a právech) poskytnuty na úrovni datové sady. NEMĚLY BY SE poskytnout různé podmínky užití pro datovou sadu a pro její distribuci, jelikož to může vést ke sporům v právním výkladu. Viz také návod v sekci 'License and rights statements'."
+    }, {
+      "@language" : "it",
+      "@value" : "Nell'ambito del DCAT 2.0, possono essere fornite informazioni su licenze e diritti per la risorsa. Si veda anche la guida nella sezione 'Licenze e dichiarazioni sui diritti'."
+    }, {
+      "@language" : "it",
+      "@value" : "Nel contesto di DCAT 2.0 dcat:Distribution, dct:license, che è una sottoproprietà di dct:rights, può essere utilizzata per collegare una distribuzione ad un documento di licenza. Tuttavia, dct:rights permette il collegamento ad una definizione dei diritti che può includere informazioni sulla licenza e altre informazioni che integrano la licenza, come l'attribuzione. Le informazioni su licenze e diritti DEVONO essere fornite a livello di distribuzione. Inoltre,  le informazioni su licenze e diritti POSSONO essere fornite per un set di dati  ma non al posto delle informazioni fornite per le distribuzioni di quel set di dati. La fornitura di informazioni sulla licenza o sui diritti per un set di dati diverso dalle informazioni fornite per una distribuzione di quel set di dati DOVREBBBE essere evitata in quanto ciò può creare conflitti legali. Si veda anche la guida nella sezione 'Licenze e dichiarazioni sui diritti'."
+    }, {
+      "@language" : "es",
+      "@value" : "En el contexto de DCAT 2.0, información sobre licencias y derechos PUEDE proveerse para un Recurso. Ver también la sección 'License and rights statements' para más información."
+    }, {
+      "@language" : "en",
+      "@value" : "In the context of DCAT 2.0, information about licenses and rights MAY be provided for the Resource. See also guidance in the section 'License and rights statements'."
+    }, {
+      "@language" : "es",
+      "@value" : "En el contexto de DCAT 2.0 dcat:Distribution, dct:license, que es una sub-propertiedad de dct:rights, puede usarse para asociar una distribución a un documento de licencia. Sin embargo, dct:rights permite asociar a una declaración de derechos que incluya información de licencias así como también otra información que suplementa la licencia, como atribución. La información sobre las licencias y derechos DEBERÍA proveerse a nivel de la Distribución. La información sobre licencias y derechos PUEDE proveerse también para un conjunto de datos pero no en lugar de la información provista para las Distribuciones del conjunto de datos. Se DEBERÍA evitar brindar información sobre licencias y derechos de un conjunto de datos que difiere de aquella de la Distribución del conjunto de datos ya que se crean conflictos legales. Ver también la sección 'License and rights statements' para más información."
+    }, {
+      "@language" : "en",
+      "@value" : "In the context of DCAT 2.0 dcat:Distribution, dct:license, which is a sub-property of dct:rights, can be used to link a distribution to a license document. However, dct:rights allows linking to a rights statement that can include licensing information as well as other information that supplements the license such as attribution. Information about licenses and rights SHOULD be provided on the level of Distribution. Information about licenses and rights MAY be provided for a Dataset in addition to but not instead of the information provided for the Distributions of that Dataset. Providing license or rights information for a Dataset that is different from information provided for a Distribution of that Dataset SHOULD be avoided as this can create legal conflicts. See also guidance in the secion on 'License and rights statements'."
+    }, {
+      "@language" : "cs",
+      "@value" : "V kontextu DCAT 2.0, pro Zdroj MŮŽE BÝT uvedena informace o podmínkách užití (licencích a právech). Viz návod v sekci 'License and rights statements'."
+    } ]
+  }, {
+    "@id" : "dct:spatial",
+    "skos:definition" : [ {
+      "@language" : "en",
+      "@value" : "In the context of DCAT 2.0 dcat:Dataset, the geographical area covered by the dataset."
+    }, {
+      "@language" : "es",
+      "@value" : "En el contexto de DCAT 2.0 dcat:Dataset, el área geográfica cubierta por el conjunto de datos."
+    }, {
+      "@language" : "en",
+      "@value" : "Spatial characteristics of the resource."
+    }, {
+      "@language" : "it",
+      "@value" : "Caratteristiche spaziali della risorsa."
+    }, {
+      "@language" : "it",
+      "@value" : "Nel contesto di DCAT 2.0 dcat:Dataset, l'area geografica coperta dal set di dati."
+    }, {
+      "@language" : "cs",
+      "@value" : "V kontextu DCAT 2.0 dcat:Dataset, geografické území pokryté datovou sadou."
+    } ],
+    "skos:scopeNote" : [ {
+      "@language" : "es",
+      "@value" : "En el contexto de DCAT 2.0 dcat:Dataset, la cobertura espacial de un conjunto de datos puede codificarse como una instancia de dct:Location, o puede indicarse usando una referencia URI (es decir, un enlace) a un recurso que describa la posición. Se recomienda que los enlaces sean a entradas en un diccionario geográfico bien mantenido como Geonames."
+    }, {
+      "@language" : "cs",
+      "@value" : "V kontextu DCAT 2.0 dcat:Dataset, územní pokrytí datové sady může být zaznamenáno jako instance dct:Location, nebo může být indikováno jako IRI odkazující na zdroj popisující území. Je doporučeno se odkazovat na udržovaný zdroj dat jako například Geonames."
+    }, {
+      "@language" : "it",
+      "@value" : "Nel contesto di DCAT 2.0 dcat:Dataset, la copertura spaziale di un set di dati può essere codificata come istanza di dct:Location, o può essere indicata utilizzando un riferimento URI (link) a una risorsa che descrive una locazione. Si raccomanda che i collegamenti siano a delle voci in un gazetteer ben mantenuto come Geonames."
+    }, {
+      "@language" : "en",
+      "@value" : "In the context of DCAT 2.0 dcat:Dataset, the spatial coverage of a dataset may be encoded as an instance of dct:Location, or may be indicated using a URI reference (link) to a resource describing a location. It is recommended that links are to entries in a well maintained gazetteer such as Geonames."
+    } ]
+  }, {
+    "@id" : "dct:temporal",
+    "skos:definition" : [ {
+      "@language" : "it",
+      "@value" : "Nel contesto di DCAT 2.0 dcat:Dataset, il periodo temporale coperto dal set di dati."
+    }, {
+      "@language" : "en",
+      "@value" : "In the context of DCAT 2.0 dcat:Dataset, the temporal period that the dataset covers."
+    }, {
+      "@language" : "cs",
+      "@value" : "V kontextu DCAT 2.0 dcat:Dataset, časové pokrytí datové sady."
+    }, {
+      "@language" : "es",
+      "@value" : "En el contexto de DCAT 2.0 dcat:Dataset, el período temporal cubierto por el conjunto de datos."
+    }, {
+      "@language" : "it",
+      "@value" : "Caratteristiche temporali della risorsa."
+    }, {
+      "@language" : "en",
+      "@value" : "Temporal characteristics of the resource."
+    } ],
+    "skos:scopeNote" : [ {
+      "@language" : "it",
+      "@value" : "Nel contesto di DCAT 2.0 dcat:Dataset, la copertura temporale di un dataset può essere codificata come istanza di dct:PeriodOfTime, o può essere indicata utilizzando un riferimento URI (link) ad una risorsa che descrive un periodo o intervallo di tempo."
+    }, {
+      "@language" : "en",
+      "@value" : "In the context of DCAT 2.0 dcat:Dataset, the temporal coverage of a dataset may be encoded as an instance of dct:PeriodOfTime, or may be indicated using a URI reference (link) to a resource describing a time period or interval."
+    }, {
+      "@language" : "es",
+      "@value" : "En el contexto de DCAT 2.0 dcat:Dataset, la cobertura temporal del conjunto de datos puede codificarse como una instancia de dct:PeriodOfTime, o puede indicarse usando una referencia URI (es decir, un enlace) a un recurso que describa el período o interválo de tiempo."
+    }, {
+      "@language" : "cs",
+      "@value" : "V kontextu DCAT 2.0 dcat:Dataset, časové pokrytí datové sady může být zaznamenáno jako instance dct:PeriodOfTime, nebo může být indikováno jako IRI odkazující na zdroj popisující či časový interval."
+    } ]
+  }, {
+    "@id" : "dct:title",
+    "skos:definition" : [ {
+      "@language" : "es",
+      "@value" : "En el contexto de DCAT 2.0 dcat:Distribution, un nombre o título dado a la distribución."
+    }, {
+      "@language" : "en",
+      "@value" : "A name given to the resource."
+    }, {
+      "@language" : "it",
+      "@value" : "Nel contesto di DCAT 2.0 dcat:Distribution, un nome o titolo dato alla distribuzione."
+    }, {
+      "@language" : "es",
+      "@value" : "En el contexto de DCAT 2.0 dcat:Resource, un nombre o título dado al elemento del catálogo."
+    }, {
+      "@language" : "en",
+      "@value" : "In the context of DCAT 2.0 dcat:Resource, a name given to the item."
+    }, {
+      "@language" : "it",
+      "@value" : "Nel contesto di DCAT 2.0 dcat:Resource, un nome dato alla elemento."
+    }, {
+      "@language" : "cs",
+      "@value" : "V kontextu DCAT 2.0 dcat:Distribution, název distribuce"
+    }, {
+      "@language" : "cs",
+      "@value" : "V kontextu DCAT 2.0 dcat:Resource, název položky"
+    }, {
+      "@language" : "en",
+      "@value" : "In the context of DCAT 2.0 dcat:Distribution, a name given to the distribution."
+    }, {
+      "@language" : "it",
+      "@value" : "Un nome dato alla risorsa."
+    } ]
+  }, {
+    "@id" : "dct:type",
+    "skos:definition" : [ {
+      "@language" : "cs",
+      "@value" : "Podstata či žánr zdroje."
+    }, {
+      "@language" : "es",
+      "@value" : "La naturaleza, género o tipo del recurso."
+    }, {
+      "@language" : "it",
+      "@value" : "La natura o il tipo di risorsa."
+    }, {
+      "@language" : "en",
+      "@value" : "The nature or genre of the resource."
+    } ],
+    "skos:scopeNote" : [ {
+      "@language" : "es",
+      "@value" : "Usa el elemento dct:format para describir el formato del archivo, el medio físico, o las dimensiones del recurso."
+    }, {
+      "@language" : "en",
+      "@value" : "To describe the file format, physical medium, or dimensions of the resource, use the dct:format element."
+    }, {
+      "@language" : "it",
+      "@value" : "Per descrivere il formato del file, il supporto fisico o le dimensioni della risorsa, utilizzare l'elemento dct:format."
+    }, {
+      "@language" : "cs",
+      "@value" : "Pro popis formátu souboru, fyzického média či dimenzí zdroje použijte dct:format."
+    }, {
+      "@language" : "en",
+      "@value" : "In the context of DCAT 2.0, the value SHOULD be taken from a well governed and broadly recognised controlled vocabulary, such as: 1. DCMI Type vocabulary [DCTERMS]; 2. ISO 19115 scope codes [ISO-19115-1]; 3. Datacite resource types [DataCite]; 4. PARSE.Insight content-types used by re3data.org [RE3DATA-SCHEMA] (see item 15 contentType); 5. MARC intellectual resource types ; Some members of these controlled vocabularies are not strictly suitable for datasets or data services (e.g. DCMI Type Event, PhysicalObject; ISO 19115 CollectionHardware, CollectionSession, Initiative, Sample, Repository), but might be used in the context of other kinds of catalogs defined in DCAT profiles or applications."
+    }, {
+      "@language" : "es",
+      "@value" : "En el contexto de DCAT 2.0, el valor DEBERÍA tomarse de un vocabulario controlado bien gobernado y ampliamente reconocido, como por ejemplo: 1. DCMI Type vocabulary [DCTERMS]; 2. códigos de alcance de ISO 19115 [ISO-19115-1]; 3. tipos de recursos de Datacite [DataCite]; 4. tipos de contenido de PARSE.Insight usados por re3data.org [RE3DATA-SCHEMA] (see item 15 contentType); 5. tipos de recurso intelectual de MARC. Algunos elementos de estos vocabularios controlados son estrictamente no apropiados para conjuntos de datos o servicios de datos (por ejemplo: DCMI Type Event, PhysicalObject; ISO 19115 CollectionHardware, CollectionSession, Initiative, Sample, Repository), pero pueden usarse en este contexto para otros tipos de catálogos definidos en perfiles de DCAT o aplicaciones."
+    }, {
+      "@language" : "cs",
+      "@value" : "V kontextu DCAT 2.0, hodnota BY MĚLA být z dobře řízeného a široce uznávaného slovníku, např.: 1. Slovník DCMI Type [DCTERMS]; 2. Kódy ISO 19115 [ISO-19115-1]; 3. Typy zdrojů Datacite [DataCite]; 4. Typy obsahu PARSE.Insight, které jsou používány re3data.org [RE3DATA-SCHEMA] (viz položka 15 contentType); 5. Typy duševních zdrojů MARC; Některé položky těchto slovníků nejsou zcela vhodné pro datové sady nebo datové služby (např. DCMI Type Event, PhysicalObject; ISO 19115 CollectionHardware, CollectionSession, Initiative, Sample, Repository), ale mohou být použity v kontextu jiných typů katalogů, které jsou definovány v profilech či aplikacích DCAT."
+    }, {
+      "@language" : "it",
+      "@value" : "Il valore DOVREBBE essere tratto da un vocabolario ben governato e ampiamente riconosciuto e controllato, come ad esempio: 1. Vocabolario dei  DCMI Type [DCTERMS]; 2. Codici di scopo ISO 19115 [ISO-19115-1];  3. Tipi di risorse del Datacite [DataCite]. 4. PARSE.Insight content-type utilizzati da re3data.org [RE3DATA-SCHEMA] (vedi punto 15 contentType); 5. Tipi di risorse intellettuali del MARC. Alcuni membri di questi vocabolari controllati non sono strettamente adatti a insiemi di dati o servizi di dati (ad es. DCMI Type Event, PhysicalObject; ISO 19115 CollectionHardware, CollectionSession, Initiative, Sample, Repository), ma possono essere utilizzati nel contesto di altri tipi di cataloghi definiti in profili o applicazioni DCAT."
+    } ]
+  }, {
+    "@id" : "time:hasBeginning",
+    "skos:changeNote" : [ {
+      "@language" : "it",
+      "@value" : "Proprietà aggiunte in questo contesto in DCAT 2.0."
+    }, {
+      "@language" : "cs",
+      "@value" : "Vlastnost v tomto kontextu byla přidána ve verzi DCAT 2.0."
+    }, {
+      "@language" : "es",
+      "@value" : "Esta propiedad fue agregada en DCAT 2.0."
+    }, {
+      "@language" : "en",
+      "@value" : "Property added in this context in DCAT 2.0."
+    } ],
+    "skos:definition" : [ {
+      "@language" : "it",
+      "@value" : "Inizio di un'entità temporale."
+    }, {
+      "@language" : "en",
+      "@value" : "In the context of DCAT 2.0, beginning of a period or interval."
+    }, {
+      "@language" : "en",
+      "@value" : "Beginning of a temporal entity."
+    } ],
+    "skos:scopeNote" : [ {
+      "@language" : "es",
+      "@value" : "En el contexto de DCAT 2.0, el uso de la propiedad time:hasBeginning implica que el valor de la propiedad dct:temporal es un miembro de la clase time:TemporalEntity de [OWL-TIME]. En este contexto, esto puede interpretarse como que implica que dct:PeriodOfTime es equivalente a la subclase time:ProperInterval."
+    }, {
+      "@language" : "en",
+      "@value" : "In the context of DCAT 2.0, use of the property time:hasBeginning entails that value of the dct:temporal property is a member of the time:TemporalEntity class from [OWL-TIME]. In this context this could be taken to imply that dct:PeriodOfTime is equivalent to the subclass time:ProperInterval."
+    }, {
+      "@language" : "cs",
+      "@value" : "V kontextu DCAT 2.0, použití vlastnosti time:hasBeginning znamená, že hodnota vlastnosti dct:temporal je instancí třídy time:TemporalEntity ze slovníku [OWL-TIME]. V tomto kontextu to může znamenat, že dct:PeriodOfTime je ekvivalentní podtřídě time:ProperInterval"
+    }, {
+      "@language" : "it",
+      "@value" : "Nel contesto di DCAT 2.0, l'uso della proprietà time:hasBeginning comporta che il valore della proprietà dct:temporal  è un membro della classe time:TemporalEntity di [OWL-TIME]. In questo contesto ciò potrebbe essere interpretato nel senso che dct:PeriodOfTime è equivalente alla sottoclasse time:ProperInterval."
+    } ]
+  }, {
+    "@id" : "time:hasEnd",
+    "skos:changeNote" : [ {
+      "@language" : "it",
+      "@value" : "Proprietà aggiunte in questo contesto in DCAT 2.0."
+    }, {
+      "@language" : "en",
+      "@value" : "Property added in this context in DCAT 2.0."
+    }, {
+      "@language" : "cs",
+      "@value" : "Vlastnost v tomto kontextu byla přidána ve verzi DCAT 2.0"
+    }, {
+      "@language" : "es",
+      "@value" : "Esta propiedad fue agregada en DCAT 2.0."
+    } ],
+    "skos:definition" : [ {
+      "@language" : "it",
+      "@value" : "Nel contesto del DCAT 2.0, fine di un periodo o intervallo."
+    }, {
+      "@language" : "en",
+      "@value" : "In the context of DCAT 2.0, end of a period or interval."
+    }, {
+      "@language" : "it",
+      "@value" : "Fine di un'entità temporale."
+    }, {
+      "@language" : "en",
+      "@value" : "End of a temporal entity."
+    } ],
+    "skos:scopeNote" : [ {
+      "@language" : "es",
+      "@value" : "En el contexto de DCAT 2.0, el uso de la propiedad time:hasEnd implica que el valor de la propiedad dct:temporal es un miembro de la clase time:TemporalEntity de [OWL-TIME]. En este contexto, esto puede interpretarse como que implica que dct:PeriodOfTime es equivalente a la subclase time:ProperInterval."
+    }, {
+      "@language" : "en",
+      "@value" : "In the context of DCAT 2.0, use of the property time:hasEnd entails that value of the dct:temporal property is a member of the time:TemporalEntity class from [OWL-TIME]. In this context this could be taken to imply that dct:PeriodOfTime is equivalent to the subclass time:ProperInterval."
+    }, {
+      "@language" : "cs",
+      "@value" : "V kontextu DCAT 2.0, použití vlastnosti time:hasEnd znamená, že hodnota vlastnosti dct:temporal je instancí třídy time:TemporalEntity ze slovníku [OWL-TIME]. V tomto kontextu to může znamenat, že dct:PeriodOfTime je ekvivalentní podtřídě time:ProperInterval."
+    }, {
+      "@language" : "it",
+      "@value" : "Nel contesto di DCAT 2.0, l'uso della proprietà time:hasEnd comporta che il valore della proprietà dct:temporal è un membro della classe time:TemporalEntity di [OWL-TIME]. In questo contesto ciò potrebbe essere interpretato nel senso che dct:PeriodOfTime è equivalente alla sottoclasse time:ProperInterval."
+    } ]
+  }, {
+    "@id" : "http://www.w3.org/ns/dcat/external",
+    "@type" : "owl:Ontology",
+    "contributor" : [ "_:b3", "_:b4", "_:b1", "_:b6", "_:b7", "_:b8", "_:b9", "_:b10", "_:b11", "_:b12", "_:b13", "_:b14", "_:b15", "_:b16", "_:b17", "_:b18" ],
+    "creator" : [ "_:b5", "_:b2" ],
+    "license" : "https://creativecommons.org/licenses/by/4.0/",
+    "modified" : [ "2019-09-09", "2013-11-28", "2012-04-24", "2013-09-20", "2017-12-19" ],
+    "rdfs:comment" : {
+      "@language" : "en",
+      "@value" : "This RDF graph contains partial descriptions of elements from external vocabularies that are used by DCAT. The primary definitions for these terms are in the original specifications and standards. In the context of DCAT some additional axioms (sub-class and sub-property relationships) are introduced, and some more specific usage notes are added."
+    },
+    "rdfs:label" : {
+      "@language" : "en",
+      "@value" : "External terms used in the data catalog vocabulary."
+    },
+    "imports" : [ "http://www.w3.org/2004/02/skos/core", "http://purl.org/dc/terms/", "http://www.w3.org/ns/prov-o#", "http://www.w3.org/ns/odrl/2/" ]
+  }, {
+    "@id" : "locn:geometry",
+    "range" : "locn:Geometry",
+    "skos:changeNote" : [ {
+      "@language" : "es",
+      "@value" : "Esta propiedad fue agregada en DCAT 2.0."
+    }, {
+      "@language" : "en",
+      "@value" : "Property added in this context in DCAT 2.0."
+    }, {
+      "@language" : "it",
+      "@value" : "Proprietà aggiunta in questo contesto in DCAT 2.0."
+    }, {
+      "@language" : "cs",
+      "@value" : "Vlastnost v tomto kontextu byla přidána ve verzi DCAT 2.0."
+    } ],
+    "skos:definition" : [ {
+      "@language" : "es",
+      "@value" : "Asocia cualquier recurso con la geometría correspondiente."
+    }, {
+      "@language" : "en",
+      "@value" : "Associates any resource with the corresponding geometry."
+    }, {
+      "@language" : "cs",
+      "@value" : "Přiřazuje geometrii jakémukoliv zdroji."
+    }, {
+      "@language" : "it",
+      "@value" : "Associa qualsiasi risorsa alla geometria corrispondente."
+    } ],
+    "skos:scopeNote" : [ {
+      "@language" : "es",
+      "@value" : "El rango de esta propiedad (locn:Geometry) permite cualquier tipo de especificación de la geometría. Por ejemplo, la geometría podría estar codificada por un literal, como WKT (geosparql:wktLiteral [GeoSPARQL]), o representada por una clase, como geosparql:Geometry (o cualquiera de sus subclases) [GeoSPARQL]."
+    }, {
+      "@language" : "cs",
+      "@value" : "Rozsah této vlastnosti (locn: Geometry) umožňuje jakýkoli typ specifikace geometrie. Například geometrie může být kódována literálem, jako WKT (geosparql: wktLiteral [GeoSPARQL]), nebo reprezentována třídou, jako geosparql: Geometry (nebo jakoukoli z jeho podtříd) [GeoSPARQL]."
+    }, {
+      "@language" : "en",
+      "@value" : "The range of this property (locn:Geometry) allows for any type of geometry specification. E.g., the geometry could be encoded by a literal, as WKT (geosparql:wktLiteral [GeoSPARQL]), or represented by a class, as geosparql:Geometry (or any of its subclasses) [GeoSPARQL]."
+    }, {
+      "@language" : "it",
+      "@value" : "Il range di questa proprietà (locn:Geometry) permette di specificare ogni tipo di geometria.  Ad esempio, la geometria potrebbe essere codificata da un letterale, come WKT (geosparql:wktLiteral [GeoSPARQL]), o rappresentata da una classe, come geosparql:Geometry (o una delle sue sottoclassi) [GeoSPARQL]."
+    } ]
+  }, {
+    "@id" : "odrl:hasPolicy",
+    "skos:definition" : [ {
+      "@language" : "en",
+      "@value" : "In the context of DCAT 2.0 dcat:Resource, an ODRL conformant policy expressing the rights associated with the resource."
+    }, {
+      "@language" : "es",
+      "@value" : "En el contexto de DCAT 2.0 dcat:Resource, una reglamentación conforme a ODRL expresando los derechos asociados con el recurso [ODRL-VOCAB]."
+    }, {
+      "@language" : "en",
+      "@value" : "In the context of DCAT 2.0 dcat:Distribution, an ODRL conformant policy expressing the rights associated with the distribution."
+    }, {
+      "@language" : "en",
+      "@value" : "Identifies an ODRL Policy for which the identified Asset is the target Asset to all the Rules."
+    }, {
+      "@language" : "cs",
+      "@value" : "V kontextu DCAT 2.0 dcat:Distribution, pravidlo vyjadřující práva spojená s distribucí, pokud je použit slovník ODRL [ODRL-VOCAB]."
+    }, {
+      "@language" : "it",
+      "@value" : "Nel contesto di DCAT 2.0 dcat:Distribution, una policy conforme all'ODRL che esprime i diritti associati alla distribuzione."
+    }, {
+      "@language" : "es",
+      "@value" : "En el contexto de DCAT 2.0 dcat:Distribution, una reglamentación conforme a ODRL expresando los derechos asociados con la distribución [ODRL-VOCAB]."
+    }, {
+      "@language" : "it",
+      "@value" : "Nel contesto di DCAT 2.0 dcat:Resource, una policy conforme all'ODRL che esprime i diritti associati alla risorsa."
+    }, {
+      "@language" : "cs",
+      "@value" : "V kontextu DCAT 2.0 dcat:Resource, pravidlo vyjadřující práva spojená se zdrojem, pokud je použit slovník ODRL [ODRL-VOCAB]."
+    } ],
+    "skos:editorialNote" : {
+      "@language" : "en",
+      "@value" : "Czech translation to be updated."
+    },
+    "skos:scopeNote" : [ {
+      "@language" : "cs",
+      "@value" : "V kontextu DCAT 2.0 dcat:Resource, pro zdroj MŮŽE BÝT uvedena informace o právech vyjádřená pomocí pravidel slovníku ODRL [ODRL-VOCAB]. Viz také návod v sekci 'License and rights statements'."
+    }, {
+      "@language" : "en",
+      "@value" : "In the context of DCAT 2.0 dcat:Distribution, information about rights expressed as an ODRL policy [ODRL-MODEL] using the ODRL vocabulary [ODRL-VOCAB] MAY be provided for the distribution. See also guidance at the section 'License and rights statements'."
+    }, {
+      "@language" : "es",
+      "@value" : "En el contexto de DCAT 2.0 dcat:Distribution, información sobre los derechos expresados como reglamentación ODRL [ODRL-MODEL] using the ODRL vocabulary [ODRL-VOCAB] PUEDE proveerse para el Distribución. Ver también la información en la sección 'License and rights statements.'"
+    }, {
+      "@language" : "en",
+      "@value" : "In the context of DCAT 2.0 dcat:Resource, information about rights expressed as an ODRL policy [ODRL-MODEL] using the ODRL vocabulary [ODRL-VOCAB] MAY be provided for the resource. See also guidance at the section 'License and rights statements'."
+    }, {
+      "@language" : "it",
+      "@value" : "Nel contesto DCAT 2.0 dcat:Resource, le informazioni sui diritti espressi come policy ODRL [ODRL-MODEL] utilizzando il vocabolario ODRL [ODRL-VOCAB] POSSONO essere fornite per la risorsa. Si veda anche la guida alla sezione 'Licenza e dichiarazioni sui diritti'."
+    }, {
+      "@language" : "es",
+      "@value" : "En el contexto de DCAT 2.0 dcat:Resource, información sobre los derechos expresados como reglamentación ODRL [ODRL-MODEL] usando el vocabulario ODRL [ODRL-VOCAB] PUEDE proveerse para el Recurso. Ver también la información en la sección 'License and rights statements'."
+    }, {
+      "@language" : "it",
+      "@value" : "Nel contesto di DCAT 2.0 dcat:Distribution, le informazioni sui diritti espressi come policy ODRL [ODRL-MODEL] utilizzando il vocabolario ODRL [ODRL-VOCAB] POSSONO essere fornite per la distribuzione. Si veda anche la guida alla sezione 'Licenza e dichiarazioni sui diritti'."
+    }, {
+      "@language" : "cs",
+      "@value" : "V kontextu DCAT 2.0 dcat:Distribution, pro distribuci MŮŽE BÝT uvedena informace o právech vyjádřená pomocí pravidel slovníku ODRL [ODRL-VOCAB]. Viz také návod v sekci 10. 'License and rights statements'."
+    } ]
+  }, {
+    "@id" : "prov:alternateOf",
+    "subPropertyOf" : "dct:relation"
+  }, {
+    "@id" : "prov:hadPrimarySource",
+    "subPropertyOf" : "dct:relation"
+  }, {
+    "@id" : "prov:qualifiedAttribution",
+    "skos:changeNote" : [ {
+      "@language" : "cs",
+      "@value" : "Vlastnost v tomto kontextu byla přidána ve verzi DCAT 2.0."
+    }, {
+      "@language" : "es",
+      "@value" : "Esta propiedad fue agregada en DCAT 2.0."
+    }, {
+      "@language" : "it",
+      "@value" : "Proprietà aggiunta in questo contesto in DCAT 2.0."
+    }, {
+      "@language" : "en",
+      "@value" : "Property added in this context in DCAT 2.0."
+    } ],
+    "skos:definition" : [ {
+      "@language" : "it",
+      "@value" : "Nel contesto di DCAT 2.0, collegamento a un agente che ha una qualche forma di responsabilità per la risorsa."
+    }, {
+      "@language" : "en",
+      "@value" : "In the context of DCAT 2.0, link to an Agent having some form of responsibility for the resource."
+    }, {
+      "@language" : "cs",
+      "@value" : "V kontextu DCAT 2.0, odkaz na Agenta, který má nějaký typ odpovědnosti za zdroj."
+    }, {
+      "@language" : "es",
+      "@value" : "En el contexto de DCAT 2.0, enlace a un Agente que tiene alguna forma de responsabilidad con el recurso."
+    } ],
+    "skos:scopeNote" : [ {
+      "@language" : "it",
+      "@value" : "Nel contesto di DCAT 2.0, utilizzato per collegarsi a un agente in cui la natura della relazione è nota ma non corrisponde a una delle proprietà Dublin Core standard (dct: creatore, dct: editore). Si usi dcat:hadRole su prov:Attribution per rappresentare la responsabilità dell'Agente in relazione alla Risorsa. Si veda https://w3c.github.io/dxwg/dcat/#qualified-attribution per gli esempi di utilizzo."
+    }, {
+      "@language" : "en",
+      "@value" : "In the context of DCAT 2.0, used to link to an Agent where the nature of the relationship is known but does not match one of the standard Dublin Core properties (dct:creator, dct:publisher). Use dcat:hadRole on the prov:Attribution to capture the responsibility of the Agent with respect to the Resource. See https://w3c.github.io/dxwg/dcat/#qualified-attribution for usage examples."
+    }, {
+      "@language" : "es",
+      "@value" : "En el contexto de DCAT 2.0, se usa para asociar un Agente cuando la naturaleza de la relación es conocida pero no es ninguna de las asociaciones estándares descriptas con propiedades de Dublin Core (dct:creator, dct:publisher). Se usa dcat:hadRole en la prov:Attribution para capturar la responsabilidad del Agente con respecto al Recurso. Ver https://w3c.github.io/dxwg/dcat/#qualified-attribution para más ejemplos de uso."
+    }, {
+      "@language" : "cs",
+      "@value" : "V kontextu DCAT 2.0, vlastnost se používá pro odkaz na Agenta tam, kde typ vztahu je znám, ale neodpovídá žádné ze standardních vlastností Dublin Core (dct:creator, dct:publisher). Pro reprezentaci vztahu Agenta ke zdroji použijte vlastnost dcat:hadRole na třídě prov:Attribution. Viz  https://w3c.github.io/dxwg/dcat/#qualified-attribution pro příklady užití."
+    } ]
+  }, {
+    "@id" : "prov:specializationOf",
+    "subPropertyOf" : "dct:relation"
+  }, {
+    "@id" : "prov:wasAttributedTo",
+    "subPropertyOf" : "dct:relation"
+  }, {
+    "@id" : "prov:wasDerivedFrom",
+    "subPropertyOf" : "dct:relation"
+  }, {
+    "@id" : "prov:wasGeneratedBy",
+    "subPropertyOf" : "dct:relation",
+    "skos:changeNote" : [ {
+      "@language" : "it",
+      "@value" : "Proprietà aggiunta in questo contesto in DCAT 2.0."
+    }, {
+      "@language" : "es",
+      "@value" : "Esta propiedad fue agregada en DCAT 2.0."
+    }, {
+      "@language" : "en",
+      "@value" : "Property added in this context in DCAT 2.0."
+    }, {
+      "@language" : "cs",
+      "@value" : "Vlastnost v tomto kontextu byla přidána ve verzi DCAT 2.0"
+    } ],
+    "skos:definition" : {
+      "@language" : "en",
+      "@value" : "In the context of DCAT 2.0 dcat:Dataset, an activity that generated, or provides the business context for, the creation of the dataset."
+    },
+    "skos:scopeNote" : [ {
+      "@language" : "es",
+      "@value" : "En el contexto de DCAT 2.0 dcat:Dataset, utiliza prov:qualifiedGeneration para adjuntar detalles adicionales sobre la relación entre el conjunto de datos y la actividad activity, por ejemplo, el tiempo exacto en el que se produjo el conjunto de datose durante la vida de un proyecto."
+    }, {
+      "@language" : "it",
+      "@value" : "Nel contesto di DCAT 2.0 dcat:Dataset, utilizzare prov:qualifiedGeneration per allegare ulteriori dettagli sulla relazione tra il dataset e l'attività, ad esempio l'ora esatta in cui il dataset è stato prodotto durante la vita di un progetto."
+    }, {
+      "@language" : "cs",
+      "@value" : "V kontextu DCAT 2.0 dcat:Dataset, aktivitou spojenou s tvorbou datové sady typicky bývá iniciativa, projekt, mise, rešerše, průběžná aktivita (běžný chod podniku) apod. Pro zaznamenání kontextu datové sady na více úrovních granulariy lze použít více hodnot vlastnosti prov:wasGeneratedBy."
+    }, {
+      "@language" : "es",
+      "@value" : "En el contexto de DCAT 2.0 dcat:Dataset, la actividad asociada con la generación de un conjunto de datos. Típicamente es una iniciativa, proyecto, misión, encuensta, una actividad contínua (la actividad usual) etc. Se pueden usar múltiples propiedades  prov:wasGeneratedBy para indicar el contexto de producción del conjunto de datos en disintos niveles de granularidad."
+    }, {
+      "@language" : "cs",
+      "@value" : "V kontextu DCAT 2.0 dcat:Dataset, pro připojení podrobností o vztahu mezi datovou sadou a aktivitou, např. přesný čas kdy byla datová sada vyprodukována během životního cyklu projektu, použijte prov:qualifiedGeneration."
+    }, {
+      "@language" : "en",
+      "@value" : "In the context of DCAT 2.0 dcat:Dataset, the activity associated with generation of a dataset will typically be an initiative, project, mission, survey, on-going activity ('business as usual') etc. Multiple prov:wasGeneratedBy properties can be used to indicate the dataset production context at various levels of granularity."
+    }, {
+      "@language" : "it",
+      "@value" : "Nel contesto di DCAT 2.0 dcat:Dataset, l'attività associata alla generazione di un dataset sarà tipicamente un'iniziativa, progetto, missione, indagine, attività in corso ('business as usual'), ecc. Multiple prov:wasGeneratedBy  possono essere utilizzate per indicare il contesto di produzione del dataset a vari livelli di granularità."
+    }, {
+      "@language" : "en",
+      "@value" : "In the context of DCAT 2.0 dcat:Dataset, use prov:qualifiedGeneration to attach additional details about the relationship between the dataset and the activity, e.g. the exact time that the dataset was produced during the lifetime of a project."
+    } ]
+  }, {
+    "@id" : "prov:wasInfluencedBy",
+    "subPropertyOf" : "dct:relation"
+  }, {
+    "@id" : "prov:wasQuotedFrom",
+    "subPropertyOf" : "dct:relation"
+  }, {
+    "@id" : "prov:wasRevisionOf",
+    "subPropertyOf" : "dct:relation"
+  }, {
+    "@id" : "foaf:homepage",
+    "skos:definition" : [ {
+      "@language" : "it",
+      "@value" : "Una homepage per qualche cosa."
+    }, {
+      "@language" : "it",
+      "@value" : "Nel contesto di DCAT 2.0 dcat:Catalog, una homepage del catalogo (un documento Web pubblico solitamente disponibile in HTML)."
+    }, {
+      "@language" : "en",
+      "@value" : "In the context of DCAT 2.0 dcat:Catalog, a homepage of the catalog (a public Web document usually available in HTML)."
+    }, {
+      "@language" : "en",
+      "@value" : "A homepage for some thing."
+    } ],
+    "skos:scopeNote" : [ {
+      "@language" : "it",
+      "@value" : "foaf:homepage è una proprietà funzionale inversa (IFP), il che significa che DEVE essere unica e identificare con precisione la pagina web della risorsa. Nel contesto di DCAT 2.0, questa proprietà indica la pagina web canonica, che potrebbe essere utile nei casi in cui ci sia più di una pagina web sulla risorsa."
+    }, {
+      "@language" : "cs",
+      "@value" : "foaf:homepage je inverzní funkčí vlastnost, což znamená, že MUSÍ být unikátní a MUSÍ přesně označovat webovou stránku zdroje. V kontextu DCAT 2.0, označuje hlavní webovou stránku, což se může hodit v případě, že webových stránek o zdroji existuje více."
+    }, {
+      "@language" : "en",
+      "@value" : "foaf:homepage is an inverse functional property (IFP), which means that it MUST be unique and precisely identify the web-page for the resource. In the context of DCAT 2.0, this property indicates the canonical web-page, which might be helpful in cases where there is more than one web-page about the resource."
+    }, {
+      "@language" : "es",
+      "@value" : "foaf:homepage es la propiedad funcional inversa (IFP por sus siglas en inglés), lo que significa que DEBE ser única y identificar la página web del recurso percisamente. En el contexto de DCAT 2.0, esta propiedad indica la página web canónica, que pude ser útil en casos en los que hay más de una página web para el recurso."
+    } ]
+  }, {
+    "@id" : "foaf:primaryTopic",
+    "skos:definition" : [ {
+      "@language" : "es",
+      "@value" : "En el contexto de DCAT 2.0 dcat:CatalogRecord, el dcat:Resource (conjunto de datos o servicio) descripto en el registro."
+    }, {
+      "@language" : "cs",
+      "@value" : "V kontextu DCAT 2.0 dcat:CatalogRecord, dcat:Resource (datová sada či služba) popsaná katalogizačním záznamem."
+    }, {
+      "@language" : "it",
+      "@value" : "Nel contesto di DCAT 2.0 dcat:CatalogRecord, il dcat:Resource (set di dati o servizio) descritto nel record."
+    }, {
+      "@language" : "en",
+      "@value" : "The primary topic of some page or document."
+    }, {
+      "@language" : "it",
+      "@value" : "L'argomento principale di qualche pagina o documento."
+    }, {
+      "@language" : "en",
+      "@value" : "In the context of DCAT 2.0 dcat:CatalogRecord, the dcat:Resource (dataset or service) described in the record."
+    } ],
+    "skos:scopeNote" : [ {
+      "@language" : "es",
+      "@value" : "La propiedad foaf:primaryTopic es funcional: en el contexto de DCAT 2.0,  cada registro del catálogo puede tener a lo sumo un tópico principal, es decir un tópico que describa el conjunto de datos o servicio."
+    }, {
+      "@language" : "it",
+      "@value" : "foaf:primaryTopic property è funzionale: nel contesto di DCAT 2.0, ogni record di catalogo può avere al massimo un argomento primario, cioè descrive un set di dati o un servizio."
+    }, {
+      "@language" : "cs",
+      "@value" : "Vlastnost foaf:primaryTopic je funkce: v kontextu DCAT 2.0, každý katalogizační záznam může mít nejvýše jednu hodnotu foaf:primaryTopic, tj. popisuje nejvýše jednu datovou sadu či službu."
+    }, {
+      "@language" : "en",
+      "@value" : "foaf:primaryTopic property is functional: in the context of DCAT 2.0, each catalog record can have at most one primary topic i.e. describes one dataset or service."
+    } ]
+  } ],
+  "@context" : {
+    "subPropertyOf" : {
+      "@id" : "http://www.w3.org/2000/01/rdf-schema#subPropertyOf",
+      "@type" : "@id"
+    },
+    "scopeNote" : {
+      "@id" : "http://www.w3.org/2004/02/skos/core#scopeNote",
+      "@type" : "http://www.w3.org/1999/02/22-rdf-syntax-ns#langString"
+    },
+    "definition" : {
+      "@id" : "http://www.w3.org/2004/02/skos/core#definition",
+      "@type" : "http://www.w3.org/1999/02/22-rdf-syntax-ns#langString"
+    },
+    "name" : {
+      "@id" : "http://xmlns.com/foaf/0.1/name",
+      "@type" : "http://www.w3.org/2001/XMLSchema#string"
+    },
+    "homepage" : {
+      "@id" : "http://xmlns.com/foaf/0.1/homepage",
+      "@type" : "@id"
+    },
+    "seeAlso" : {
+      "@id" : "http://www.w3.org/2000/01/rdf-schema#seeAlso",
+      "@type" : "@id"
+    },
+    "imports" : {
+      "@id" : "http://www.w3.org/2002/07/owl#imports",
+      "@type" : "@id"
+    },
+    "modified" : {
+      "@id" : "http://purl.org/dc/terms/modified",
+      "@type" : "http://www.w3.org/2001/XMLSchema#date"
+    },
+    "contributor" : {
+      "@id" : "http://purl.org/dc/terms/contributor",
+      "@type" : "@id"
+    },
+    "creator" : {
+      "@id" : "http://purl.org/dc/terms/creator",
+      "@type" : "@id"
+    },
+    "label" : {
+      "@id" : "http://www.w3.org/2000/01/rdf-schema#label",
+      "@type" : "http://www.w3.org/1999/02/22-rdf-syntax-ns#langString"
+    },
+    "comment" : {
+      "@id" : "http://www.w3.org/2000/01/rdf-schema#comment",
+      "@type" : "http://www.w3.org/1999/02/22-rdf-syntax-ns#langString"
+    },
+    "license" : {
+      "@id" : "http://purl.org/dc/terms/license",
+      "@type" : "@id"
+    },
+    "changeNote" : {
+      "@id" : "http://www.w3.org/2004/02/skos/core#changeNote",
+      "@type" : "http://www.w3.org/1999/02/22-rdf-syntax-ns#langString"
+    },
+    "affiliation" : {
+      "@id" : "http://schema.org/affiliation",
+      "@type" : "@id"
+    },
+    "range" : {
+      "@id" : "http://www.w3.org/2000/01/rdf-schema#range",
+      "@type" : "@id"
+    },
+    "editorialNote" : {
+      "@id" : "http://www.w3.org/2004/02/skos/core#editorialNote",
+      "@type" : "http://www.w3.org/1999/02/22-rdf-syntax-ns#langString"
+    },
+    "workInfoHomepage" : {
+      "@id" : "http://xmlns.com/foaf/0.1/workInfoHomepage",
+      "@type" : "@id"
+    },
+    "owl" : "http://www.w3.org/2002/07/owl#",
+    "xsd" : "http://www.w3.org/2001/XMLSchema#",
+    "skos" : "http://www.w3.org/2004/02/skos/core#",
+    "rdfs" : "http://www.w3.org/2000/01/rdf-schema#",
+    "dct" : "http://purl.org/dc/terms/",
+    "rdf" : "http://www.w3.org/1999/02/22-rdf-syntax-ns#",
+    "time" : "http://www.w3.org/2006/time#",
+    "dcat" : "http://www.w3.org/ns/dcat#",
+    "locn" : "http://www.w3.org/ns/locn#",
+    "odrl" : "http://www.w3.org/ns/odrl/2/",
+    "prov" : "http://www.w3.org/ns/prov#",
+    "foaf" : "http://xmlns.com/foaf/0.1/",
+    "sdo" : "http://schema.org/"
+  }
+}

--- a/dcat/rdf/dcat-external.rdf
+++ b/dcat/rdf/dcat-external.rdf
@@ -1,911 +1,634 @@
-<?xml version="1.0"?>
-<rdf:RDF xmlns="http://www.w3.org/ns/dcat/external#"
-     xml:base="http://www.w3.org/ns/dcat/external"
-     xmlns:owl="http://www.w3.org/2002/07/owl#"
-     xmlns:xsd="http://www.w3.org/2001/XMLSchema#"
-     xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-     xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
-     xmlns:dct="http://purl.org/dc/terms/"
-     xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-     xmlns:xml="http://www.w3.org/XML/1998/namespace"
-     xmlns:time="http://www.w3.org/2006/time#"
-     xmlns:odrl="http://www.w3.org/ns/odrl/2/"
-     xmlns:locn="http://www.w3.org/ns/locn#"
-     xmlns:dcat="http://www.w3.org/ns/dcat#"
-     xmlns:prov="http://www.w3.org/ns/prov#"
-     xmlns:foaf="http://xmlns.com/foaf/0.1/"
-     xmlns:sdo="http://schema.org/">
-    <owl:Ontology rdf:about="http://www.w3.org/ns/dcat/external">
-        <owl:imports rdf:resource="http://www.w3.org/ns/odrl/2/"/>
-        <owl:imports rdf:resource="http://www.w3.org/ns/prov-o#"/>
-        <owl:imports rdf:resource="http://purl.org/dc/terms/"/>
-        <owl:imports rdf:resource="http://www.w3.org/2004/02/skos/core"/>
-        <dct:contributor>
-            <rdf:Description>
-                <sdo:affiliation>
-                    <rdf:Description>
-                        <foaf:homepage rdf:resource="http://www.refinitiv.com"/>
-                        <foaf:name>Refinitiv</foaf:name>
-                    </rdf:Description>
-                </sdo:affiliation>
-                <foaf:name>David Browning</foaf:name>
-            </rdf:Description>
-        </dct:contributor>
-        <dct:contributor>
-            <rdf:Description>
-                <foaf:name>Martin Alvarez-Espinar</foaf:name>
-            </rdf:Description>
-        </dct:contributor>
-        <dct:contributor>
-            <rdf:Description>
-                <foaf:name>Alejandra Gonzalez-Beltran</foaf:name>
-                <sdo:affiliation>
-                    <rdf:Description>
-                        <foaf:homepage rdf:resource="http://stfc.ac.uk"/>
-                        <foaf:name>Science and Technology Facilities Council, UK</foaf:name>
-                    </rdf:Description>
-                </sdo:affiliation>
-                <foaf:homepage rdf:resource="https://agbeltran.github.io"/>
-                <rdfs:seeAlso rdf:resource="https://orcid.org/0000-0003-3499-8262"/>
-            </rdf:Description>
-        </dct:contributor>
-        <dct:contributor>
-            <rdf:Description>
-                <foaf:name>Richard Cyganiak</foaf:name>
-            </rdf:Description>
-        </dct:contributor>
-        <dct:contributor>
-            <rdf:Description>
-                <foaf:name>Marios Meimaris</foaf:name>
-            </rdf:Description>
-        </dct:contributor>
-        <dct:contributor>
-            <rdf:Description>
-                <rdfs:seeAlso rdf:resource="https://orcid.org/0000-0002-3884-3420"/>
-                <foaf:name>Simon J D Cox</foaf:name>
-                <sdo:affiliation>
-                    <rdf:Description>
-                        <foaf:homepage rdf:resource="https://csiro.au"/>
-                        <foaf:name>Commonwealth Scientific and Industrial Research Organisation</foaf:name>
-                    </rdf:Description>
-                </sdo:affiliation>
-                <rdf:type rdf:resource="http://xmlns.com/foaf/0.1/Person"/>
-                <foaf:workInfoHomepage rdf:resource="http://people.csiro.au/Simon-Cox"/>
-            </rdf:Description>
-        </dct:contributor>
-        <rdfs:label xml:lang="en">External terms used in the data catalog vocabulary.</rdfs:label>
-        <rdfs:comment xml:lang="en">This RDF graph contains partial descriptions of elements from external vocabularies that are used by DCAT. The primary definitions for these terms are in the original specifications and standards. In the context of DCAT some additional axioms (sub-class and sub-property relationships) are introduced, and some more specific usage notes are added.</rdfs:comment>
-        <dct:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2012-04-24</dct:modified>
-        <dct:contributor>
-            <rdf:Description>
-                <sdo:affiliation rdf:resource="http://www.w3.org/data#W3C"/>
-                <foaf:homepage rdf:resource="http://www.w3.org/People/all#phila"/>
-                <foaf:name>Phil Archer</foaf:name>
-                <rdfs:seeAlso rdf:resource="http://philarcher.org/foaf.rdf#me"/>
-            </rdf:Description>
-        </dct:contributor>
-        <dct:contributor>
-            <rdf:Description>
-                <foaf:name>Boris Villazón-Terrazas</foaf:name>
-            </rdf:Description>
-        </dct:contributor>
-        <dct:contributor>
-            <rdf:Description>
-                <foaf:homepage rdf:resource="http://makxdekkers.com/"/>
-                <foaf:name>Makx Dekkers</foaf:name>
-                <rdfs:seeAlso rdf:resource="http://makxdekkers.com/makxdekkers.rdf#me"/>
-            </rdf:Description>
-        </dct:contributor>
-        <dct:contributor>
-            <rdf:Description>
-                <sdo:affiliation>
-                    <rdf:Description>
-                        <foaf:homepage rdf:resource="http://okfn.org"/>
-                        <foaf:name>Open Knowledge Foundation</foaf:name>
-                    </rdf:Description>
-                </sdo:affiliation>
-                <foaf:name>Rufus Pollock</foaf:name>
-            </rdf:Description>
-        </dct:contributor>
-        <dct:contributor>
-            <rdf:Description>
-                <foaf:name>Andrea Perego</foaf:name>
-                <foaf:homepage rdf:resource="http://www.andrea-perego.name/foaf/#me"/>
-                <rdfs:seeAlso rdf:resource="https://orcid.org/0000-0001-9300-2694"/>
-            </rdf:Description>
-        </dct:contributor>
-        <dct:contributor>
-            <rdf:Description>
-                <foaf:homepage rdf:resource="http://www.imati.cnr.it/index.php/people/8-curricula/178-riccardo-albertoni"/>
-                <foaf:name>Riccardo Albertoni</foaf:name>
-                <rdfs:seeAlso rdf:resource="https://orcid.org/0000-0001-5648-2713"/>
-                <foaf:homepage rdf:resource="https://w3id.org/people/ralbertoni/"/>
-            </rdf:Description>
-        </dct:contributor>
-        <dct:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2013-11-28</dct:modified>
-        <dct:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2019-09-09</dct:modified>
-        <dct:contributor>
-            <rdf:Description>
-                <foaf:name>Ghislain Auguste Atemezing</foaf:name>
-                <rdfs:seeAlso rdf:resource="http://www.eurecom.fr/~atemezin/gatemezing-foaf.rdf"/>
-            </rdf:Description>
-        </dct:contributor>
-        <dct:contributor>
-            <rdf:Description>
-                <rdfs:seeAlso rdf:resource="https://jakub.klímek.com/#me"/>
-                <foaf:homepage rdf:resource="https://jakub.klímek.com/"/>
-                <foaf:name>Jakub Klímek</foaf:name>
-            </rdf:Description>
-        </dct:contributor>
-        <dct:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2017-12-19</dct:modified>
-        <dct:creator>
-            <rdf:Description>
-                <foaf:name>Fadi Maali</foaf:name>
-                <rdfs:seeAlso rdf:resource="http://fadmaa.me/foaf.ttl"/>
-            </rdf:Description>
-        </dct:creator>
-        <dct:creator>
-            <rdf:Description>
-                <foaf:name>John Erickson</foaf:name>
-            </rdf:Description>
-        </dct:creator>
-        <dct:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2013-09-20</dct:modified>
-        <dct:license rdf:resource="https://creativecommons.org/licenses/by/4.0/"/>
-        <dct:contributor>
-            <rdf:Description>
-                <foaf:homepage rdf:resource="http://www.asahi-net.or.jp/~ax2s-kmtn/"/>
-                <foaf:name>Shuji Kamitsuna</foaf:name>
-            </rdf:Description>
-        </dct:contributor>
-        <dct:contributor>
-            <rdf:Description>
-                <sdo:affiliation>
-                    <rdf:Description>
-                        <foaf:homepage rdf:resource="http://ec.europa.eu/dgs/informatics/"/>
-                        <foaf:name>European Commission, DG DIGIT</foaf:name>
-                    </rdf:Description>
-                </sdo:affiliation>
-                <foaf:name>Vassilios Peristeras</foaf:name>
-            </rdf:Description>
-        </dct:contributor>
-    </owl:Ontology>
-    
-
-
-    <!-- 
-    ///////////////////////////////////////////////////////////////////////////////////////
-    //
-    // Annotation properties
-    //
-    ///////////////////////////////////////////////////////////////////////////////////////
-     -->
-
-    
-
-
-    <!-- http://purl.org/dc/terms/creator -->
-
-    <rdf:Description rdf:about="http://purl.org/dc/terms/creator">
-        <skos:changeNote xml:lang="es">Esta propiedad fue agregada en DCAT 2.0, específicamente para tratar los requerimientos de cita de datos.</skos:changeNote>
-        <skos:changeNote xml:lang="en">Property added in this context in DCAT 2.0, specifically to address data citation requirements.</skos:changeNote>
-        <skos:changeNote xml:lang="it">Proprietà aggiunta in questo contesto in DCAT 2.0, in particolare per soddisfare i requisiti di citazione dei dati.</skos:changeNote>
-        <skos:changeNote xml:lang="cs">Vlastnost v tomto kontextu byla přidána ve verzi DCAT 2.0 zejména za účelem uspokojení požadavků na citace dat.</skos:changeNote>
-        <skos:definition xml:lang="en">An entity primarily responsible for making the resource.</skos:definition>
-        <skos:definition xml:lang="es">En el contexto de DCAT 2.0, la entidad responsable de producier el recurso.</skos:definition>
-        <skos:definition xml:lang="en">In the context of DCAT 2.0, the entity responsible for producing the resource.</skos:definition>
-        <skos:definition xml:lang="it">Nel contesto del DCAT 2.0, l&apos;entità responsabile della produzione della risorsa.</skos:definition>
-        <skos:definition xml:lang="it">Un&apos;entità principalmente responsabile della creazione della risorsa.</skos:definition>
-        <skos:definition xml:lang="cs">V kontextu DCAT 2.0, entita zodpovědná za tvorbu zdroje.</skos:definition>
-        <skos:scopeNote xml:lang="es">En el contexto de DCAT 2.0, se recomienda que los valores de esta propiedad sean recurso de tipo foaf:Agent.</skos:scopeNote>
-        <skos:scopeNote xml:lang="en">In the context of DCAT 2.0, resources of type foaf:Agent are recommended as values for this property.</skos:scopeNote>
-        <skos:scopeNote xml:lang="it">Nel contesto di DCAT 2.0, si raccomandano come valori per questa proprietà le risorse di tipo foaf:Agent.</skos:scopeNote>
-        <skos:scopeNote xml:lang="cs">V kontextu DCAT 2.0, doporučovanou hodnotou této vlastnosti jsou zdroje typu foaf:Agent.</skos:scopeNote>
-    </rdf:Description>
-    
-
-
-    <!-- http://purl.org/dc/terms/license -->
-
-    <rdf:Description rdf:about="http://purl.org/dc/terms/license">
-        <skos:definition xml:lang="en">A legal document giving official permission to do something with the resource.</skos:definition>
-        <skos:definition xml:lang="es">En el contexto de DCAT 2.0 dcat:DataService, uh documento legal bajo el cuál se hace disponible el servicio.</skos:definition>
-        <skos:definition xml:lang="es">En el contexto de DCAT 2.0 dcat:Distribution, uh documento legal bajo el cuál se hace disponible la distribución.</skos:definition>
-        <skos:definition xml:lang="es">En el contexto de DCAT 2.0 dcat:Resource, uh documento legal bajo el cuál se hace disponible el recurso.</skos:definition>
-        <skos:definition xml:lang="en">In the context of DCAT 2.0 dcat:DataService, a legal document under which the service is made available.</skos:definition>
-        <skos:definition xml:lang="en">In the context of DCAT 2.0 dcat:Distribution, a legal document under which the distribution is made available.</skos:definition>
-        <skos:definition xml:lang="en">In the context of DCAT 2.0 dcat:Resource, a legal document under which the resource is made available.</skos:definition>
-        <skos:definition xml:lang="it">Nel contesto di DCAT 2.0 dcat:Distribution, un documento legale in base al quale viene resa disponibile la distribuzione.</skos:definition>
-        <skos:definition xml:lang="it">Nel contesto di DCAT 2.0 dcat:Resource, un documento legale in base al quale la risorsa è resa disponibile.</skos:definition>
-        <skos:definition xml:lang="it">Nell&apos;ambito di DCAT 2.0 dcat:DataService, un documento legale in base al quale il servizio è reso disponibile.</skos:definition>
-        <skos:definition xml:lang="it">Un documento legale che dà il permesso ufficiale di fare qualcosa con la risorsa.</skos:definition>
-        <skos:definition xml:lang="cs">V kontextu DCAT 2.0 dcat:DataService, právní dokument popisující podmínky užití služby.</skos:definition>
-        <skos:definition xml:lang="cs">V kontextu DCAT 2.0 dcat:Distribution, právní dokument popisující podmínky užití distribuce.</skos:definition>
-        <skos:definition xml:lang="cs">V kontextu DCAT 2.0 dcat:Resource, právní dokument popisující podmínky užití zdroje.</skos:definition>
-        <skos:scopeNote xml:lang="es">En el contexto de DCAT 2.0 dcat:Resource, PUEDE proveerse información sobre licencias y derechos para el Recurso. Vea también información en la sección &apos;License and rights statements&apos;.</skos:scopeNote>
-        <skos:scopeNote xml:lang="es">En el contexto de DCAT 2.0, la información sobre licencias y derechos DEBERÍA darse a nivel de la Distribución. La información sobre licencias y derechos PUEDE proveerse también para un conjunto de datos pero no en lugar de la información para la distribución del conjunto de datos. Se DEBERÍA evitar dar información de licencia o derechos para un conjunto de datos que es diferente de la de su distribución ya que en este caso puede haber conflictos legales. Ver más información en la sección &apos;License and rights statements&apos;.</skos:scopeNote>
-        <skos:scopeNote xml:lang="en">In the context of DCAT 2.0 dcat:Resource, information about licenses and rights MAY be provided for the Resource. See also guidance in the section &apos;License and rights statements&apos;.</skos:scopeNote>
-        <skos:scopeNote xml:lang="en">In the context of DCAT 2.0, information about licenses and rights SHOULD be provided on the level of Distribution. Information about licenses and rights MAY be provided for a Dataset in addition to but not instead of the information provided for the Distributions of that Dataset. Providing license or rights information for a Dataset that is different from information provided for a Distribution of that Dataset SHOULD be avoided as this can create legal conflicts. See also guidance in the section &apos;License and rights statements&apos;.</skos:scopeNote>
-        <skos:scopeNote xml:lang="it">Nel contesto di DCAT 2.0 dcat:Resource, le informazioni sulle licenze e i diritti POSSONO essere fornite per la risorsa. Si veda anche la guida nella sezione &apos;Licenze e dichiarazioni dei diritti&apos;.</skos:scopeNote>
-        <skos:scopeNote xml:lang="it">Nell&apos;ambito del DCAT 2.0, le informazioni su licenze e diritti dovrebbero essere fornite a livello di distribuzione. Le informazioni su licenze e diritti POSSONO essere fornite per un set di dati in aggiunta ma non in alternativa alle informazioni fornite per le distribuzioni di tale set di dati. La fornitura di informazioni sulla licenza o sui diritti per un set di dati che è diverso dalle informazioni fornite per una distribuzione di quel set di dati DOVREBBBE essere evitato in quanto ciò può creare conflitti legali. Si veda anche la guida nella sezione &apos;Licenze e dichiarazioni dei diritti&apos;.</skos:scopeNote>
-        <skos:scopeNote xml:lang="cs">V kontextu DCAT 2.0 dcat:Resource, pro Zdroj MŮŽE BÝT uvedena informace o podmínkách užití (licencích a právech). Viz návod v sekci &apos;License and rights statements&apos;.</skos:scopeNote>
-        <skos:scopeNote xml:lang="cs">V kontextu DCAT 2.0, informace o podmínkách užití (licencích a právech) BY MĚLY být poskytnuty na úrovni distribuce. Navíc, nikoliv místo, MOHOU BÝT informace o podmínkách užití (licencích a právech) poskytnuty na úrovni datové sady. NEMĚLY BY SE poskytnout různé podmínky užití pro datovou sadu a pro její distribuci, jelikož to může vést ke sporům v právním výkladu. Viz také návod v sekci &apos;License and rights statements&apos;.</skos:scopeNote>
-    </rdf:Description>
-    
-
-
-    <!-- http://purl.org/dc/terms/modified -->
-
-    <rdf:Description rdf:about="http://purl.org/dc/terms/modified">
-        <skos:definition xml:lang="it">Data in cui la risorsa è stata cambiata.</skos:definition>
-        <skos:definition xml:lang="en">Date on which the resource was changed.</skos:definition>
-        <skos:definition xml:lang="es">En el contexto de DCAT 2.0 dcat:CatalogRecord, la fecha más reciente en la que se modificó o actualizó la entrada del catálogo.</skos:definition>
-        <skos:definition xml:lang="es">En el contexto de DCAT 2.0 dcat:Distribution, la fecha más reciente en la que se modificó o actualizó la distribución.</skos:definition>
-        <skos:definition xml:lang="es">En el contexto de DCAT 2.0 dcat:Resource, la fecha más reciente en la que se modificó o actualizó el ítem del catálogo.</skos:definition>
-        <skos:definition xml:lang="en">In the context of DCAT 2.0 dcat:CatalogRecord, most recent date on which the catalog entry was changed, updated or modified.</skos:definition>
-        <skos:definition xml:lang="en">In the context of DCAT 2.0 dcat:Distribution, most recent date on which the distribution  was changed, updated or modified.</skos:definition>
-        <skos:definition xml:lang="en">In the context of DCAT 2.0 dcat:Resource, most recent date on which the item was changed, updated or modified.</skos:definition>
-        <skos:definition xml:lang="it">Nel contesto di DCAT 2.0 dcat:CatalogRecord, la data più recente in cui la voce di catalogo è stata cambiata, aggiornata o modificata.</skos:definition>
-        <skos:definition xml:lang="it">Nel contesto di DCAT 2.0 dcat:Distribution, la data più recente in cui la distribuzione è stata cambiata, aggiornata o modificata.</skos:definition>
-        <skos:definition xml:lang="it">Nel contesto di DCAT 2.0 dcat:Resource, la data più recente in cui l&apos;elemento è stato cambiato, aggiornato o modificato.</skos:definition>
-        <skos:definition xml:lang="cs">V kontextu DCAT 2.0 dcat:CatalogRecord, poslední datum kdy byl katalogizační záznam změněn či aktualizován.</skos:definition>
-        <skos:definition xml:lang="cs">V kontextu DCAT 2.0 dcat:Distribution, poslední datum kdy byla distribuce změněna či aktualizována.</skos:definition>
-        <skos:definition xml:lang="cs">V kontextu DCAT 2.0 dcat:Resource, poslední datum kdy byla položka změněna či aktualizována.</skos:definition>
-        <skos:scopeNote xml:lang="es">En el contexto de DCAT 2.0 dcat:CatalogRecord, indica la fecha en que se hizo la última modificación a la entrada del catálogo, es decir, de los metadatos en el catálogo sobre el conjunto de datos, y no sobre el mismo conjunto de datos.</skos:scopeNote>
-        <skos:scopeNote xml:lang="es">En el contexto de DCAT 2.0 dcat:Resource, el valor de esta propiedad indica un cambio del ítem, no un cambio en el registro del catálogo. La ausencia de valor PUEDE indicar que el ítem nunca se modificó después de su publicación inicial, o que no se conoce la fecha de su última modificación, o que el ítem se actualiza contínuamente.</skos:scopeNote>
-        <skos:scopeNote xml:lang="en">In the context of DCAT 2.0 dcat:CatalogRecord, this indicates the date of last change of a catalog entry, i.e. the catalog metadata description of the dataset, and not the date of the dataset itself.</skos:scopeNote>
-        <skos:scopeNote xml:lang="en">In the context of DCAT 2.0 dcat:Resource, the value of this property indicates a change to the actual item, not a change to the catalog record. An absent value MAY indicate that the item has never changed after its initial publication, or that the date of last modification is not known, or that the item is continuously updated.</skos:scopeNote>
-        <skos:scopeNote xml:lang="it">Nel contesto di DCAT 2.0 dcat:CatalogRecord, indica la data dell&apos;ultima modifica di una voce di catalogo, cioè la descrizione dei metadati di catalogo del dataset, e non la data del dataset stesso.</skos:scopeNote>
-        <skos:scopeNote xml:lang="it">Nel contesto di DCAT 2.0 dcat:Resource, il valore di questa proprietà indica una modifica all&apos;elemento effettivo, non una modifica al record del catalogo. Un valore assente PUÒ indicare che l&apos;articolo non è mai cambiato dopo la sua pubblicazione iniziale, o che la data dell&apos;ultima modifica non è nota, o che l&apos;articolo viene continuamente aggiornato.</skos:scopeNote>
-        <skos:scopeNote xml:lang="cs">V kontextu DCAT 2.0 dcat:CatalogRecord, tato vlastnost indikuje datum poslední změny katalogizačního záznamu, nikoliv datum změny datové sady samotné.</skos:scopeNote>
-        <skos:scopeNote xml:lang="cs">V kontextu DCAT 2.0 dcat:Resource, hodnota této vlastnosti udává změnu položky, nikoliv změnu jejího katalogizačního záznamu. Pokud hodnota chybí, MŮŽE to znamenat, že po publikaci položka již nebyla měněna, že datum změny není známo, nebo že je položka aktualizována neustále.</skos:scopeNote>
-    </rdf:Description>
-    
-
-
-    <!-- http://schema.org/affiliation -->
-
-    <owl:AnnotationProperty rdf:about="http://schema.org/affiliation"/>
-    
-
-
-    <!-- http://xmlns.com/foaf/0.1/homepage -->
-
-    <owl:AnnotationProperty rdf:about="http://xmlns.com/foaf/0.1/homepage">
-        <skos:definition xml:lang="en">A homepage for some thing.</skos:definition>
-        <skos:definition xml:lang="en">In the context of DCAT 2.0 dcat:Catalog, a homepage of the catalog (a public Web document usually available in HTML).</skos:definition>
-        <skos:definition xml:lang="it">Nel contesto di DCAT 2.0 dcat:Catalog, una homepage del catalogo (un documento Web pubblico solitamente disponibile in HTML).</skos:definition>
-        <skos:definition xml:lang="it">Una homepage per qualche cosa.</skos:definition>
-        <skos:scopeNote xml:lang="es">foaf:homepage es la propiedad funcional inversa (IFP por sus siglas en inglés), lo que significa que DEBE ser única y identificar la página web del recurso percisamente. En el contexto de DCAT 2.0, esta propiedad indica la página web canónica, que pude ser útil en casos en los que hay más de una página web para el recurso.</skos:scopeNote>
-        <skos:scopeNote xml:lang="en">foaf:homepage is an inverse functional property (IFP), which means that it MUST be unique and precisely identify the web-page for the resource. In the context of DCAT 2.0, this property indicates the canonical web-page, which might be helpful in cases where there is more than one web-page about the resource.</skos:scopeNote>
-        <skos:scopeNote xml:lang="cs">foaf:homepage je inverzní funkčí vlastnost, což znamená, že MUSÍ být unikátní a MUSÍ přesně označovat webovou stránku zdroje. V kontextu DCAT 2.0, označuje hlavní webovou stránku, což se může hodit v případě, že webových stránek o zdroji existuje více.</skos:scopeNote>
-        <skos:scopeNote xml:lang="it">foaf:homepage è una proprietà funzionale inversa (IFP), il che significa che DEVE essere unica e identificare con precisione la pagina web della risorsa. Nel contesto di DCAT 2.0, questa proprietà indica la pagina web canonica, che potrebbe essere utile nei casi in cui ci sia più di una pagina web sulla risorsa.</skos:scopeNote>
-    </owl:AnnotationProperty>
-    
-
-
-    <!-- http://xmlns.com/foaf/0.1/name -->
-
-    <owl:AnnotationProperty rdf:about="http://xmlns.com/foaf/0.1/name"/>
-    
-
-
-    <!-- http://xmlns.com/foaf/0.1/workInfoHomepage -->
-
-    <owl:AnnotationProperty rdf:about="http://xmlns.com/foaf/0.1/workInfoHomepage"/>
-    
-
-
-    <!-- 
-    ///////////////////////////////////////////////////////////////////////////////////////
-    //
-    // Object Properties
-    //
-    ///////////////////////////////////////////////////////////////////////////////////////
-     -->
-
-    
-
-
-    <!-- http://purl.org/dc/terms/relation -->
-
-    <owl:ObjectProperty rdf:about="http://purl.org/dc/terms/relation">
-        <skos:definition xml:lang="en">A related resource.</skos:definition>
+<rdf:RDF
+    xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+    xmlns:odrl="http://www.w3.org/ns/odrl/2/"
+    xmlns:locn="http://www.w3.org/ns/locn#"
+    xmlns:sdo="http://schema.org/"
+    xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
+    xmlns:dct="http://purl.org/dc/terms/"
+    xmlns:time="http://www.w3.org/2006/time#"
+    xmlns:owl="http://www.w3.org/2002/07/owl#"
+    xmlns:prov="http://www.w3.org/ns/prov#"
+    xmlns:skos="http://www.w3.org/2004/02/skos/core#"
+    xmlns:dcat="http://www.w3.org/ns/dcat#"
+    xmlns:foaf="http://xmlns.com/foaf/0.1/"
+    xmlns:xsd="http://www.w3.org/2001/XMLSchema#">
+  <owl:Ontology rdf:about="http://www.w3.org/ns/dcat/external">
+    <dct:contributor>
+      <foaf:Person>
+        <foaf:workInfoHomepage rdf:resource="http://people.csiro.au/Simon-Cox"/>
+        <foaf:name>Simon J D Cox</foaf:name>
+        <rdfs:seeAlso rdf:resource="https://orcid.org/0000-0002-3884-3420"/>
+        <sdo:affiliation rdf:parseType="Resource">
+          <foaf:name>Commonwealth Scientific and Industrial Research Organisation</foaf:name>
+          <foaf:homepage rdf:resource="https://csiro.au"/>
+        </sdo:affiliation>
+      </foaf:Person>
+    </dct:contributor>
+    <dct:creator rdf:parseType="Resource">
+      <foaf:name>Fadi Maali</foaf:name>
+      <rdfs:seeAlso rdf:resource="http://fadmaa.me/foaf.ttl"/>
+    </dct:creator>
+    <owl:imports rdf:resource="http://www.w3.org/2004/02/skos/core"/>
+    <dct:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#date"
+    >2019-09-09</dct:modified>
+    <owl:imports rdf:resource="http://purl.org/dc/terms/"/>
+    <dct:contributor rdf:parseType="Resource">
+      <foaf:name>Shuji Kamitsuna</foaf:name>
+      <foaf:homepage rdf:resource="http://www.asahi-net.or.jp/~ax2s-kmtn/"/>
+    </dct:contributor>
+    <dct:contributor rdf:parseType="Resource">
+      <foaf:name>Martin Alvarez-Espinar</foaf:name>
+    </dct:contributor>
+    <dct:contributor rdf:parseType="Resource">
+      <foaf:name>Marios Meimaris</foaf:name>
+    </dct:contributor>
+    <dct:contributor rdf:parseType="Resource">
+      <foaf:name>Rufus Pollock</foaf:name>
+      <sdo:affiliation rdf:parseType="Resource">
+        <foaf:name>Open Knowledge Foundation</foaf:name>
+        <foaf:homepage rdf:resource="http://okfn.org"/>
+      </sdo:affiliation>
+    </dct:contributor>
+    <dct:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#date"
+    >2013-11-28</dct:modified>
+    <dct:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#date"
+    >2012-04-24</dct:modified>
+    <dct:contributor rdf:parseType="Resource">
+      <foaf:name>Makx Dekkers</foaf:name>
+      <foaf:homepage rdf:resource="http://makxdekkers.com/"/>
+      <rdfs:seeAlso rdf:resource="http://makxdekkers.com/makxdekkers.rdf#me"/>
+    </dct:contributor>
+    <rdfs:label xml:lang="en">External terms used in the data catalog vocabulary.</rdfs:label>
+    <rdfs:comment xml:lang="en">This RDF graph contains partial descriptions of elements from external vocabularies that are used by DCAT. The primary definitions for these terms are in the original specifications and standards. In the context of DCAT some additional axioms (sub-class and sub-property relationships) are introduced, and some more specific usage notes are added.</rdfs:comment>
+    <dct:license rdf:resource="https://creativecommons.org/licenses/by/4.0/"/>
+    <dct:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#date"
+    >2013-09-20</dct:modified>
+    <owl:imports rdf:resource="http://www.w3.org/ns/prov-o#"/>
+    <dct:contributor rdf:parseType="Resource">
+      <foaf:name>Ghislain Auguste Atemezing</foaf:name>
+      <rdfs:seeAlso rdf:resource="http://www.eurecom.fr/~atemezin/gatemezing-foaf.rdf"/>
+    </dct:contributor>
+    <dct:contributor rdf:parseType="Resource">
+      <foaf:name>Phil Archer</foaf:name>
+      <foaf:homepage rdf:resource="http://www.w3.org/People/all#phila"/>
+      <rdfs:seeAlso rdf:resource="http://philarcher.org/foaf.rdf#me"/>
+      <sdo:affiliation rdf:resource="http://www.w3.org/data#W3C"/>
+    </dct:contributor>
+    <dct:contributor rdf:parseType="Resource">
+      <foaf:name>Richard Cyganiak</foaf:name>
+    </dct:contributor>
+    <dct:contributor rdf:parseType="Resource">
+      <foaf:name>Alejandra Gonzalez-Beltran</foaf:name>
+      <foaf:homepage rdf:resource="https://agbeltran.github.io"/>
+      <rdfs:seeAlso rdf:resource="https://orcid.org/0000-0003-3499-8262"/>
+      <sdo:affiliation rdf:parseType="Resource">
+        <foaf:name>Science and Technology Facilities Council, UK</foaf:name>
+        <foaf:homepage rdf:resource="http://stfc.ac.uk"/>
+      </sdo:affiliation>
+    </dct:contributor>
+    <dct:contributor rdf:parseType="Resource">
+      <foaf:name>Riccardo Albertoni</foaf:name>
+      <foaf:homepage rdf:resource="https://w3id.org/people/ralbertoni/"/>
+      <foaf:homepage rdf:resource="http://www.imati.cnr.it/index.php/people/8-curricula/178-riccardo-albertoni"/>
+      <rdfs:seeAlso rdf:resource="https://orcid.org/0000-0001-5648-2713"/>
+    </dct:contributor>
+    <dct:contributor rdf:parseType="Resource">
+      <foaf:name>Andrea Perego</foaf:name>
+      <foaf:homepage rdf:resource="http://www.andrea-perego.name/foaf/#me"/>
+      <rdfs:seeAlso rdf:resource="https://orcid.org/0000-0001-9300-2694"/>
+    </dct:contributor>
+    <dct:contributor rdf:parseType="Resource">
+      <foaf:name>Boris Villazón-Terrazas</foaf:name>
+    </dct:contributor>
+    <dct:creator rdf:parseType="Resource">
+      <foaf:name>John Erickson</foaf:name>
+    </dct:creator>
+    <dct:contributor rdf:parseType="Resource">
+      <foaf:name>Vassilios Peristeras</foaf:name>
+      <sdo:affiliation rdf:parseType="Resource">
+        <foaf:name>European Commission, DG DIGIT</foaf:name>
+        <foaf:homepage rdf:resource="http://ec.europa.eu/dgs/informatics/"/>
+      </sdo:affiliation>
+    </dct:contributor>
+    <dct:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#date"
+    >2017-12-19</dct:modified>
+    <owl:imports rdf:resource="http://www.w3.org/ns/odrl/2/"/>
+    <dct:contributor rdf:parseType="Resource">
+      <foaf:name>Jakub Klímek</foaf:name>
+      <foaf:homepage rdf:resource="https://jakub.klímek.com/"/>
+      <rdfs:seeAlso rdf:resource="https://jakub.klímek.com/#me"/>
+    </dct:contributor>
+    <dct:contributor rdf:parseType="Resource">
+      <foaf:name>David Browning</foaf:name>
+      <sdo:affiliation rdf:parseType="Resource">
+        <foaf:name>Refinitiv</foaf:name>
+        <foaf:homepage rdf:resource="http://www.refinitiv.com"/>
+      </sdo:affiliation>
+    </dct:contributor>
+  </owl:Ontology>
+  <rdf:Description rdf:about="http://www.w3.org/ns/prov#wasQuotedFrom">
+    <rdfs:subPropertyOf>
+      <rdf:Description rdf:about="http://purl.org/dc/terms/relation">
         <skos:definition xml:lang="es">En el contexto de DCAT 2.0 dcat:Relationship, el recurso relacionado con el recurso que se está describiendo.</skos:definition>
         <skos:definition xml:lang="es">En el contexto de DCAT 2.0 dcat:Resource, un recurso con una relación no especificada con el recurso catalogado que se está describiendo.</skos:definition>
-        <skos:definition xml:lang="en">In the context of DCAT 2.0 dcat:Relationship, the resource related to the source resource.</skos:definition>
-        <skos:definition xml:lang="en">In the context of DCAT 2.0 dcat:Resource, a resource with an unspecified relationship to the catalogued item.</skos:definition>
-        <skos:definition xml:lang="it">Nel contesto di DCAT 2.0 dcat:Relationship, la risorsa relativa alla risorsa di origine.</skos:definition>
-        <skos:definition xml:lang="it">Nel contesto di DCAT 2.0 dcat:Resource, una risorsa con una relazione non specificata con l&apos;elemento catalogato.</skos:definition>
-        <skos:definition xml:lang="it">Una risorsa correlata.</skos:definition>
-        <skos:definition xml:lang="cs">V kontextu DCAT 2.0 dcat:Relationship, Zdroj ve vztahu se popisovaným zdrojem.</skos:definition>
-        <skos:definition xml:lang="cs">V kontextu DCAT 2.0 dcat:Resource, Zdroj s nespecifikovaným vztahem ke katalogizované položce.</skos:definition>
-        <skos:scopeNote xml:lang="en">In the context of DCAT 2.0, dct:relation SHOULD be used where the nature of the relationship between a catalogued item and related resources is not known. A more specific sub-property SHOULD be used if the nature of the relationship of the link is known. The property dcat:distribution SHOULD be used to link from a dcat:Dataset to a representation of the dataset, described as a dcat:Distribution.</skos:scopeNote>
-        <skos:scopeNote xml:lang="en">In the context of DCAT 2.0, see also: Sub-properties of dct:relation in particular dcat:distribution, dct:hasPart, dct:isPartOf, dct:conformsTo, dct:isFormatOf, dct:hasFormat, dct:isVersionOf, dct:hasVersion, dct:replaces, dct:isReplacedBy, dct:references, dct:isReferencedBy, dct:requires, dct:isRequiredBy.</skos:scopeNote>
-        <skos:scopeNote xml:lang="en">In the context of a DCAT 2.0 dcat:Relationship this is expected to point to another dcat:Dataset or other catalogued resource.</skos:scopeNote>
         <skos:scopeNote xml:lang="it">Nel contesto del DCAT 2.0, vedi anche: le sottoproprietà di dct:relation in particolare dct:hasPart, dct:hasPart, dct:isPartOf, dct:isPartOf, dct:isFormatOf, dct:isFormat, dct:isVersionOf, dct:hasVersion, dct:hasVersion, dct:replaces, dct:isReplacedBy, dct:references, dct:isReferencedBy, dct:requires, dct:isRequiredBy.</skos:scopeNote>
-        <skos:scopeNote xml:lang="it">Nel contesto di DCAT 2.0, dct:relation DOVREBBE essere utilizzato quando la natura della relazione tra un articolo catalogato e le risorse correlate non è nota. Una sottoproprietà più specifica DOVREBBE essere utilizzata se la natura della relazione del collegamento è nota. La proprietà dcat:distribution DEVE essere usata per collegare da un dcat:Dataset ad una rappresentazione del dataset, descritto come dcat:Distribution.</skos:scopeNote>
-        <skos:scopeNote xml:lang="it">Nel contesto di un DCAT 2.0, dcat:Relationship ci si aspetta che punti ad un altro dcat:Dataset o altra risorsa catalogata.</skos:scopeNote>
-        <skos:scopeNote xml:lang="cs">V kontextu DCAT 2.0 dcat:Relationship se očekává, že tato vlastnost bude ukazovat na jiný dcat:Dataset nebo jiný katalogizovaný zdroj.</skos:scopeNote>
+        <skos:definition xml:lang="cs">V kontextu DCAT 2.0 dcat:Relationship, Zdroj ve vztahu se popisovaným zdrojem.</skos:definition>
+        <skos:scopeNote xml:lang="en">In the context of a DCAT 2.0 dcat:Relationship this is expected to point to another dcat:Dataset or other catalogued resource.</skos:scopeNote>
+        <skos:definition xml:lang="it">Nel contesto di DCAT 2.0 dcat:Relationship, la risorsa relativa alla risorsa di origine.</skos:definition>
+        <skos:scopeNote xml:lang="en">In the context of DCAT 2.0, see also: Sub-properties of dct:relation in particular dcat:distribution, dct:hasPart, dct:isPartOf, dct:conformsTo, dct:isFormatOf, dct:hasFormat, dct:isVersionOf, dct:hasVersion, dct:replaces, dct:isReplacedBy, dct:references, dct:isReferencedBy, dct:requires, dct:isRequiredBy.</skos:scopeNote>
+        <skos:definition xml:lang="it">Nel contesto di DCAT 2.0 dcat:Resource, una risorsa con una relazione non specificata con l'elemento catalogato.</skos:definition>
+        <skos:definition xml:lang="en">In the context of DCAT 2.0 dcat:Relationship, the resource related to the source resource.</skos:definition>
+        <skos:scopeNote xml:lang="en">In the context of DCAT 2.0, dct:relation SHOULD be used where the nature of the relationship between a catalogued item and related resources is not known. A more specific sub-property SHOULD be used if the nature of the relationship of the link is known. The property dcat:distribution SHOULD be used to link from a dcat:Dataset to a representation of the dataset, described as a dcat:Distribution.</skos:scopeNote>
+        <skos:definition xml:lang="en">A related resource.</skos:definition>
+        <skos:definition xml:lang="it">Una risorsa correlata.</skos:definition>
         <skos:scopeNote xml:lang="cs">V kontextu DCAT 2.0, dct:relation BY MĚLA být použita tam, kde není znám typ vztahu mezi katalogizovanou položkou a vztaženým zdrojem. Pokud typ vztahu znám je, MĚLA BY být použita konkrétnější podvlastnost. Pro propojení datové sady dcat:Dataset a reprezentaci datové sady dcat:Distribution BY MĚLA BÝT použita vlastnost dcat:distribution.</skos:scopeNote>
+        <skos:scopeNote xml:lang="cs">V kontextu DCAT 2.0 dcat:Relationship se očekává, že tato vlastnost bude ukazovat na jiný dcat:Dataset nebo jiný katalogizovaný zdroj.</skos:scopeNote>
+        <skos:scopeNote xml:lang="it">Nel contesto di DCAT 2.0, dct:relation DOVREBBE essere utilizzato quando la natura della relazione tra un articolo catalogato e le risorse correlate non è nota. Una sottoproprietà più specifica DOVREBBE essere utilizzata se la natura della relazione del collegamento è nota. La proprietà dcat:distribution DEVE essere usata per collegare da un dcat:Dataset ad una rappresentazione del dataset, descritto come dcat:Distribution.</skos:scopeNote>
+        <skos:definition xml:lang="en">In the context of DCAT 2.0 dcat:Resource, a resource with an unspecified relationship to the catalogued item.</skos:definition>
         <skos:scopeNote xml:lang="cs">V kontextu DCAT 2.0, viz také: Podvlastnosti dct:relation, zejména dcat:distribution, dct:hasPart, dct:isPartOf, dct:conformsTo, dct:isFormatOf, dct:hasFormat, dct:isVersionOf, dct:hasVersion, dct:replaces, dct:isReplacedBy, dct:references, dct:isReferencedBy, dct:requires, dct:isRequiredBy.</skos:scopeNote>
-    </owl:ObjectProperty>
-    
-
-
-    <!-- http://www.w3.org/ns/locn#geometry -->
-
-    <owl:ObjectProperty rdf:about="http://www.w3.org/ns/locn#geometry">
-        <rdfs:range rdf:resource="http://www.w3.org/2000/01/rdf-schema#Literal"/>
-        <skos:changeNote xml:lang="es">Esta propiedad fue agregada en DCAT 2.0.</skos:changeNote>
-        <skos:changeNote xml:lang="en">Property added in this context in DCAT 2.0.</skos:changeNote>
-        <skos:changeNote xml:lang="it">Proprietà aggiunta in questo contesto in DCAT 2.0.</skos:changeNote>
-        <skos:changeNote xml:lang="cs">Vlastnost v tomto kontextu byla přidána ve verzi DCAT 2.0.</skos:changeNote>
-        <skos:definition xml:lang="es">Asocia cualquier recurso con la geometría correspondiente.</skos:definition>
-        <skos:definition xml:lang="it">Associa qualsiasi risorsa alla geometria corrispondente.</skos:definition>
-        <skos:definition xml:lang="en">Associates any resource with the corresponding geometry.</skos:definition>
-        <skos:definition xml:lang="cs">Přiřazuje geometrii jakémukoliv zdroji.</skos:definition>
-        <skos:scopeNote xml:lang="es"> el contexto de DCAT 2.0, el rango de esta propiedad es intencionalmente genérico con el propósito de permitir distintas codificaciones de la geometría. Por ejemplo, la geometría puede codificarse como WKT (geosparql:wktLiteral [GeoSPARQL]).</skos:scopeNote>
-        <skos:scopeNote xml:lang="en">In the context of DCAT 2.0, the range of this property is intentionally generic, with the purpose of allowing different geometry encodings. E.g., the geometry could be encoded as WKT (geosparql:wktLiteral [GeoSPARQL]).</skos:scopeNote>
-        <skos:scopeNote xml:lang="it">Nel contesto del DCAT 2.0, il range di questa proprietà è volutamente generico, con lo scopo di consentire diverse codifiche geometriche. Ad esempio, la geometria potrebbe essere codificata come WKT (geosparql:wktLiteral [GeoSPARQL]).</skos:scopeNote>
-        <skos:scopeNote xml:lang="cs">V kontextu DCAT 2.0, obor hodnot této vlastnosti je úmyslně obecný, aby umožnil různé kódování geometrií. Geometrie by kupříkladu mohla být kódována jako WKT (geosparql:wktLiteral [GeoSPARQL]).</skos:scopeNote>
-    </owl:ObjectProperty>
-    
-
-
-    <!-- http://www.w3.org/ns/prov#alternateOf -->
-
-    <rdf:Description rdf:about="http://www.w3.org/ns/prov#alternateOf">
-        <rdfs:subPropertyOf rdf:resource="http://purl.org/dc/terms/relation"/>
-    </rdf:Description>
-    
-
-
-    <!-- http://www.w3.org/ns/prov#hadPrimarySource -->
-
-    <rdf:Description rdf:about="http://www.w3.org/ns/prov#hadPrimarySource">
-        <rdfs:subPropertyOf rdf:resource="http://purl.org/dc/terms/relation"/>
-    </rdf:Description>
-    
-
-
-    <!-- http://www.w3.org/ns/prov#specializationOf -->
-
-    <rdf:Description rdf:about="http://www.w3.org/ns/prov#specializationOf">
-        <rdfs:subPropertyOf rdf:resource="http://purl.org/dc/terms/relation"/>
-    </rdf:Description>
-    
-
-
-    <!-- http://www.w3.org/ns/prov#wasAttributedTo -->
-
-    <rdf:Description rdf:about="http://www.w3.org/ns/prov#wasAttributedTo">
-        <rdfs:subPropertyOf rdf:resource="http://purl.org/dc/terms/relation"/>
-    </rdf:Description>
-    
-
-
-    <!-- http://www.w3.org/ns/prov#wasDerivedFrom -->
-
-    <rdf:Description rdf:about="http://www.w3.org/ns/prov#wasDerivedFrom">
-        <rdfs:subPropertyOf rdf:resource="http://purl.org/dc/terms/relation"/>
-    </rdf:Description>
-    
-
-
-    <!-- http://www.w3.org/ns/prov#wasGeneratedBy -->
-
-    <rdf:Description rdf:about="http://www.w3.org/ns/prov#wasGeneratedBy">
-        <rdfs:subPropertyOf rdf:resource="http://purl.org/dc/terms/relation"/>
-        <skos:changeNote xml:lang="es">Esta propiedad fue agregada en DCAT 2.0.</skos:changeNote>
-        <skos:changeNote xml:lang="en">Property added in this context in DCAT 2.0.</skos:changeNote>
-        <skos:changeNote xml:lang="it">Proprietà aggiunta in questo contesto in DCAT 2.0.</skos:changeNote>
-        <skos:changeNote xml:lang="cs">Vlastnost v tomto kontextu byla přidána ve verzi DCAT 2.0</skos:changeNote>
-        <skos:definition xml:lang="en">In the context of DCAT 2.0 dcat:Dataset, an activity that generated, or provides the business context for, the creation of the dataset.</skos:definition>
-        <skos:scopeNote xml:lang="es">En el contexto de DCAT 2.0 dcat:Dataset, la actividad asociada con la generación de un conjunto de datos. Típicamente es una iniciativa, proyecto, misión, encuensta, una actividad contínua (la actividad usual) etc. Se pueden usar múltiples propiedades  prov:wasGeneratedBy para indicar el contexto de producción del conjunto de datos en disintos niveles de granularidad.</skos:scopeNote>
-        <skos:scopeNote xml:lang="es">En el contexto de DCAT 2.0 dcat:Dataset, utiliza prov:qualifiedGeneration para adjuntar detalles adicionales sobre la relación entre el conjunto de datos y la actividad activity, por ejemplo, el tiempo exacto en el que se produjo el conjunto de datose durante la vida de un proyecto.</skos:scopeNote>
-        <skos:scopeNote xml:lang="en">In the context of DCAT 2.0 dcat:Dataset, the activity associated with generation of a dataset will typically be an initiative, project, mission, survey, on-going activity (&apos;business as usual&apos;) etc. Multiple prov:wasGeneratedBy properties can be used to indicate the dataset production context at various levels of granularity.</skos:scopeNote>
-        <skos:scopeNote xml:lang="en">In the context of DCAT 2.0 dcat:Dataset, use prov:qualifiedGeneration to attach additional details about the relationship between the dataset and the activity, e.g. the exact time that the dataset was produced during the lifetime of a project.</skos:scopeNote>
-        <skos:scopeNote xml:lang="it">Nel contesto di DCAT 2.0 dcat:Dataset, l&apos;attività associata alla generazione di un dataset sarà tipicamente un&apos;iniziativa, progetto, missione, indagine, attività in corso (&apos;business as usual&apos;), ecc. Multiple prov:wasGeneratedBy  possono essere utilizzate per indicare il contesto di produzione del dataset a vari livelli di granularità.</skos:scopeNote>
-        <skos:scopeNote xml:lang="it">Nel contesto di DCAT 2.0 dcat:Dataset, utilizzare prov:qualifiedGeneration per allegare ulteriori dettagli sulla relazione tra il dataset e l&apos;attività, ad esempio l&apos;ora esatta in cui il dataset è stato prodotto durante la vita di un progetto.</skos:scopeNote>
-        <skos:scopeNote xml:lang="cs">V kontextu DCAT 2.0 dcat:Dataset, aktivitou spojenou s tvorbou datové sady typicky bývá iniciativa, projekt, mise, rešerše, průběžná aktivita (běžný chod podniku) apod. Pro zaznamenání kontextu datové sady na více úrovních granulariy lze použít více hodnot vlastnosti prov:wasGeneratedBy.</skos:scopeNote>
-        <skos:scopeNote xml:lang="cs">V kontextu DCAT 2.0 dcat:Dataset, pro připojení podrobností o vztahu mezi datovou sadou a aktivitou, např. přesný čas kdy byla datová sada vyprodukována během životního cyklu projektu, použijte prov:qualifiedGeneration.</skos:scopeNote>
-    </rdf:Description>
-    
-
-
-    <!-- http://www.w3.org/ns/prov#wasInfluencedBy -->
-
-    <rdf:Description rdf:about="http://www.w3.org/ns/prov#wasInfluencedBy">
-        <rdfs:subPropertyOf rdf:resource="http://purl.org/dc/terms/relation"/>
-    </rdf:Description>
-    
-
-
-    <!-- http://www.w3.org/ns/prov#wasQuotedFrom -->
-
-    <rdf:Description rdf:about="http://www.w3.org/ns/prov#wasQuotedFrom">
-        <rdfs:subPropertyOf rdf:resource="http://purl.org/dc/terms/relation"/>
-    </rdf:Description>
-    
-
-
-    <!-- http://www.w3.org/ns/prov#wasRevisionOf -->
-
-    <rdf:Description rdf:about="http://www.w3.org/ns/prov#wasRevisionOf">
-        <rdfs:subPropertyOf rdf:resource="http://purl.org/dc/terms/relation"/>
-    </rdf:Description>
-    <rdf:Description>
-        <rdfs:seeAlso rdf:resource="http://fadmaa.me/foaf.ttl"/>
-        <foaf:name>Fadi Maali</foaf:name>
-    </rdf:Description>
-    <rdf:Description>
-        <sdo:affiliation>
-            <rdf:Description>
-                <foaf:homepage rdf:resource="http://ec.europa.eu/dgs/informatics/"/>
-                <foaf:name>European Commission, DG DIGIT</foaf:name>
-            </rdf:Description>
-        </sdo:affiliation>
-        <foaf:name>Vassilios Peristeras</foaf:name>
-    </rdf:Description>
-    <rdf:Description>
-        <foaf:homepage rdf:resource="http://www.asahi-net.or.jp/~ax2s-kmtn/"/>
-        <foaf:name>Shuji Kamitsuna</foaf:name>
-    </rdf:Description>
-    <rdf:Description>
-        <sdo:affiliation>
-            <rdf:Description>
-                <foaf:homepage rdf:resource="http://okfn.org"/>
-                <foaf:name>Open Knowledge Foundation</foaf:name>
-            </rdf:Description>
-        </sdo:affiliation>
-        <foaf:name>Rufus Pollock</foaf:name>
-    </rdf:Description>
-    <rdf:Description>
-        <rdfs:seeAlso rdf:resource="https://orcid.org/0000-0001-5648-2713"/>
-        <foaf:homepage rdf:resource="http://www.imati.cnr.it/index.php/people/8-curricula/178-riccardo-albertoni"/>
-        <foaf:homepage rdf:resource="https://w3id.org/people/ralbertoni/"/>
-        <foaf:name>Riccardo Albertoni</foaf:name>
-    </rdf:Description>
-    <rdf:Description>
-        <rdfs:seeAlso rdf:resource="https://orcid.org/0000-0001-9300-2694"/>
-        <foaf:homepage rdf:resource="http://www.andrea-perego.name/foaf/#me"/>
-        <foaf:name>Andrea Perego</foaf:name>
-    </rdf:Description>
-    <rdf:Description>
-        <rdfs:seeAlso rdf:resource="http://www.eurecom.fr/~atemezin/gatemezing-foaf.rdf"/>
-        <foaf:name>Ghislain Auguste Atemezing</foaf:name>
-    </rdf:Description>
-    <rdf:Description>
-        <rdfs:seeAlso rdf:resource="https://jakub.klímek.com/#me"/>
-        <foaf:homepage rdf:resource="https://jakub.klímek.com/"/>
-        <foaf:name>Jakub Klímek</foaf:name>
-    </rdf:Description>
-    <rdf:Description>
-        <sdo:affiliation rdf:resource="http://www.w3.org/data#W3C"/>
-        <rdfs:seeAlso rdf:resource="http://philarcher.org/foaf.rdf#me"/>
-        <foaf:homepage rdf:resource="http://www.w3.org/People/all#phila"/>
-        <foaf:name>Phil Archer</foaf:name>
-    </rdf:Description>
-    <rdf:Description>
-        <rdfs:seeAlso rdf:resource="http://makxdekkers.com/makxdekkers.rdf#me"/>
-        <foaf:homepage rdf:resource="http://makxdekkers.com/"/>
-        <foaf:name>Makx Dekkers</foaf:name>
-    </rdf:Description>
-    <rdf:Description>
-        <foaf:name>Boris Villazón-Terrazas</foaf:name>
-    </rdf:Description>
-    <rdf:Description>
-        <foaf:name>Martin Alvarez-Espinar</foaf:name>
-    </rdf:Description>
-    <rdf:Description>
-        <sdo:affiliation>
-            <rdf:Description>
-                <foaf:homepage rdf:resource="http://www.refinitiv.com"/>
-                <foaf:name>Refinitiv</foaf:name>
-            </rdf:Description>
-        </sdo:affiliation>
-        <foaf:name>David Browning</foaf:name>
-    </rdf:Description>
-    <rdf:Description>
-        <foaf:name>Richard Cyganiak</foaf:name>
-    </rdf:Description>
-    <rdf:Description>
-        <sdo:affiliation>
-            <rdf:Description>
-                <foaf:homepage rdf:resource="http://stfc.ac.uk"/>
-                <foaf:name>Science and Technology Facilities Council, UK</foaf:name>
-            </rdf:Description>
-        </sdo:affiliation>
-        <rdfs:seeAlso rdf:resource="https://orcid.org/0000-0003-3499-8262"/>
-        <foaf:homepage rdf:resource="https://agbeltran.github.io"/>
-        <foaf:name>Alejandra Gonzalez-Beltran</foaf:name>
-    </rdf:Description>
-    <rdf:Description>
-        <foaf:name>Marios Meimaris</foaf:name>
-    </rdf:Description>
-    <rdf:Description>
-        <foaf:name>John Erickson</foaf:name>
-    </rdf:Description>
-    <rdf:Description>
-        <rdf:type rdf:resource="http://xmlns.com/foaf/0.1/Person"/>
-        <sdo:affiliation>
-            <rdf:Description>
-                <foaf:homepage rdf:resource="https://csiro.au"/>
-                <foaf:name>Commonwealth Scientific and Industrial Research Organisation</foaf:name>
-            </rdf:Description>
-        </sdo:affiliation>
-        <rdfs:seeAlso rdf:resource="https://orcid.org/0000-0002-3884-3420"/>
-        <foaf:name>Simon J D Cox</foaf:name>
-        <foaf:workInfoHomepage rdf:resource="http://people.csiro.au/Simon-Cox"/>
-    </rdf:Description>
-    
-
-
-    <!-- 
-    ///////////////////////////////////////////////////////////////////////////////////////
-    //
-    // Annotations
-    //
-    ///////////////////////////////////////////////////////////////////////////////////////
-     -->
-
-    <rdf:Description rdf:about="http://purl.org/dc/terms/Location">
-        <skos:definition xml:lang="it">Una regione spaziale o un luogo designato.</skos:definition>
-        <skos:scopeNote xml:lang="en">In the context of DCAT 2.0, for an extensive geometry (i.e., a set of coordinates denoting the vertices of the relevant geographic area), the property locn:geometry [[LOCN]] SHOULD be used.</skos:scopeNote>
-        <skos:definition xml:lang="cs">Prostorová oblast či pojmenované místo.</skos:definition>
-        <skos:scopeNote xml:lang="cs">En el contexto de DCAT 2.0, pro rozsáhlé geometrie (tj. sady souřadnic určujících relevantní geografickou oblast) BY MĚLA být použita vlastnost locn:geometry [[LOCN]].</skos:scopeNote>
-        <skos:changeNote xml:lang="cs">Třída v tomto kontextu byla přidána ve verzi DCAT 2.0.</skos:changeNote>
-        <skos:scopeNote xml:lang="cs">En el contexto de DCAT 2.0, pro geografický rámec ohraničující prostorové oblasti BY MĚLA být použita vlastnost dcat:bbox.</skos:scopeNote>
-        <skos:scopeNote xml:lang="en">In the context of DCAT 2.0, for the geographic center of a spatial area, or another characteristic point, the property dcat:centroid SHOULD be used.</skos:scopeNote>
-        <skos:definition xml:lang="en">A spatial region or named place.</skos:definition>
-        <skos:scopeNote xml:lang="it">Nel contesto del DCAT 2.0, per una geometria estesa (cioè, un insieme di coordinate che indicano i vertici dell&apos;area geografica rilevante), si DOVREBBE usare la  proprietà locn:geometry [[LOCN]].</skos:scopeNote>
-        <skos:scopeNote xml:lang="it">Nel contesto di DCAT 2.0, per il centro geografico di un&apos;area spaziale, o di un altro punto caratteristico, si DOVREBBE utilizzare la proprietà dcat:centroid.</skos:scopeNote>
-        <skos:scopeNote xml:lang="es">En el contexto de DCAT 2.0, para un cuadro delimitador geográfico que delimita un área espacial se DEBE usar la propiedad dcat:bbox.</skos:scopeNote>
-        <skos:scopeNote xml:lang="es">En el contexto de DCAT 2.0, para el centro geográfico de un área espacial, o algún otro punto característico, se DEBE usar la propriedad dcat:centroid.</skos:scopeNote>
-        <skos:changeNote xml:lang="en">Class added in this context in DCAT 2.0.</skos:changeNote>
-        <skos:scopeNote xml:lang="it">Nel contesto di DCAT 2.0, per un rettangolo di delimitazione geografica che delimita un&apos;area territoriale si DOVREBBE utilizzare la proprietà dcat:bbox.</skos:scopeNote>
-        <skos:definition xml:lang="es">Una región espacial o un lugar con nombre.</skos:definition>
-        <skos:changeNote xml:lang="es">Esta clase se agregó en este contexto en DCAT 2.0.</skos:changeNote>
-        <skos:changeNote xml:lang="it">Classe aggiunta in questo contesto in DCAT 2.0.</skos:changeNote>
-        <skos:scopeNote xml:lang="es">En el contexto de DCAT 2.0, para una geometría extensiva (es decir, un conjunto de coordinadas que denotan los vértices de un área geográfica), DEBE usarse la propiedad locn:geometry [[LOCN]].</skos:scopeNote>
-        <skos:scopeNote xml:lang="cs">En el contexto de DCAT 2.0, pro geografický střed prostorové oblasti či jiný charakteristický bod BY MĚLA být použita vlastnost dcat:centroid.</skos:scopeNote>
-        <skos:scopeNote xml:lang="en">In the context of DCAT 2.0, for a geographic bounding box delimiting a spatial area the property dcat:bbox SHOULD be used.</skos:scopeNote>
-    </rdf:Description>
-    <rdf:Description rdf:about="http://purl.org/dc/terms/PeriodOfTime">
-        <skos:definition xml:lang="en">An interval of time that is named or defined by its start and end dates.</skos:definition>
-        <skos:definition xml:lang="en">In the context of DCAT 2.0, an interval of time that is named or defined by its start and end.</skos:definition>
-        <skos:scopeNote xml:lang="es">En el contexto de DCAT 2.0, el comienzo y fin de un intervalo pueden representarse usando las propiedades dcat:startDate o time:hasBeginning, y dcat:endDate o time:hasEnd, respectivamente. El interválo también puede ser un interválo abierto - es decir, puede tener sólo un comienzo o un fin.</skos:scopeNote>
-        <skos:definition xml:lang="it">Nel contesto di DCAT 2.0, un intervallo di tempo che viene chiamato o definito dal suo inizio e fine.</skos:definition>
-        <skos:scopeNote xml:lang="cs">En el contexto de DCAT 2.0, začátek a konec intervalu může být dán vlastnostmi dcat:startDate či time:hasBeginning a dcat:endDate či time:hasEnd. Interval také může být otevřený, tj. může mít pouze začátek či pouze konec.</skos:scopeNote>
-        <skos:changeNote xml:lang="it">Classe aggiunta in questo contesto in DCAT 2.0.</skos:changeNote>
-        <skos:changeNote xml:lang="cs">Třída v tomto kontextu byla přidána ve verzi DCAT 2.0.</skos:changeNote>
-        <skos:scopeNote xml:lang="en">In the context of DCAT 2.0, the start and end of the interval may be given by using properties dcat:startDate or time:hasBeginning, and dcat:endDate or time:hasEnd, respectively. The interval can also be open - i.e., it can have just a start or just an end.</skos:scopeNote>
-        <skos:definition xml:lang="es">En el contexto de DCAT 2.0, un interválo de tiempo que se nombra o define por su principio y fin.</skos:definition>
-        <skos:changeNote xml:lang="en">Class added in this context in DCAT 2.0.</skos:changeNote>
-        <skos:changeNote xml:lang="es">Esta clase se agregó en este contexto en DCAT 2.0.</skos:changeNote>
-        <skos:definition xml:lang="cs">En el contexto de DCAT 2.0, časový interval který je pojmenovaný, nebo určený svým začátkem a koncem.</skos:definition>
-        <skos:scopeNote xml:lang="it">Nel contesto di DCAT 2.0, l&apos;inizio e la fine dell&apos;intervallo possono essere dati rispettivamente utilizzando le proprietà dcat:startDate o time:hasBeginning, e dcat:endDate o time:hasEnd. L&apos;intervallo può anche essere aperto, cioè può avere solo un inizio o solo una fine.</skos:scopeNote>
-    </rdf:Description>
-    <rdf:Description rdf:about="http://purl.org/dc/terms/accessRights">
-        <skos:definition xml:lang="it">Informazioni su chi può accedere alla risorsa o un&apos;indicazione del suo stato di sicurezza.</skos:definition>
-        <skos:definition xml:lang="en">Information about who can access the resource or an indication of its security status.</skos:definition>
-        <skos:scopeNote xml:lang="en">In the context of DCAT 2.0 dcat:DataService, access Rights MAY include information regarding access or restrictions based on privacy, security, or other policies.</skos:scopeNote>
-        <skos:definition xml:lang="cs">V kontextu DCAT 2.0 dcat:Distribution, podmínky užití řešící způsob přístupu k distribuci.</skos:definition>
-        <skos:scopeNote xml:lang="es">En el contexto de DCAT 2.0 dcat:Distribution, información sobre licencias y derechos que PUEDE proveerse para una Distribución. Ver también la información en la sección &apos;License and rights statements&apos;.</skos:scopeNote>
-        <skos:scopeNote xml:lang="es">En el contexto de DCAT 2.0 dcat:Resource, información sobre las licencias y derechos que PUEDEN proveerse para un Recurso. Ver también la información en la sección &apos;License and rights statements&apos;.</skos:scopeNote>
-        <skos:scopeNote xml:lang="cs">V kontextu DCAT 2.0 dcat:DataService, podmínky užití MOHOU obsahovat informace o přístupu nebo omezení z hlediska soukromí, bezpečnosti nebo jiných pravidel.</skos:scopeNote>
-        <skos:definition xml:lang="es">En el contexto de DCAT 2.0 dcat:Distribution, una declaración de derechos sobre cómo se puede acceder la distribución.</skos:definition>
-        <skos:scopeNote xml:lang="cs">V kontextu DCAT 2.0 dcat:Resource, pro Zdroj MŮŽE BÝT uvedena informace o podmínkách užití (licencích a právech). Viz návod v sekci &apos;License and rights statements&apos;.</skos:scopeNote>
-        <skos:scopeNote xml:lang="cs">V kontextu DCAT 2.0 dcat:Distribution, pro Distribuci MŮŽE BÝT uvedena informace o podmínkách užití (licencích a právech). Viz návod v sekci &apos;License and rights statements&apos;.</skos:scopeNote>
-        <skos:scopeNote xml:lang="it">Nel contesto di DCAT 2.0 dcat:DataService, i diritti di accesso POSSONO includere informazioni riguardanti l&apos;accesso o restrizioni basate su privacy, sicurezza o altre policy.</skos:scopeNote>
-        <skos:scopeNote xml:lang="en">In the context of DCAT 2.0 dcat:Distribution, information about licenses and rights MAY be provided for the Distribution. See also guidance in the section &apos;License and rights statements&apos;.</skos:scopeNote>
-        <skos:definition xml:lang="en">In the context of DCAT 2.0 dcat:Distribution, a rights statement that concerns how the distribution is accessed.</skos:definition>
-        <skos:scopeNote xml:lang="it">Nel contesto di DCAT 2.0 dcat:Resource, le informazioni sulle licenze e i diritti POSSONO essere fornite per la risorsa. Si vedano anche le indicazioni nella sezione &apos;Licenze e dichiarazioni sui diritti&apos;.</skos:scopeNote>
-        <skos:scopeNote xml:lang="en">In the context of DCAT 2.0 dcat:Resource, information about licenses and rights MAY be provided for the Resource. See also guidance in the section &apos;License and rights statements&apos;.</skos:scopeNote>
-        <skos:scopeNote xml:lang="es">En el contexto de DCAT 2.0 dcat:DataService, los derechos de acceso PUEDEN incluir información sobre acceso o restricciones basadas en privacidad, seguridad, u otras reglamentaciones.</skos:scopeNote>
-        <skos:scopeNote xml:lang="it">Nell&apos;ambito di DCAT 2.0 dcat:Distribution, le informazioni su licenze e diritti POSSONO essere fornite per la distribuzione. Si vedano anche le indicazioni nella sezione &apos;Licenze e dichiarazioni sui diritti&apos;.</skos:scopeNote>
-        <skos:definition xml:lang="it">Nel contesto di DCAT 2.0 dcat:Distribution, una dichiarazione dei diritti che riguarda le modalità di accesso alla distribuzione.</skos:definition>
-    </rdf:Description>
-    <rdf:Description rdf:about="http://purl.org/dc/terms/accrualPeriodicity">
-        <skos:definition xml:lang="en">In the context of DCAT 2.0, the frequency at which dataset is published.</skos:definition>
-        <skos:definition xml:lang="it">La frequenza con cui gli elementi vengono aggiunti a una collezione.</skos:definition>
-        <skos:definition xml:lang="it">Nel contesto del DCAT 2.0, la frequenza di pubblicazione dell&apos;insieme di dati.</skos:definition>
-        <skos:scopeNote xml:lang="cs">V kontextu DCAT 2.0, hodnota dct:accrualPeriodicity udává frekvenci, se kterou se aktualizuje datová sada jako celek. Toto může být doplněno vlastností dcat:temporalResolution pro udání času mezi jednotlivými body v časové řadě.</skos:scopeNote>
-        <skos:scopeNote xml:lang="en">In the context of DCAT 2.0, the value of dct:accrualPeriodicity gives the rate at which the dataset-as-a-whole is updated. This may be complemented by dcat:temporalResolution to give the time between collected data points in a time series.</skos:scopeNote>
-        <skos:scopeNote xml:lang="es">En el contexto de DCAT 2.0, el valor de dct:accrualPeriodicity da la tasa de actualización del conjunto de datos como entidad. Esto puede complementarse con dcat:temporalResolution para dar el tiempo entre los puntos en que se recopilan los datos en una serie temporal.</skos:scopeNote>
-        <skos:definition xml:lang="cs">V kontextu DCAT 2.0, frekvence publikace datové sady.</skos:definition>
-        <skos:definition xml:lang="en">The frequency with which items are added to a collection.</skos:definition>
-        <skos:scopeNote xml:lang="it">Nel contesto di DCAT 2.0, il valore di dct:accrualPeriodicity indica il tasso di aggiornamento del dataset nella sua interezza. Questo può essere completato da dcat:temporalResolution per dare il tempo tra i punti di dati raccolti in una serie temporale.</skos:scopeNote>
-        <skos:definition xml:lang="es">En el contexto de DCAT 2.0, la frecuencia con que se publica el conjunto de datos.</skos:definition>
-    </rdf:Description>
-    <rdf:Description rdf:about="http://purl.org/dc/terms/conformsTo">
-        <skos:definition xml:lang="en">In the context of DCAT 2.0 dcat:Distribution, an established standard to which the distribution conforms.</skos:definition>
-        <skos:definition xml:lang="it">Nel contesto di DCAT 2.0 dcat:Distribution, uno standard consolidato a cui la distribuzione è conforme.</skos:definition>
-        <skos:changeNote xml:lang="it">Proprietà aggiunta in questo contesto in DCAT 2.0.</skos:changeNote>
-        <skos:scopeNote xml:lang="cs">V kontextu DCAT 2.0 dcat:Distribution, tato vlastnost BY MĚLA být použita k udání modelu, schématu, ontologie, pohledu nebo profilu, kterému tato reprezentace datové sady odpovídá. Toto (obvykle) doplňuje typ média či formát.</skos:scopeNote>
-        <skos:definition xml:lang="en">An established standard to which the described resource conforms.</skos:definition>
-        <skos:scopeNote xml:lang="es">En el contexto de DCAT 2.0 dcat:Distribution, esta propiedad DEBERÍA usarse para indicar el modelo, esquema, ontología, vista or perfil al que se ajusta esta representación del conjunto de datos. Este es (generalmente) un asunto complementario al de &apos;media type&apos; o formato.</skos:scopeNote>
-        <skos:changeNote xml:lang="en">Property added in this context in DCAT 2.0.</skos:changeNote>
-        <skos:scopeNote xml:lang="es">En el contexto de DCAT 2.0 dcat:Resource, esta propiedad DEBERÍA usarse para indicar el modelo, esquema, ontología, vista or perfil al que se ajusta el recurso catalogado.</skos:scopeNote>
-        <skos:scopeNote xml:lang="en">In the context of DCAT 2.0 dcat:Distribution, this property SHOULD be used to indicate the model, schema, ontology, view or profile that this representation of a dataset conforms to. This is (generally) a complementary concern to the media-type or format.</skos:scopeNote>
-        <skos:scopeNote xml:lang="en">In the context of DCAT 2.0 dcat:Resource, this property SHOULD be used to indicate the model, schema, ontology, view or profile that the cataloged resource content conforms to.</skos:scopeNote>
-        <skos:definition xml:lang="es">En el contexto de DCAT 2.0 dcat:Distribution, un estándar establecido al cuál se ajusta la distribución.</skos:definition>
-        <skos:definition xml:lang="it">Uno standard stabilito al quale la risorsa descritta è conforme.</skos:definition>
-        <skos:definition xml:lang="cs">V kontextu DCAT 2.0 dcat:Distribution, uznávaný standard, kterým se popisovaný zdroj řídí.</skos:definition>
-        <skos:scopeNote xml:lang="cs">V kontextu DCAT 2.0 dcat:Resource, tato vlastnost BY MĚLA být použita k udání modelu, schématu, ontologie, pohledu nebo profilu, kterému katalogizovaný zdroj odpovídá.</skos:scopeNote>
-        <skos:changeNote xml:lang="es">Esta propiedad fue agregada en DCAT 2.0.</skos:changeNote>
-        <skos:scopeNote xml:lang="it">Nel contesto di DCAT 2.0 dcat:Distribution, questa proprietà DEVE essere usata per indicare il modello, lo schema, l&apos;ontologia, la vista o il profilo a cui questa rappresentazione di un dataset è conforme. Questa è (generalmente) una questione complementare al tipo di supporto o formato.</skos:scopeNote>
-        <skos:scopeNote xml:lang="it">Nel contesto di DCAT 2.0 dcat:Resource, questa proprietà DEVE essere utilizzata per indicare il modello, lo schema, l&apos;ontologia, la vista o il profilo a cui il contenuto della risorsa catalogata è conforme.</skos:scopeNote>
-        <skos:changeNote xml:lang="cs">Vlastnost v tomto kontextu byla přidána ve verzi DCAT 2.0.</skos:changeNote>
-        <skos:definition xml:lang="es">Un estándar establecido al cuál se ajusta el recurso descripto.</skos:definition>
-    </rdf:Description>
-    <rdf:Description rdf:about="http://purl.org/dc/terms/description">
-        <skos:definition xml:lang="en">In the context of DCAT 2.0, a free-text account of the item.</skos:definition>
-        <skos:definition xml:lang="it">Nel contesto del DCAT 2.0, un resoconto a testo libero dell’ elemento.</skos:definition>
-        <skos:definition xml:lang="es">En el contexto de DCAT 2.0, una explicación en texto sobre el ítem.</skos:definition>
-        <skos:definition xml:lang="en">An account of the resource.</skos:definition>
-        <skos:definition xml:lang="it">Un resoconto della risorsa.</skos:definition>
-        <skos:definition xml:lang="cs">V kontextu DCAT 2.0, popis položky pomocí volného textu.</skos:definition>
-    </rdf:Description>
-    <rdf:Description rdf:about="http://purl.org/dc/terms/format">
-        <skos:definition xml:lang="es">En el contexto de DCAT 2.0, el formato del archivo de la distribución.</skos:definition>
-        <skos:definition xml:lang="en">In the context of DCAT 2.0, the file format of the distribution.</skos:definition>
-        <skos:scopeNote xml:lang="cs">V kontextu DCAT 2.0, pokud je typ distribuce definován IANA [IANA-MEDIA-TYPES], MĚLA BY být použita vlastnost dcat:mediaType.</skos:scopeNote>
-        <skos:scopeNote xml:lang="en">In the context of DCAT 2.0, dcat:mediaType SHOULD be used if the type of the distribution is defined by IANA [IANA-MEDIA-TYPES].</skos:scopeNote>
-        <skos:definition xml:lang="en">The file format, physical medium, or dimensions of the resource.</skos:definition>
-        <skos:definition xml:lang="it">Il formato del file, il supporto fisico o le dimensioni della risorsa.</skos:definition>
-        <skos:definition xml:lang="cs">V kontextu DCAT 2.0, formát souboru distribuce.</skos:definition>
-        <skos:scopeNote xml:lang="es">En el contexto de DCAT 2.0, dcat:mediaType DEBERÍA usarse si el tipo de distribución se define por IANA [IANA-MEDIA-TYPES].</skos:scopeNote>
-        <skos:definition xml:lang="it">Nel contesto di DCAT 2.0, il formato di file della distribuzione.</skos:definition>
-        <skos:scopeNote xml:lang="it">Nel contesto di DCAT 2.0, dcat:mediaType DEVE essere usato se il tipo di distribuzione è definito da IANA [IANA-MEDIA-TYPES].</skos:scopeNote>
-    </rdf:Description>
-    <rdf:Description rdf:about="http://purl.org/dc/terms/hasPart">
-        <skos:scopeNote xml:lang="es">En el contexto de DCAT 2.0, este es el predicado más general para la membresía en un catálogo. Se recomienda usar una sub-propiedad más específica si hay una disponible.</skos:scopeNote>
-        <skos:scopeNote xml:lang="cs">V kontextu DCAT 2.0, viz také: Podvlastnosti dct:hasPart; zejména dcat:dataset, dcat:catalog, dcat:service.</skos:scopeNote>
-        <skos:definition xml:lang="en">In the context of DCAT 2.0 dcat:Catalog, an item that is listed in the catalog.</skos:definition>
-        <skos:scopeNote xml:lang="it">Nel contesto del DCAT 2.0, vedi anche:  le sottoproprietà di dct:hasPart; in particolare dcat:dataset, dcat:catalog, dcat:service.</skos:scopeNote>
-        <skos:scopeNote xml:lang="cs">V kontextu DCAT 2.0, toto je nejobecnější predikát pro příslušnost do katalogu. Pokud je to možné, doporučuje se použít konkrétnější vztah.</skos:scopeNote>
-        <skos:scopeNote xml:lang="es">En el contexto de DCAT 2.0, vea también: sub-propiedades de dct:hasPart; en particular dcat:dataset, dcat:catalog, dcat:service.</skos:scopeNote>
-        <skos:scopeNote xml:lang="en">In the context of DCAT 2.0, this is the most general predicate for membership of a catalog. Use of a more specific sub-property is recommended when available.</skos:scopeNote>
-        <skos:scopeNote xml:lang="it">Nel contesto del DCAT 2.0, questo è il predicato più generale per l&apos;appartenenza ad un catalogo. L&apos;uso di una sottoproprietà più specifica è raccomandato se disponibile.</skos:scopeNote>
-        <skos:definition xml:lang="it">Nel contesto di DCAT 2.0 dcat:Catalog, un elemento che è elencato nel catalogo.</skos:definition>
-        <skos:definition xml:lang="en">A related resource that is included either physically or logically in the described resource.</skos:definition>
-        <skos:scopeNote xml:lang="en">In the context of DCAT 2.0, see also: Sub-properties of dct:hasPart; in particular dcat:dataset, dcat:catalog, dcat:service.</skos:scopeNote>
-        <skos:definition xml:lang="it">Una risorsa correlata che è inclusa fisicamente o logicamente nella risorsa descritta.</skos:definition>
-    </rdf:Description>
-    <rdf:Description rdf:about="http://purl.org/dc/terms/identifier">
-        <skos:definition xml:lang="es">En el contexto de DCAT 2.0, un identificador único para el ítem.</skos:definition>
-        <skos:scopeNote xml:lang="es">En el contexto de DCAT 2.0, el identificador puede usarse como parte de la URI del ítem, pero es útil tenerlo representado de forma explícita.</skos:scopeNote>
-        <skos:scopeNote xml:lang="en">In the context of DCAT 2.0, the identifier might be used as part of the URI of the item, but still having it represented explicitly is useful.</skos:scopeNote>
-        <skos:definition xml:lang="en">In the context of DCAT 2.0, a unique identifier of the item.</skos:definition>
-        <skos:definition xml:lang="cs">V kontextu DCAT 2.0, unikátní identifikátor položky.</skos:definition>
-        <skos:definition xml:lang="it">Un riferimento univoco alla risorsa in un dato contesto.</skos:definition>
-        <skos:scopeNote xml:lang="it">Nel contesto di DCAT 2.0, l&apos;identificatore può essere usato come parte dell&apos;URI dell&apos;elemento, ma comunque è utile averlo rappresentato esplicitamente.</skos:scopeNote>
-        <skos:definition xml:lang="en">An unambiguous reference to the resource within a given context.</skos:definition>
-        <skos:scopeNote xml:lang="cs">V kontextu DCAT 2.0, identifikátor může být použit jako součást IRI položky. I přesto je užitečné mít jeho explicitní reprezentaci.</skos:scopeNote>
-        <skos:definition xml:lang="it">Nel contesto del DCAT 2.0, un identificatore unico dell&apos;elemento.</skos:definition>
-    </rdf:Description>
-    <rdf:Description rdf:about="http://purl.org/dc/terms/isReferencedBy">
-        <skos:definition xml:lang="it">Una risorsa correlata che fa riferimento, cita o indica in altro modo la risorsa descritta.</skos:definition>
-        <skos:changeNote xml:lang="it">Proprietà aggiunte in questo contesto in DCAT 2.0.</skos:changeNote>
-        <skos:changeNote xml:lang="es">En el contexto de DCAT 2.0, esta propiedad fue agregada en DCAT 2.0.</skos:changeNote>
-        <skos:scopeNote xml:lang="en">In the context of DCAT 2.0, this property is used to associate a resource to the catalogued resource (of type dcat:Resource) in question. For other relations to resources not covered with this property, the more generic property dcat:qualifiedRelation can be used. See also the section about § 9. Qualified relations.</skos:scopeNote>
-        <skos:definition xml:lang="en">A related resource that references, cites, or otherwise points to the described resource.</skos:definition>
-        <skos:definition xml:lang="en">In the context of DCAT 2.0, a related resource, such as a publication, that references, cites, or otherwise points to the catalogued resource.</skos:definition>
-        <skos:definition xml:lang="cs">V kontextu DCAT 2.0, související zdroj, např. publikace, který se odkazuje, cituje nebo jinak ukazuje na katalogizovaný zdroj.</skos:definition>
-        <skos:changeNote xml:lang="cs">Vlastnost byla v tomto kontextu přidána ve verzi DCAT 2.0</skos:changeNote>
-        <skos:scopeNote xml:lang="cs">V kontextu DCAT 2.0,tato vlastnost je použita k přiřazení zdroje ke katalogizovanému zdroji (typu dcat:Resource). Pro jiné typy vztahů ke zdrojům, které nejsou touto vlastností pokryty, může být použita obecnější vlastnost dcat:qualifiedRelation. Viz také sekce 9. &apos;Qualified relations&apos;.</skos:scopeNote>
-        <skos:scopeNote xml:lang="en">In the context of DCAT 2.0, in relation to the use case of data citation, when the catalogued resource is a dataset, the dct:isReferencedBy property allows to relate the dataset to the resources (such as scholarly publications) that cite or point to the dataset. Multiple dct:isReferencedBy properties can be used to indicate the dataset has been referenced by multiple publications, or other resources.</skos:scopeNote>
-        <skos:scopeNote xml:lang="it">Nel contesto di DCAT 2.0, questa proprietà viene utilizzata per associare una risorsa alla risorsa catalogata (di tipo dcat:Resource) in questione. Per le altre relazioni con risorse non coperte da questa proprietà, si può utilizzare la proprietà più generica dcat:qualifiedRelation. Si veda anche la sezione relativa al § 9. Relazioni qualificate.</skos:scopeNote>
-        <skos:scopeNote xml:lang="es">En el contexto de DCAT 2.0, esta propiedad se usa para asociar un recurso a un elemento del catálogo  (de tipo dcat:Resource). Para representar otro tipo de associaciones a recursos, se puede utilizar la propiedad más genérica dcat:qualifiedRelation. Para más detalle, ver la sección en relaciones calificadas de la especificación.</skos:scopeNote>
-        <skos:scopeNote xml:lang="cs">V kontextu DCAT 2.0, ohledně případu užití vztahujícího se k citaci dat, pokud je katalogizovaný zdroj datovou sadou, vlastnost dct:isReferencedBy umožňuje vztáhnout tuto datovou sadu ke zdroji (např. odborné publikaci) která ji cituje nebo na ni odkazuje. dct:isReferencedBy lze užít vícenásobně pro zaznamenání faktu, že datová sada byla odkazována z více publikací nebo jiných zdrojů.</skos:scopeNote>
-        <skos:scopeNote xml:lang="it">Nel contesto di DCAT 2.0, in relazione al caso d&apos;uso della citazione dei dati, quando la risorsa catalogata è un dataset, la proprietà dct:isReferencedBy permette di mettere in relazione il dataset con le risorse (come le pubblicazioni scientifiche) che citano o puntano al dataset. Molteplici proprietà dct:isReferencedBy possono essere utilizzate per indicare che il dataset è stato referenziato da più pubblicazioni, o altre risorse.</skos:scopeNote>
-        <skos:definition xml:lang="it">Nel contesto del DCAT 2.0, una risorsa correlata, come una pubblicazione, che rimanda, cita o indica in altro modo la risorsa catalogata.</skos:definition>
-        <skos:scopeNote xml:lang="es">En el contexto de DCAT 2.0, en relación al caso de uso sobre cita de datos, cuando el recurso catalogado es un conjunto de datos, la propiedad dct:isReferencedBy permite relacionar el conjunto de datos a publicaciones que citan o apuntan al conjunto de datos. Se pueden utilizar múltiples propiedades dct:isReferencedBy para indicar que el conjunto de datos se ha referenciado en múltiples publicaciones u otros recursos.</skos:scopeNote>
-        <skos:changeNote xml:lang="en">Property added in this context in DCAT 2.0.</skos:changeNote>
-        <skos:definition xml:lang="es">En el contexto de DCAT 2.0, un recurso relacionado, como por ejemplo una publicación, que referencia, cita, o apunta al recurso del catálogo.</skos:definition>
-    </rdf:Description>
-    <rdf:Description rdf:about="http://purl.org/dc/terms/issued">
-        <skos:definition xml:lang="it">Nel contesto del DCAT 2.0 dcat:Distribution, data di emissione formale (ad esempio, pubblicazione) della distribuzione.</skos:definition>
-        <skos:scopeNote xml:lang="en">In the context of DCAT 2.0, this property SHOULD be set using the first known date of issuance.</skos:scopeNote>
-        <skos:definition xml:lang="es">En el contexto de DCAT 2.0 dcat:CatalogRecord, la fecha en que lista (es decir, se registra formalmente) el conjunto de datos o servicio correspondiente en el catálogo.</skos:definition>
-        <skos:scopeNote xml:lang="it">Nel contesto di DCAT 2.0, questa proprietà DOVREBBE essere impostata utilizzando la prima data nota di emissione.</skos:scopeNote>
-        <skos:definition xml:lang="en">In the context of DCAT 2.0 dcat:Distribution, date of formal issuance (e.g., publication) of the distribution.</skos:definition>
-        <skos:scopeNote xml:lang="en">In the context of DCAT 2.0 dcat:CatalogRecord, this indicates the date of listing the dataset in the catalog and not the publication date of the dataset itself.</skos:scopeNote>
-        <skos:definition xml:lang="cs">V kontextu DCAT 2.0 dcat:Distribution, datum formálního vydání distribuce.</skos:definition>
-        <skos:definition xml:lang="es">En el contexto de DCAT 2.0 dcat:Distribution, fecha de emisión formal (es decir, publicación) de la distribución.</skos:definition>
-        <skos:scopeNote xml:lang="es">En el contexto de DCAT 2.0 dcat:CatalogRecord, indica la fecha en que se lista el conjunto de datos en el catálogo, y no la fecha de publicación del propio conjunto de datos.</skos:scopeNote>
-        <skos:scopeNote xml:lang="es">En el contexto de DCAT 2.0, esta propiedad DEBERÍA incluir como valor la primer fecha de emisión.</skos:scopeNote>
-        <skos:definition xml:lang="it">Data di emissione formale (ad esempio, pubblicazione) della risorsa.</skos:definition>
-        <skos:definition xml:lang="it">Nel contesto del DCAT 2.0 dcat:Resource, data di emissione formale (es. pubblicazione) di questo elemento.</skos:definition>
-        <skos:scopeNote xml:lang="cs">V kontextu DCAT 2.0 dcat:CatalogRecord, tato vlastnost indikuje datum zanesení datové sady do katalogu a ne datum vydání datové sady samotné.</skos:scopeNote>
-        <skos:definition xml:lang="cs">V kontextu DCAT 2.0 dcat:CatalogRecord, datum zanesení datové sady nebo služby do katalogu.</skos:definition>
-        <skos:definition xml:lang="cs">V kontextu DCAT 2.0 dcat:Resource, datum formálního vydání položky.</skos:definition>
-        <skos:definition xml:lang="en">In the context of DCAT 2.0 dcat:CatalogRecord, the date of listing (i.e. formal recording) of the corresponding dataset or service in the catalog.</skos:definition>
-        <skos:definition xml:lang="it">Nel contesto di DCAT 2.0 dcat:CatalogRecord, la data di inserimento (cioè la registrazione formale) del corrispondente set di dati o servizio nel catalogo.</skos:definition>
-        <skos:definition xml:lang="en">Date of formal issuance (e.g., publication) of the resource.</skos:definition>
-        <skos:definition xml:lang="es">En el contexto de DCAT 2.0 dcat:Resource, fecha de emisión formal (es decir, publicación) de un ítem.</skos:definition>
-        <skos:definition xml:lang="en">In the context of DCAT 2.0 dcat:Resource, date of formal issuance (e.g., publication) of the item.</skos:definition>
-        <skos:scopeNote xml:lang="cs">V kontextu DCAT 2.0, tato vlastnost BY MĚLA obsahovat první známé datum vydání.</skos:scopeNote>
-    </rdf:Description>
-    <rdf:Description rdf:about="http://purl.org/dc/terms/language">
-        <skos:definition xml:lang="en">A language of the resource.</skos:definition>
-        <skos:definition xml:lang="es">En el contexto de DCAT 2.0, el idioma del ítem. Este se refiere al lenguaje natural que se usa para los metadatos textuales (es decir, títulos, descripciones, etc) de un recurso catalogado (como ser un conjunto o servicio de datos) o los valores textuales de las distribuciones de un conjunto de datos.</skos:definition>
-        <skos:definition xml:lang="it">Nel contesto del DCAT 2.0, una lingua dell&apos;elemento. Si riferisce al linguaggio naturale utilizzato per i metadati testuali (titoli, descrizioni, ecc.) di una risorsa catalogata (dataset o servizio) o ai valori testuali di una distribuzione di un dataset.</skos:definition>
-        <skos:scopeNote xml:lang="it">Nel contesto del DCAT 2.0, i valori forniti per i membri di un catalogo (cioè set di dati o servizio) sostituiscono i valori forniti per il catalogo in caso di conflitto.</skos:scopeNote>
-        <skos:scopeNote xml:lang="en">In the context of DCAT 2.0, if representations of a dataset are available for each language separately, define an instance of dcat:Distribution for each language and describe the specific language of each distribution using dct:language (i.e. the dataset will have multiple dct:language values and each distribution will have just one as the value of its dct:language property).</skos:scopeNote>
-        <skos:scopeNote xml:lang="cs">V kontextu DCAT 2.0, pokud jsou reprezentace datové sady k dispozici pro každý jazyk zvlášť, definujte pro každý jazyk jednu instanci dcat:Distribution a popište jazyk dané distribuce pomocí dct:language. (tj. datová sada bude mít více hodnot dct:language a každá distribuce bude mít pouze jednu hodnotu její vlastnosti dct:language).</skos:scopeNote>
-        <skos:scopeNote xml:lang="es">En el contexto de DCAT 2.0, repetir esta propiedad si el recurso está disponible un múltiples idiomas.</skos:scopeNote>
-        <skos:scopeNote xml:lang="en">In the context of DCAT 2.0, repeat this property if the resource is available in multiple languages.</skos:scopeNote>
-        <skos:scopeNote xml:lang="it">Nel contesto di DCAT 2.0, ripetere questa proprietà se la risorsa è disponibile in più lingue.</skos:scopeNote>
-        <skos:scopeNote xml:lang="en">In the context of DCAT 2.0, the value(s) provided for members of a catalog (i.e. dataset or service) override the value(s) provided for the catalog if they conflict.</skos:scopeNote>
-        <skos:scopeNote xml:lang="cs">V kontextu DCAT 2.0, tuto vlastnost opakujte, pokud je zdroj k dispozici ve více jazycích.</skos:scopeNote>
-        <skos:scopeNote xml:lang="it">Nel contesto di DCAT 2.0, se le rappresentazioni di un dataset sono disponibili separatamente per ogni lingua, definire un&apos;istanza di dcat:Distribution per ogni lingua e descrivere la lingua specifica di ogni distribuzione usando dct:language (cioè il dataset avrà valori multipli di dct:language e ogni distribuzione avrà uno solo come valore della sua proprietà dct:language).</skos:scopeNote>
-        <skos:scopeNote xml:lang="es">En el contexto de DCAT 2.0, en el caso de conflictos, el valor (o los valores) datos para miembros del catálogo (es decir, conjunto de datos o servicios) sobreescribe el valor (o los valores) dados apra el catálogo.</skos:scopeNote>
-        <skos:scopeNote xml:lang="es">En el contexto de DCAT 2.0, si las representaciones de un conjunto de datos están disponibles por separado para cada idioma, defina una instancia de dcat:Distribution para cada idioma y describa el lenguaje específico de cada distribución usando dct:language (es decir, el conjunto de datos tendrá múltiples valores para dct:language y cada distribución tendrá sólo un valor de la propiedad dct:language).</skos:scopeNote>
-        <skos:definition xml:lang="cs">V kontextu DCAT 2.0, jazyk položky. Tato vlastnost úvádí přirozený jazyk použitý pro textová metadata, tj. názvy, popisy apod., katalogizovaného zdroje, tj. datové sady nebo služby, nebo textový obsah distribuce datové sady.</skos:definition>
-        <skos:definition xml:lang="en">In the context of DCAT 2.0, a language of the item. This refers to the natural language used for textual metadata (i.e. titles, descriptions, etc) of a catalogued resource (i.e. dataset or service) or the textual values of a dataset distribution.</skos:definition>
-        <skos:scopeNote xml:lang="cs">V kontextu DCAT 2.0, hodnoty uvedené pro katalogizované položky, tj. datové sady či služby, mají přednost před hodnotami uvedenými pro katalog, pokud jsou ve sporu.</skos:scopeNote>
-        <skos:definition xml:lang="it">Una lingua della risorsa.</skos:definition>
-    </rdf:Description>
-    <rdf:Description rdf:about="http://purl.org/dc/terms/publisher">
-        <skos:definition xml:lang="it">Un&apos;entità responsabile della messa a disposizione della risorsa.</skos:definition>
-        <skos:definition xml:lang="es">En el contexto de DCAT 2.0, la entidad responsable de hacer el item disponible.</skos:definition>
-        <skos:definition xml:lang="cs">V kontextu DCAT 2.0, entita zodpovědná za zpřístupnění položky.</skos:definition>
-        <skos:scopeNote xml:lang="cs">V kontextu DCAT 2.0, doporučovanou hodnotou této vlastnosti jsou zdroje typu foaf:Agent.</skos:scopeNote>
-        <skos:definition xml:lang="en">An entity responsible for making the resource available.</skos:definition>
-        <skos:definition xml:lang="it">Nell&apos;ambito del DCAT 2.0, l&apos;entità responsabile della messa a disposizione dell&apos;elemento.</skos:definition>
-        <skos:scopeNote xml:lang="es">En el contexto de DCAT 2.0, se recomienda usar recursos del tipo foaf:Agent para los valores de esta propiedad.</skos:scopeNote>
-        <skos:scopeNote xml:lang="it">Nel contesto di DCAT 2.0, si raccomandano risorse di tipo foaf:Agent come valori per questa proprietà.</skos:scopeNote>
-        <skos:definition xml:lang="en">In the context of DCAT 2.0, the entity responsible for making the item available.</skos:definition>
-        <skos:scopeNote xml:lang="en">In the context of DCAT 2.0, resources of type foaf:Agent are recommended as values for this property.</skos:scopeNote>
-    </rdf:Description>
-    <rdf:Description rdf:about="http://purl.org/dc/terms/rights">
-        <skos:definition xml:lang="es">En el contexto de DCAT 2.0 dcat:Resource, una declaración que tiene que ver con todos los derechos no representados con dct:license o dct:accessRights, como por ejemplo declaraciones de derechos de autor.</skos:definition>
-        <skos:scopeNote xml:lang="en">In the context of DCAT 2.0 dcat:Distribution, dct:license, which is a sub-property of dct:rights, can be used to link a distribution to a license document. However, dct:rights allows linking to a rights statement that can include licensing information as well as other information that supplements the license such as attribution. Information about licenses and rights SHOULD be provided on the level of Distribution. Information about licenses and rights MAY be provided for a Dataset in addition to but not instead of the information provided for the Distributions of that Dataset. Providing license or rights information for a Dataset that is different from information provided for a Distribution of that Dataset SHOULD be avoided as this can create legal conflicts. See also guidance in the secion on &apos;License and rights statements&apos;.</skos:scopeNote>
-        <skos:definition xml:lang="en">In the context of DCAT 2.0 dcat:Distribution, information about rights held in and over the distribution.</skos:definition>
-        <skos:scopeNote xml:lang="cs">V kontextu DCAT 2.0 dcat:Distribution, dct:license, což je podvlastnost dct:rights, může být použita k propojení distribuce a licenčního dokumentu. dct:rights ale umožňuje odkazovat na podmínky užití, které také mohou obsahovat licenční informace, které mohou licenci upřesňovat například nutností citace. Informace o podmínkách užití (licencích a právech) BY MĚLY být poskytnuty na úrovni distribuce. Navíc, nikoliv místo, MOHOU BÝT informace o podmínkách užití (licencích a právech) poskytnuty na úrovni datové sady. NEMĚLY BY SE poskytnout různé podmínky užití pro datovou sadu a pro její distribuci, jelikož to může vést ke sporům v právním výkladu. Viz také návod v sekci &apos;License and rights statements&apos;.</skos:scopeNote>
-        <skos:definition xml:lang="cs">V kontextu DCAT 2.0 dcat:Distribution, informace o právech vztahujících se na distribuci.</skos:definition>
-        <skos:definition xml:lang="cs">V kontextu DCAT 2.0 dcat:Resource, dokument zabývající se všemi právy, které nejsou ošetřeny v dct:license či dct:rights, jako je například copyright.</skos:definition>
-        <skos:scopeNote xml:lang="cs">V kontextu DCAT 2.0, pro Zdroj MŮŽE BÝT uvedena informace o podmínkách užití (licencích a právech). Viz návod v sekci &apos;License and rights statements&apos;.</skos:scopeNote>
-        <skos:scopeNote xml:lang="es">En el contexto de DCAT 2.0 dcat:Distribution, dct:license, que es una sub-propertiedad de dct:rights, puede usarse para asociar una distribución a un documento de licencia. Sin embargo, dct:rights permite asociar a una declaración de derechos que incluya información de licencias así como también otra información que suplementa la licencia, como atribución. La información sobre las licencias y derechos DEBERÍA proveerse a nivel de la Distribución. La información sobre licencias y derechos PUEDE proveerse también para un conjunto de datos pero no en lugar de la información provista para las Distribuciones del conjunto de datos. Se DEBERÍA evitar brindar información sobre licencias y derechos de un conjunto de datos que difiere de aquella de la Distribución del conjunto de datos ya que se crean conflictos legales. Ver también la sección &apos;License and rights statements&apos; para más información.</skos:scopeNote>
-        <skos:scopeNote xml:lang="es">En el contexto de DCAT 2.0, información sobre licencias y derechos PUEDE proveerse para un Recurso. Ver también la sección &apos;License and rights statements&apos; para más información.</skos:scopeNote>
-        <skos:definition xml:lang="en">In the context of DCAT 2.0 dcat:Resource, a statement that concerns all rights not addressed with dct:license or dct:accessRights, such as copyright statements.</skos:definition>
-        <skos:definition xml:lang="en">Information about rights held in and over the resource.</skos:definition>
-        <skos:definition xml:lang="it">Informazioni sui diritti inerenti alla risorsa e su di essa.</skos:definition>
-        <skos:definition xml:lang="es">En el contexto de DCAT 2.0 dcat:Distribution, información sobre los derechos mantenido por las distribuciones.</skos:definition>
-        <skos:scopeNote xml:lang="it">Nel contesto di DCAT 2.0 dcat:Distribution, dct:license, che è una sottoproprietà di dct:rights, può essere utilizzata per collegare una distribuzione ad un documento di licenza. Tuttavia, dct:rights permette il collegamento ad una definizione dei diritti che può includere informazioni sulla licenza e altre informazioni che integrano la licenza, come l&apos;attribuzione. Le informazioni su licenze e diritti DEVONO essere fornite a livello di distribuzione. Inoltre,  le informazioni su licenze e diritti POSSONO essere fornite per un set di dati  ma non al posto delle informazioni fornite per le distribuzioni di quel set di dati. La fornitura di informazioni sulla licenza o sui diritti per un set di dati diverso dalle informazioni fornite per una distribuzione di quel set di dati DOVREBBBE essere evitata in quanto ciò può creare conflitti legali. Si veda anche la guida nella sezione &apos;Licenze e dichiarazioni sui diritti&apos;.</skos:scopeNote>
-        <skos:definition xml:lang="it">Nel contesto di DCAT 2.0 dcat:Resource, una dichiarazione che riguarda tutti i diritti non trattati con dct:license o dct:accessRights, come le dichiarazioni di copyright.</skos:definition>
-        <skos:definition xml:lang="it">Nel contesto di DCAT 2.0 dcat:Distribution, informazioni sui diritti relativi alla distribuzione.</skos:definition>
-        <skos:scopeNote xml:lang="it">Nell&apos;ambito del DCAT 2.0, possono essere fornite informazioni su licenze e diritti per la risorsa. Si veda anche la guida nella sezione &apos;Licenze e dichiarazioni sui diritti&apos;.</skos:scopeNote>
-        <skos:scopeNote xml:lang="en">In the context of DCAT 2.0, information about licenses and rights MAY be provided for the Resource. See also guidance in the section &apos;License and rights statements&apos;.</skos:scopeNote>
-    </rdf:Description>
-    <rdf:Description rdf:about="http://purl.org/dc/terms/spatial">
-        <skos:scopeNote xml:lang="en">In the context of DCAT 2.0 dcat:Dataset, the spatial coverage of a dataset may be encoded as an instance of dct:Location, or may be indicated using a URI reference (link) to a resource describing a location. It is recommended that links are to entries in a well maintained gazetteer such as Geonames.</skos:scopeNote>
-        <skos:definition xml:lang="en">In the context of DCAT 2.0 dcat:Dataset, the geographical area covered by the dataset.</skos:definition>
-        <skos:definition xml:lang="cs">V kontextu DCAT 2.0 dcat:Dataset, geografické území pokryté datovou sadou.</skos:definition>
-        <skos:definition xml:lang="it">Nel contesto di DCAT 2.0 dcat:Dataset, l&apos;area geografica coperta dal set di dati.</skos:definition>
-        <skos:scopeNote xml:lang="es">En el contexto de DCAT 2.0 dcat:Dataset, la cobertura espacial de un conjunto de datos puede codificarse como una instancia de dct:Location, o puede indicarse usando una referencia URI (es decir, un enlace) a un recurso que describa la posición. Se recomienda que los enlaces sean a entradas en un diccionario geográfico bien mantenido como Geonames.</skos:scopeNote>
-        <skos:definition xml:lang="it">Caratteristiche spaziali della risorsa.</skos:definition>
-        <skos:definition xml:lang="es">En el contexto de DCAT 2.0 dcat:Dataset, el área geográfica cubierta por el conjunto de datos.</skos:definition>
-        <skos:scopeNote xml:lang="cs">V kontextu DCAT 2.0 dcat:Dataset, územní pokrytí datové sady může být zaznamenáno jako instance dct:Location, nebo může být indikováno jako IRI odkazující na zdroj popisující území. Je doporučeno se odkazovat na udržovaný zdroj dat jako například Geonames.</skos:scopeNote>
-        <skos:definition xml:lang="en">Spatial characteristics of the resource.</skos:definition>
-        <skos:scopeNote xml:lang="it">Nel contesto di DCAT 2.0 dcat:Dataset, la copertura spaziale di un set di dati può essere codificata come istanza di dct:Location, o può essere indicata utilizzando un riferimento URI (link) a una risorsa che descrive una locazione. Si raccomanda che i collegamenti siano a delle voci in un gazetteer ben mantenuto come Geonames.</skos:scopeNote>
-    </rdf:Description>
-    <rdf:Description rdf:about="http://purl.org/dc/terms/temporal">
-        <skos:definition xml:lang="it">Nel contesto di DCAT 2.0 dcat:Dataset, il periodo temporale coperto dal set di dati.</skos:definition>
-        <skos:definition xml:lang="it">Caratteristiche temporali della risorsa.</skos:definition>
-        <skos:definition xml:lang="es">En el contexto de DCAT 2.0 dcat:Dataset, el período temporal cubierto por el conjunto de datos.</skos:definition>
-        <skos:definition xml:lang="cs">V kontextu DCAT 2.0 dcat:Dataset, časové pokrytí datové sady.</skos:definition>
-        <skos:scopeNote xml:lang="it">Nel contesto di DCAT 2.0 dcat:Dataset, la copertura temporale di un dataset può essere codificata come istanza di dct:PeriodOfTime, o può essere indicata utilizzando un riferimento URI (link) ad una risorsa che descrive un periodo o intervallo di tempo.</skos:scopeNote>
-        <skos:scopeNote xml:lang="es">En el contexto de DCAT 2.0 dcat:Dataset, la cobertura temporal del conjunto de datos puede codificarse como una instancia de dct:PeriodOfTime, o puede indicarse usando una referencia URI (es decir, un enlace) a un recurso que describa el período o interválo de tiempo.</skos:scopeNote>
-        <skos:scopeNote xml:lang="cs">V kontextu DCAT 2.0 dcat:Dataset, časové pokrytí datové sady může být zaznamenáno jako instance dct:PeriodOfTime, nebo může být indikováno jako IRI odkazující na zdroj popisující či časový interval.</skos:scopeNote>
-        <skos:scopeNote xml:lang="en">In the context of DCAT 2.0 dcat:Dataset, the temporal coverage of a dataset may be encoded as an instance of dct:PeriodOfTime, or may be indicated using a URI reference (link) to a resource describing a time period or interval.</skos:scopeNote>
-        <skos:definition xml:lang="en">Temporal characteristics of the resource.</skos:definition>
-        <skos:definition xml:lang="en">In the context of DCAT 2.0 dcat:Dataset, the temporal period that the dataset covers.</skos:definition>
-    </rdf:Description>
-    <rdf:Description rdf:about="http://purl.org/dc/terms/title">
-        <skos:definition xml:lang="it">Nel contesto di DCAT 2.0 dcat:Resource, un nome dato alla elemento.</skos:definition>
-        <skos:definition xml:lang="it">Un nome dato alla risorsa.</skos:definition>
-        <skos:definition xml:lang="cs">V kontextu DCAT 2.0 dcat:Distribution, název distribuce</skos:definition>
-        <skos:definition xml:lang="es">En el contexto de DCAT 2.0 dcat:Resource, un nombre o título dado al elemento del catálogo.</skos:definition>
-        <skos:definition xml:lang="es">En el contexto de DCAT 2.0 dcat:Distribution, un nombre o título dado a la distribución.</skos:definition>
-        <skos:definition xml:lang="en">In the context of DCAT 2.0 dcat:Resource, a name given to the item.</skos:definition>
-        <skos:definition xml:lang="it">Nel contesto di DCAT 2.0 dcat:Distribution, un nome o titolo dato alla distribuzione.</skos:definition>
-        <skos:definition xml:lang="cs">V kontextu DCAT 2.0 dcat:Resource, název položky</skos:definition>
-        <skos:definition xml:lang="en">A name given to the resource.</skos:definition>
-        <skos:definition xml:lang="en">In the context of DCAT 2.0 dcat:Distribution, a name given to the distribution.</skos:definition>
-    </rdf:Description>
-    <rdf:Description rdf:about="http://purl.org/dc/terms/type">
-        <skos:scopeNote xml:lang="es">En el contexto de DCAT 2.0, el valor DEBERÍA tomarse de un vocabulario controlado bien gobernado y ampliamente reconocido, como por ejemplo: 1. DCMI Type vocabulary [DCTERMS]; 2. códigos de alcance de ISO 19115 [ISO-19115-1]; 3. tipos de recursos de Datacite [DataCite]; 4. tipos de contenido de PARSE.Insight usados por re3data.org [RE3DATA-SCHEMA] (see item 15 contentType); 5. tipos de recurso intelectual de MARC. Algunos elementos de estos vocabularios controlados son estrictamente no apropiados para conjuntos de datos o servicios de datos (por ejemplo: DCMI Type Event, PhysicalObject; ISO 19115 CollectionHardware, CollectionSession, Initiative, Sample, Repository), pero pueden usarse en este contexto para otros tipos de catálogos definidos en perfiles de DCAT o aplicaciones.</skos:scopeNote>
-        <skos:scopeNote xml:lang="en">In the context of DCAT 2.0, the value SHOULD be taken from a well governed and broadly recognised controlled vocabulary, such as: 1. DCMI Type vocabulary [DCTERMS]; 2. ISO 19115 scope codes [ISO-19115-1]; 3. Datacite resource types [DataCite]; 4. PARSE.Insight content-types used by re3data.org [RE3DATA-SCHEMA] (see item 15 contentType); 5. MARC intellectual resource types ; Some members of these controlled vocabularies are not strictly suitable for datasets or data services (e.g. DCMI Type Event, PhysicalObject; ISO 19115 CollectionHardware, CollectionSession, Initiative, Sample, Repository), but might be used in the context of other kinds of catalogs defined in DCAT profiles or applications.</skos:scopeNote>
-        <skos:definition xml:lang="en">The nature or genre of the resource.</skos:definition>
-        <skos:scopeNote xml:lang="es">Usa el elemento dct:format para describir el formato del archivo, el medio físico, o las dimensiones del recurso.</skos:scopeNote>
-        <skos:scopeNote xml:lang="cs">Pro popis formátu souboru, fyzického média či dimenzí zdroje použijte dct:format.</skos:scopeNote>
-        <skos:scopeNote xml:lang="cs">V kontextu DCAT 2.0, hodnota BY MĚLA být z dobře řízeného a široce uznávaného slovníku, např.: 1. Slovník DCMI Type [DCTERMS]; 2. Kódy ISO 19115 [ISO-19115-1]; 3. Typy zdrojů Datacite [DataCite]; 4. Typy obsahu PARSE.Insight, které jsou používány re3data.org [RE3DATA-SCHEMA] (viz položka 15 contentType); 5. Typy duševních zdrojů MARC; Některé položky těchto slovníků nejsou zcela vhodné pro datové sady nebo datové služby (např. DCMI Type Event, PhysicalObject; ISO 19115 CollectionHardware, CollectionSession, Initiative, Sample, Repository), ale mohou být použity v kontextu jiných typů katalogů, které jsou definovány v profilech či aplikacích DCAT.</skos:scopeNote>
-        <skos:scopeNote xml:lang="it">Per descrivere il formato del file, il supporto fisico o le dimensioni della risorsa, utilizzare l&apos;elemento dct:format.</skos:scopeNote>
-        <skos:definition xml:lang="es">La naturaleza, género o tipo del recurso.</skos:definition>
-        <skos:scopeNote xml:lang="en">To describe the file format, physical medium, or dimensions of the resource, use the dct:format element.</skos:scopeNote>
-        <skos:scopeNote xml:lang="it">Il valore DOVREBBE essere tratto da un vocabolario ben governato e ampiamente riconosciuto e controllato, come ad esempio: 1. Vocabolario dei  DCMI Type [DCTERMS]; 2. Codici di scopo ISO 19115 [ISO-19115-1];  3. Tipi di risorse del Datacite [DataCite]. 4. PARSE.Insight content-type utilizzati da re3data.org [RE3DATA-SCHEMA] (vedi punto 15 contentType); 5. Tipi di risorse intellettuali del MARC. Alcuni membri di questi vocabolari controllati non sono strettamente adatti a insiemi di dati o servizi di dati (ad es. DCMI Type Event, PhysicalObject; ISO 19115 CollectionHardware, CollectionSession, Initiative, Sample, Repository), ma possono essere utilizzati nel contesto di altri tipi di cataloghi definiti in profili o applicazioni DCAT.</skos:scopeNote>
-        <skos:definition xml:lang="it">La natura o il tipo di risorsa.</skos:definition>
-        <skos:definition xml:lang="cs">Podstata či žánr zdroje.</skos:definition>
-    </rdf:Description>
-    <rdf:Description rdf:about="http://www.w3.org/2006/time#hasBeginning">
-        <skos:scopeNote xml:lang="cs">V kontextu DCAT 2.0, použití vlastnosti time:hasBeginning znamená, že hodnota vlastnosti dct:temporal je instancí třídy time:TemporalEntity ze slovníku [OWL-TIME]. V tomto kontextu to může znamenat, že dct:PeriodOfTime je ekvivalentní podtřídě time:ProperInterval</skos:scopeNote>
-        <skos:scopeNote xml:lang="it">Nel contesto di DCAT 2.0, l&apos;uso della proprietà time:hasBeginning comporta che il valore della proprietà dct:temporal  è un membro della classe time:TemporalEntity di [OWL-TIME]. In questo contesto ciò potrebbe essere interpretato nel senso che dct:PeriodOfTime è equivalente alla sottoclasse time:ProperInterval.</skos:scopeNote>
-        <skos:scopeNote xml:lang="en">In the context of DCAT 2.0, use of the property time:hasBeginning entails that value of the dct:temporal property is a member of the time:TemporalEntity class from [OWL-TIME]. In this context this could be taken to imply that dct:PeriodOfTime is equivalent to the subclass time:ProperInterval.</skos:scopeNote>
-        <skos:changeNote xml:lang="es">Esta propiedad fue agregada en DCAT 2.0.</skos:changeNote>
-        <skos:definition xml:lang="it">Inizio di un&apos;entità temporale.</skos:definition>
-        <skos:changeNote xml:lang="en">Property added in this context in DCAT 2.0.</skos:changeNote>
-        <skos:changeNote xml:lang="it">Proprietà aggiunte in questo contesto in DCAT 2.0.</skos:changeNote>
-        <skos:definition xml:lang="en">In the context of DCAT 2.0, beginning of a period or interval.</skos:definition>
-        <skos:definition xml:lang="en">Beginning of a temporal entity.</skos:definition>
-        <skos:scopeNote xml:lang="es">En el contexto de DCAT 2.0, el uso de la propiedad time:hasBeginning implica que el valor de la propiedad dct:temporal es un miembro de la clase time:TemporalEntity de [OWL-TIME]. En este contexto, esto puede interpretarse como que implica que dct:PeriodOfTime es equivalente a la subclase time:ProperInterval.</skos:scopeNote>
-        <skos:changeNote xml:lang="cs">Vlastnost v tomto kontextu byla přidána ve verzi DCAT 2.0.</skos:changeNote>
-    </rdf:Description>
-    <rdf:Description rdf:about="http://www.w3.org/2006/time#hasEnd">
-        <skos:changeNote xml:lang="es">Esta propiedad fue agregada en DCAT 2.0.</skos:changeNote>
-        <skos:scopeNote xml:lang="es">En el contexto de DCAT 2.0, el uso de la propiedad time:hasEnd implica que el valor de la propiedad dct:temporal es un miembro de la clase time:TemporalEntity de [OWL-TIME]. En este contexto, esto puede interpretarse como que implica que dct:PeriodOfTime es equivalente a la subclase time:ProperInterval.</skos:scopeNote>
-        <skos:changeNote xml:lang="en">Property added in this context in DCAT 2.0.</skos:changeNote>
-        <skos:scopeNote xml:lang="it">Nel contesto di DCAT 2.0, l&apos;uso della proprietà time:hasEnd comporta che il valore della proprietà dct:temporal è un membro della classe time:TemporalEntity di [OWL-TIME]. In questo contesto ciò potrebbe essere interpretato nel senso che dct:PeriodOfTime è equivalente alla sottoclasse time:ProperInterval.</skos:scopeNote>
-        <skos:definition xml:lang="en">In the context of DCAT 2.0, end of a period or interval.</skos:definition>
-        <skos:definition xml:lang="en">End of a temporal entity.</skos:definition>
-        <skos:definition xml:lang="it">Nel contesto del DCAT 2.0, fine di un periodo o intervallo.</skos:definition>
-        <skos:scopeNote xml:lang="en">In the context of DCAT 2.0, use of the property time:hasEnd entails that value of the dct:temporal property is a member of the time:TemporalEntity class from [OWL-TIME]. In this context this could be taken to imply that dct:PeriodOfTime is equivalent to the subclass time:ProperInterval.</skos:scopeNote>
-        <skos:scopeNote xml:lang="cs">V kontextu DCAT 2.0, použití vlastnosti time:hasEnd znamená, že hodnota vlastnosti dct:temporal je instancí třídy time:TemporalEntity ze slovníku [OWL-TIME]. V tomto kontextu to může znamenat, že dct:PeriodOfTime je ekvivalentní podtřídě time:ProperInterval.</skos:scopeNote>
-        <skos:changeNote xml:lang="it">Proprietà aggiunte in questo contesto in DCAT 2.0.</skos:changeNote>
-        <skos:changeNote xml:lang="cs">Vlastnost v tomto kontextu byla přidána ve verzi DCAT 2.0</skos:changeNote>
-        <skos:definition xml:lang="it">Fine di un&apos;entità temporale.</skos:definition>
-    </rdf:Description>
-    <rdf:Description rdf:about="http://www.w3.org/ns/odrl/2/hasPolicy">
-        <skos:definition xml:lang="es">En el contexto de DCAT 2.0 dcat:Resource, una reglamentación conforme a ODRL expresando los derechos asociados con el recurso [ODRL-VOCAB].</skos:definition>
-        <skos:scopeNote xml:lang="it">Nel contesto di DCAT 2.0 dcat:Distribution, le informazioni sui diritti espressi come policy ODRL [ODRL-MODEL] utilizzando il vocabolario ODRL [ODRL-VOCAB] POSSONO essere fornite per la distribuzione. Si veda anche la guida alla sezione &apos;Licenza e dichiarazioni sui diritti&apos;.</skos:scopeNote>
-        <skos:scopeNote xml:lang="en">In the context of DCAT 2.0 dcat:Resource, information about rights expressed as an ODRL policy [ODRL-MODEL] using the ODRL vocabulary [ODRL-VOCAB] MAY be provided for the resource. See also guidance at the section &apos;License and rights statements&apos;.</skos:scopeNote>
-        <skos:scopeNote xml:lang="en">In the context of DCAT 2.0 dcat:Distribution, information about rights expressed as an ODRL policy [ODRL-MODEL] using the ODRL vocabulary [ODRL-VOCAB] MAY be provided for the distribution. See also guidance at the section &apos;License and rights statements&apos;.</skos:scopeNote>
-        <skos:definition xml:lang="it">Nel contesto di DCAT 2.0 dcat:Distribution, una policy conforme all&apos;ODRL che esprime i diritti associati alla distribuzione.</skos:definition>
-        <skos:definition xml:lang="cs">V kontextu DCAT 2.0 dcat:Resource, pravidlo vyjadřující práva spojená se zdrojem, pokud je použit slovník ODRL [ODRL-VOCAB].</skos:definition>
-        <skos:definition xml:lang="en">Identifies an ODRL Policy for which the identified Asset is the target Asset to all the Rules.</skos:definition>
-        <skos:scopeNote xml:lang="cs">V kontextu DCAT 2.0 dcat:Distribution, pro distribuci MŮŽE BÝT uvedena informace o právech vyjádřená pomocí pravidel slovníku ODRL [ODRL-VOCAB]. Viz také návod v sekci 10. &apos;License and rights statements&apos;.</skos:scopeNote>
-        <skos:definition xml:lang="it">Nel contesto di DCAT 2.0 dcat:Resource, una policy conforme all&apos;ODRL che esprime i diritti associati alla risorsa.</skos:definition>
-        <skos:definition xml:lang="en">In the context of DCAT 2.0 dcat:Resource, an ODRL conformant policy expressing the rights associated with the resource.</skos:definition>
-        <skos:scopeNote xml:lang="it">Nel contesto DCAT 2.0 dcat:Resource, le informazioni sui diritti espressi come policy ODRL [ODRL-MODEL] utilizzando il vocabolario ODRL [ODRL-VOCAB] POSSONO essere fornite per la risorsa. Si veda anche la guida alla sezione &apos;Licenza e dichiarazioni sui diritti&apos;.</skos:scopeNote>
-        <skos:scopeNote xml:lang="cs">V kontextu DCAT 2.0 dcat:Resource, pro zdroj MŮŽE BÝT uvedena informace o právech vyjádřená pomocí pravidel slovníku ODRL [ODRL-VOCAB]. Viz také návod v sekci &apos;License and rights statements&apos;.</skos:scopeNote>
-        <skos:definition xml:lang="en">In the context of DCAT 2.0 dcat:Distribution, an ODRL conformant policy expressing the rights associated with the distribution.</skos:definition>
-        <skos:editorialNote xml:lang="en">Czech translation to be updated.</skos:editorialNote>
-        <skos:scopeNote xml:lang="es">En el contexto de DCAT 2.0 dcat:Resource, información sobre los derechos expresados como reglamentación ODRL [ODRL-MODEL] usando el vocabulario ODRL [ODRL-VOCAB] PUEDE proveerse para el Recurso. Ver también la información en la sección &apos;License and rights statements&apos;.</skos:scopeNote>
-        <skos:definition xml:lang="cs">V kontextu DCAT 2.0 dcat:Distribution, pravidlo vyjadřující práva spojená s distribucí, pokud je použit slovník ODRL [ODRL-VOCAB].</skos:definition>
-        <skos:definition xml:lang="es">En el contexto de DCAT 2.0 dcat:Distribution, una reglamentación conforme a ODRL expresando los derechos asociados con la distribución [ODRL-VOCAB].</skos:definition>
-        <skos:scopeNote xml:lang="es">En el contexto de DCAT 2.0 dcat:Distribution, información sobre los derechos expresados como reglamentación ODRL [ODRL-MODEL] using the ODRL vocabulary [ODRL-VOCAB] PUEDE proveerse para el Distribución. Ver también la información en la sección &apos;License and rights statements.&apos;</skos:scopeNote>
-    </rdf:Description>
-    <rdf:Description rdf:about="http://www.w3.org/ns/prov#qualifiedAttribution">
-        <skos:scopeNote xml:lang="en">In the context of DCAT 2.0, used to link to an Agent where the nature of the relationship is known but does not match one of the standard Dublin Core properties (dct:creator, dct:publisher). Use dcat:hadRole on the prov:Attribution to capture the responsibility of the Agent with respect to the Resource. See https://w3c.github.io/dxwg/dcat/#qualified-attribution for usage examples.</skos:scopeNote>
-        <skos:definition xml:lang="cs">V kontextu DCAT 2.0, odkaz na Agenta, který má nějaký typ odpovědnosti za zdroj.</skos:definition>
-        <skos:definition xml:lang="en">In the context of DCAT 2.0, link to an Agent having some form of responsibility for the resource.</skos:definition>
-        <skos:definition xml:lang="it">Nel contesto di DCAT 2.0, collegamento a un agente che ha una qualche forma di responsabilità per la risorsa.</skos:definition>
-        <skos:definition xml:lang="es">En el contexto de DCAT 2.0, enlace a un Agente que tiene alguna forma de responsabilidad con el recurso.</skos:definition>
-        <skos:changeNote xml:lang="en">Property added in this context in DCAT 2.0.</skos:changeNote>
-        <skos:scopeNote xml:lang="es">En el contexto de DCAT 2.0, se usa para asociar un Agente cuando la naturaleza de la relación es conocida pero no es ninguna de las asociaciones estándares descriptas con propiedades de Dublin Core (dct:creator, dct:publisher). Se usa dcat:hadRole en la prov:Attribution para capturar la responsabilidad del Agente con respecto al Recurso. Ver https://w3c.github.io/dxwg/dcat/#qualified-attribution para más ejemplos de uso.</skos:scopeNote>
-        <skos:changeNote xml:lang="it">Proprietà aggiunta in questo contesto in DCAT 2.0.</skos:changeNote>
-        <skos:changeNote xml:lang="cs">Vlastnost v tomto kontextu byla přidána ve verzi DCAT 2.0.</skos:changeNote>
-        <skos:scopeNote xml:lang="cs">V kontextu DCAT 2.0, vlastnost se používá pro odkaz na Agenta tam, kde typ vztahu je znám, ale neodpovídá žádné ze standardních vlastností Dublin Core (dct:creator, dct:publisher). Pro reprezentaci vztahu Agenta ke zdroji použijte vlastnost dcat:hadRole na třídě prov:Attribution. Viz  https://w3c.github.io/dxwg/dcat/#qualified-attribution pro příklady užití.</skos:scopeNote>
-        <skos:scopeNote xml:lang="it">Nel contesto di DCAT 2.0, utilizzato per collegarsi a un agente in cui la natura della relazione è nota ma non corrisponde a una delle proprietà Dublin Core standard (dct: creatore, dct: editore). Si usi dcat:hadRole su prov:Attribution per rappresentare la responsabilità dell&apos;Agente in relazione alla Risorsa. Si veda https://w3c.github.io/dxwg/dcat/#qualified-attribution per gli esempi di utilizzo.</skos:scopeNote>
-        <skos:changeNote xml:lang="es">Esta propiedad fue agregada en DCAT 2.0.</skos:changeNote>
-    </rdf:Description>
-    <rdf:Description rdf:about="http://xmlns.com/foaf/0.1/primaryTopic">
-        <skos:scopeNote xml:lang="it">foaf:primaryTopic property è funzionale: nel contesto di DCAT 2.0, ogni record di catalogo può avere al massimo un argomento primario, cioè descrive un set di dati o un servizio.</skos:scopeNote>
-        <skos:definition xml:lang="cs">V kontextu DCAT 2.0 dcat:CatalogRecord, dcat:Resource (datová sada či služba) popsaná katalogizačním záznamem.</skos:definition>
-        <skos:definition xml:lang="en">The primary topic of some page or document.</skos:definition>
-        <skos:scopeNote xml:lang="cs">Vlastnost foaf:primaryTopic je funkce: v kontextu DCAT 2.0, každý katalogizační záznam může mít nejvýše jednu hodnotu foaf:primaryTopic, tj. popisuje nejvýše jednu datovou sadu či službu.</skos:scopeNote>
-        <skos:definition xml:lang="es">En el contexto de DCAT 2.0 dcat:CatalogRecord, el dcat:Resource (conjunto de datos o servicio) descripto en el registro.</skos:definition>
-        <skos:definition xml:lang="it">Nel contesto di DCAT 2.0 dcat:CatalogRecord, il dcat:Resource (set di dati o servizio) descritto nel record.</skos:definition>
-        <skos:scopeNote xml:lang="es">La propiedad foaf:primaryTopic es funcional: en el contexto de DCAT 2.0,  cada registro del catálogo puede tener a lo sumo un tópico principal, es decir un tópico que describa el conjunto de datos o servicio.</skos:scopeNote>
-        <skos:scopeNote xml:lang="en">foaf:primaryTopic property is functional: in the context of DCAT 2.0, each catalog record can have at most one primary topic i.e. describes one dataset or service.</skos:scopeNote>
-        <skos:definition xml:lang="it">L&apos;argomento principale di qualche pagina o documento.</skos:definition>
-        <skos:definition xml:lang="en">In the context of DCAT 2.0 dcat:CatalogRecord, the dcat:Resource (dataset or service) described in the record.</skos:definition>
-    </rdf:Description>
+        <skos:definition xml:lang="cs">V kontextu DCAT 2.0 dcat:Resource, Zdroj s nespecifikovaným vztahem ke katalogizované položce.</skos:definition>
+        <skos:scopeNote xml:lang="it">Nel contesto di un DCAT 2.0, dcat:Relationship ci si aspetta che punti ad un altro dcat:Dataset o altra risorsa catalogata.</skos:scopeNote>
+      </rdf:Description>
+    </rdfs:subPropertyOf>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://www.w3.org/ns/prov#specializationOf">
+    <rdfs:subPropertyOf rdf:resource="http://purl.org/dc/terms/relation"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.org/dc/terms/rights">
+    <skos:scopeNote xml:lang="cs">V kontextu DCAT 2.0 dcat:Distribution, dct:license, což je podvlastnost dct:rights, může být použita k propojení distribuce a licenčního dokumentu. dct:rights ale umožňuje odkazovat na podmínky užití, které také mohou obsahovat licenční informace, které mohou licenci upřesňovat například nutností citace. Informace o podmínkách užití (licencích a právech) BY MĚLY být poskytnuty na úrovni distribuce. Navíc, nikoliv místo, MOHOU BÝT informace o podmínkách užití (licencích a právech) poskytnuty na úrovni datové sady. NEMĚLY BY SE poskytnout různé podmínky užití pro datovou sadu a pro její distribuci, jelikož to může vést ke sporům v právním výkladu. Viz také návod v sekci 'License and rights statements'.</skos:scopeNote>
+    <skos:scopeNote xml:lang="it">Nell'ambito del DCAT 2.0, possono essere fornite informazioni su licenze e diritti per la risorsa. Si veda anche la guida nella sezione 'Licenze e dichiarazioni sui diritti'.</skos:scopeNote>
+    <skos:scopeNote xml:lang="it">Nel contesto di DCAT 2.0 dcat:Distribution, dct:license, che è una sottoproprietà di dct:rights, può essere utilizzata per collegare una distribuzione ad un documento di licenza. Tuttavia, dct:rights permette il collegamento ad una definizione dei diritti che può includere informazioni sulla licenza e altre informazioni che integrano la licenza, come l'attribuzione. Le informazioni su licenze e diritti DEVONO essere fornite a livello di distribuzione. Inoltre,  le informazioni su licenze e diritti POSSONO essere fornite per un set di dati  ma non al posto delle informazioni fornite per le distribuzioni di quel set di dati. La fornitura di informazioni sulla licenza o sui diritti per un set di dati diverso dalle informazioni fornite per una distribuzione di quel set di dati DOVREBBBE essere evitata in quanto ciò può creare conflitti legali. Si veda anche la guida nella sezione 'Licenze e dichiarazioni sui diritti'.</skos:scopeNote>
+    <skos:scopeNote xml:lang="es">En el contexto de DCAT 2.0, información sobre licencias y derechos PUEDE proveerse para un Recurso. Ver también la sección 'License and rights statements' para más información.</skos:scopeNote>
+    <skos:definition xml:lang="it">Informazioni sui diritti inerenti alla risorsa e su di essa.</skos:definition>
+    <skos:scopeNote xml:lang="en">In the context of DCAT 2.0, information about licenses and rights MAY be provided for the Resource. See also guidance in the section 'License and rights statements'.</skos:scopeNote>
+    <skos:definition xml:lang="es">En el contexto de DCAT 2.0 dcat:Distribution, información sobre los derechos mantenido por las distribuciones.</skos:definition>
+    <skos:definition xml:lang="es">En el contexto de DCAT 2.0 dcat:Resource, una declaración que tiene que ver con todos los derechos no representados con dct:license o dct:accessRights, como por ejemplo declaraciones de derechos de autor.</skos:definition>
+    <skos:definition xml:lang="cs">V kontextu DCAT 2.0 dcat:Distribution, informace o právech vztahujících se na distribuci.</skos:definition>
+    <skos:scopeNote xml:lang="es">En el contexto de DCAT 2.0 dcat:Distribution, dct:license, que es una sub-propertiedad de dct:rights, puede usarse para asociar una distribución a un documento de licencia. Sin embargo, dct:rights permite asociar a una declaración de derechos que incluya información de licencias así como también otra información que suplementa la licencia, como atribución. La información sobre las licencias y derechos DEBERÍA proveerse a nivel de la Distribución. La información sobre licencias y derechos PUEDE proveerse también para un conjunto de datos pero no en lugar de la información provista para las Distribuciones del conjunto de datos. Se DEBERÍA evitar brindar información sobre licencias y derechos de un conjunto de datos que difiere de aquella de la Distribución del conjunto de datos ya que se crean conflictos legales. Ver también la sección 'License and rights statements' para más información.</skos:scopeNote>
+    <skos:definition xml:lang="en">In the context of DCAT 2.0 dcat:Resource, a statement that concerns all rights not addressed with dct:license or dct:accessRights, such as copyright statements.</skos:definition>
+    <skos:scopeNote xml:lang="en">In the context of DCAT 2.0 dcat:Distribution, dct:license, which is a sub-property of dct:rights, can be used to link a distribution to a license document. However, dct:rights allows linking to a rights statement that can include licensing information as well as other information that supplements the license such as attribution. Information about licenses and rights SHOULD be provided on the level of Distribution. Information about licenses and rights MAY be provided for a Dataset in addition to but not instead of the information provided for the Distributions of that Dataset. Providing license or rights information for a Dataset that is different from information provided for a Distribution of that Dataset SHOULD be avoided as this can create legal conflicts. See also guidance in the secion on 'License and rights statements'.</skos:scopeNote>
+    <skos:definition xml:lang="en">In the context of DCAT 2.0 dcat:Distribution, information about rights held in and over the distribution.</skos:definition>
+    <skos:definition xml:lang="cs">V kontextu DCAT 2.0 dcat:Resource, dokument zabývající se všemi právy, které nejsou ošetřeny v dct:license či dct:rights, jako je například copyright.</skos:definition>
+    <skos:scopeNote xml:lang="cs">V kontextu DCAT 2.0, pro Zdroj MŮŽE BÝT uvedena informace o podmínkách užití (licencích a právech). Viz návod v sekci 'License and rights statements'.</skos:scopeNote>
+    <skos:definition xml:lang="it">Nel contesto di DCAT 2.0 dcat:Resource, una dichiarazione che riguarda tutti i diritti non trattati con dct:license o dct:accessRights, come le dichiarazioni di copyright.</skos:definition>
+    <skos:definition xml:lang="en">Information about rights held in and over the resource.</skos:definition>
+    <skos:definition xml:lang="it">Nel contesto di DCAT 2.0 dcat:Distribution, informazioni sui diritti relativi alla distribuzione.</skos:definition>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.org/dc/terms/conformsTo">
+    <skos:scopeNote xml:lang="it">Nel contesto di DCAT 2.0 dcat:Distribution, questa proprietà DEVE essere usata per indicare il modello, lo schema, l'ontologia, la vista o il profilo a cui questa rappresentazione di un dataset è conforme. Questa è (generalmente) una questione complementare al tipo di supporto o formato.</skos:scopeNote>
+    <skos:changeNote xml:lang="en">Property added in this context in DCAT 2.0.</skos:changeNote>
+    <skos:definition xml:lang="en">In the context of DCAT 2.0 dcat:Distribution, an established standard to which the distribution conforms.</skos:definition>
+    <skos:changeNote xml:lang="it">Proprietà aggiunta in questo contesto in DCAT 2.0.</skos:changeNote>
+    <skos:definition xml:lang="it">Nel contesto di DCAT 2.0 dcat:Distribution, uno standard consolidato a cui la distribuzione è conforme.</skos:definition>
+    <skos:scopeNote xml:lang="en">In the context of DCAT 2.0 dcat:Distribution, this property SHOULD be used to indicate the model, schema, ontology, view or profile that this representation of a dataset conforms to. This is (generally) a complementary concern to the media-type or format.</skos:scopeNote>
+    <skos:scopeNote xml:lang="es">En el contexto de DCAT 2.0 dcat:Distribution, esta propiedad DEBERÍA usarse para indicar el modelo, esquema, ontología, vista or perfil al que se ajusta esta representación del conjunto de datos. Este es (generalmente) un asunto complementario al de 'media type' o formato.</skos:scopeNote>
+    <skos:changeNote xml:lang="es">Esta propiedad fue agregada en DCAT 2.0.</skos:changeNote>
+    <skos:scopeNote xml:lang="cs">V kontextu DCAT 2.0 dcat:Resource, tato vlastnost BY MĚLA být použita k udání modelu, schématu, ontologie, pohledu nebo profilu, kterému katalogizovaný zdroj odpovídá.</skos:scopeNote>
+    <skos:scopeNote xml:lang="it">Nel contesto di DCAT 2.0 dcat:Resource, questa proprietà DEVE essere utilizzata per indicare il modello, lo schema, l'ontologia, la vista o il profilo a cui il contenuto della risorsa catalogata è conforme.</skos:scopeNote>
+    <skos:definition xml:lang="es">En el contexto de DCAT 2.0 dcat:Distribution, un estándar establecido al cuál se ajusta la distribución.</skos:definition>
+    <skos:scopeNote xml:lang="es">En el contexto de DCAT 2.0 dcat:Resource, esta propiedad DEBERÍA usarse para indicar el modelo, esquema, ontología, vista or perfil al que se ajusta el recurso catalogado.</skos:scopeNote>
+    <skos:definition xml:lang="en">An established standard to which the described resource conforms.</skos:definition>
+    <skos:changeNote xml:lang="cs">Vlastnost v tomto kontextu byla přidána ve verzi DCAT 2.0.</skos:changeNote>
+    <skos:scopeNote xml:lang="en">In the context of DCAT 2.0 dcat:Resource, this property SHOULD be used to indicate the model, schema, ontology, view or profile that the cataloged resource content conforms to.</skos:scopeNote>
+    <skos:definition xml:lang="cs">V kontextu DCAT 2.0 dcat:Distribution, uznávaný standard, kterým se popisovaný zdroj řídí.</skos:definition>
+    <skos:scopeNote xml:lang="cs">V kontextu DCAT 2.0 dcat:Distribution, tato vlastnost BY MĚLA být použita k udání modelu, schématu, ontologie, pohledu nebo profilu, kterému tato reprezentace datové sady odpovídá. Toto (obvykle) doplňuje typ média či formát.</skos:scopeNote>
+    <skos:definition xml:lang="es">Un estándar establecido al cuál se ajusta el recurso descripto.</skos:definition>
+    <skos:definition xml:lang="it">Uno standard stabilito al quale la risorsa descritta è conforme.</skos:definition>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://www.w3.org/2006/time#hasBeginning">
+    <skos:scopeNote xml:lang="es">En el contexto de DCAT 2.0, el uso de la propiedad time:hasBeginning implica que el valor de la propiedad dct:temporal es un miembro de la clase time:TemporalEntity de [OWL-TIME]. En este contexto, esto puede interpretarse como que implica que dct:PeriodOfTime es equivalente a la subclase time:ProperInterval.</skos:scopeNote>
+    <skos:scopeNote xml:lang="en">In the context of DCAT 2.0, use of the property time:hasBeginning entails that value of the dct:temporal property is a member of the time:TemporalEntity class from [OWL-TIME]. In this context this could be taken to imply that dct:PeriodOfTime is equivalent to the subclass time:ProperInterval.</skos:scopeNote>
+    <skos:definition xml:lang="it">Inizio di un'entità temporale.</skos:definition>
+    <skos:definition xml:lang="en">In the context of DCAT 2.0, beginning of a period or interval.</skos:definition>
+    <skos:scopeNote xml:lang="cs">V kontextu DCAT 2.0, použití vlastnosti time:hasBeginning znamená, že hodnota vlastnosti dct:temporal je instancí třídy time:TemporalEntity ze slovníku [OWL-TIME]. V tomto kontextu to může znamenat, že dct:PeriodOfTime je ekvivalentní podtřídě time:ProperInterval</skos:scopeNote>
+    <skos:definition xml:lang="en">Beginning of a temporal entity.</skos:definition>
+    <skos:changeNote xml:lang="it">Proprietà aggiunte in questo contesto in DCAT 2.0.</skos:changeNote>
+    <skos:scopeNote xml:lang="it">Nel contesto di DCAT 2.0, l'uso della proprietà time:hasBeginning comporta che il valore della proprietà dct:temporal  è un membro della classe time:TemporalEntity di [OWL-TIME]. In questo contesto ciò potrebbe essere interpretato nel senso che dct:PeriodOfTime è equivalente alla sottoclasse time:ProperInterval.</skos:scopeNote>
+    <skos:changeNote xml:lang="cs">Vlastnost v tomto kontextu byla přidána ve verzi DCAT 2.0.</skos:changeNote>
+    <skos:changeNote xml:lang="es">Esta propiedad fue agregada en DCAT 2.0.</skos:changeNote>
+    <skos:changeNote xml:lang="en">Property added in this context in DCAT 2.0.</skos:changeNote>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://www.w3.org/ns/prov#qualifiedAttribution">
+    <skos:scopeNote xml:lang="it">Nel contesto di DCAT 2.0, utilizzato per collegarsi a un agente in cui la natura della relazione è nota ma non corrisponde a una delle proprietà Dublin Core standard (dct: creatore, dct: editore). Si usi dcat:hadRole su prov:Attribution per rappresentare la responsabilità dell'Agente in relazione alla Risorsa. Si veda https://w3c.github.io/dxwg/dcat/#qualified-attribution per gli esempi di utilizzo.</skos:scopeNote>
+    <skos:changeNote xml:lang="cs">Vlastnost v tomto kontextu byla přidána ve verzi DCAT 2.0.</skos:changeNote>
+    <skos:definition xml:lang="it">Nel contesto di DCAT 2.0, collegamento a un agente che ha una qualche forma di responsabilità per la risorsa.</skos:definition>
+    <skos:changeNote xml:lang="es">Esta propiedad fue agregada en DCAT 2.0.</skos:changeNote>
+    <skos:definition xml:lang="en">In the context of DCAT 2.0, link to an Agent having some form of responsibility for the resource.</skos:definition>
+    <skos:changeNote xml:lang="it">Proprietà aggiunta in questo contesto in DCAT 2.0.</skos:changeNote>
+    <skos:definition xml:lang="cs">V kontextu DCAT 2.0, odkaz na Agenta, který má nějaký typ odpovědnosti za zdroj.</skos:definition>
+    <skos:scopeNote xml:lang="en">In the context of DCAT 2.0, used to link to an Agent where the nature of the relationship is known but does not match one of the standard Dublin Core properties (dct:creator, dct:publisher). Use dcat:hadRole on the prov:Attribution to capture the responsibility of the Agent with respect to the Resource. See https://w3c.github.io/dxwg/dcat/#qualified-attribution for usage examples.</skos:scopeNote>
+    <skos:changeNote xml:lang="en">Property added in this context in DCAT 2.0.</skos:changeNote>
+    <skos:scopeNote xml:lang="es">En el contexto de DCAT 2.0, se usa para asociar un Agente cuando la naturaleza de la relación es conocida pero no es ninguna de las asociaciones estándares descriptas con propiedades de Dublin Core (dct:creator, dct:publisher). Se usa dcat:hadRole en la prov:Attribution para capturar la responsabilidad del Agente con respecto al Recurso. Ver https://w3c.github.io/dxwg/dcat/#qualified-attribution para más ejemplos de uso.</skos:scopeNote>
+    <skos:definition xml:lang="es">En el contexto de DCAT 2.0, enlace a un Agente que tiene alguna forma de responsabilidad con el recurso.</skos:definition>
+    <skos:scopeNote xml:lang="cs">V kontextu DCAT 2.0, vlastnost se používá pro odkaz na Agenta tam, kde typ vztahu je znám, ale neodpovídá žádné ze standardních vlastností Dublin Core (dct:creator, dct:publisher). Pro reprezentaci vztahu Agenta ke zdroji použijte vlastnost dcat:hadRole na třídě prov:Attribution. Viz  https://w3c.github.io/dxwg/dcat/#qualified-attribution pro příklady užití.</skos:scopeNote>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.org/dc/terms/accrualPeriodicity">
+    <skos:definition xml:lang="it">Nel contesto del DCAT 2.0, la frequenza di pubblicazione dell'insieme di dati.</skos:definition>
+    <skos:definition xml:lang="it">La frequenza con cui gli elementi vengono aggiunti a una collezione.</skos:definition>
+    <skos:definition xml:lang="es">En el contexto de DCAT 2.0, la frecuencia con que se publica el conjunto de datos.</skos:definition>
+    <skos:scopeNote xml:lang="it">Nel contesto di DCAT 2.0, il valore di dct:accrualPeriodicity indica il tasso di aggiornamento del dataset nella sua interezza. Questo può essere completato da dcat:temporalResolution per dare il tempo tra i punti di dati raccolti in una serie temporale.</skos:scopeNote>
+    <skos:definition xml:lang="en">The frequency with which items are added to a collection.</skos:definition>
+    <skos:scopeNote xml:lang="es">En el contexto de DCAT 2.0, el valor de dct:accrualPeriodicity da la tasa de actualización del conjunto de datos como entidad. Esto puede complementarse con dcat:temporalResolution para dar el tiempo entre los puntos en que se recopilan los datos en una serie temporal.</skos:scopeNote>
+    <skos:scopeNote xml:lang="en">In the context of DCAT 2.0, the value of dct:accrualPeriodicity gives the rate at which the dataset-as-a-whole is updated. This may be complemented by dcat:temporalResolution to give the time between collected data points in a time series.</skos:scopeNote>
+    <skos:scopeNote xml:lang="cs">V kontextu DCAT 2.0, hodnota dct:accrualPeriodicity udává frekvenci, se kterou se aktualizuje datová sada jako celek. Toto může být doplněno vlastností dcat:temporalResolution pro udání času mezi jednotlivými body v časové řadě.</skos:scopeNote>
+    <skos:definition xml:lang="en">In the context of DCAT 2.0, the frequency at which dataset is published.</skos:definition>
+    <skos:definition xml:lang="cs">V kontextu DCAT 2.0, frekvence publikace datové sady.</skos:definition>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://www.w3.org/ns/odrl/2/hasPolicy">
+    <skos:definition xml:lang="en">In the context of DCAT 2.0 dcat:Resource, an ODRL conformant policy expressing the rights associated with the resource.</skos:definition>
+    <skos:definition xml:lang="es">En el contexto de DCAT 2.0 dcat:Resource, una reglamentación conforme a ODRL expresando los derechos asociados con el recurso [ODRL-VOCAB].</skos:definition>
+    <skos:definition xml:lang="en">In the context of DCAT 2.0 dcat:Distribution, an ODRL conformant policy expressing the rights associated with the distribution.</skos:definition>
+    <skos:definition xml:lang="en">Identifies an ODRL Policy for which the identified Asset is the target Asset to all the Rules.</skos:definition>
+    <skos:definition xml:lang="cs">V kontextu DCAT 2.0 dcat:Distribution, pravidlo vyjadřující práva spojená s distribucí, pokud je použit slovník ODRL [ODRL-VOCAB].</skos:definition>
+    <skos:definition xml:lang="it">Nel contesto di DCAT 2.0 dcat:Distribution, una policy conforme all'ODRL che esprime i diritti associati alla distribuzione.</skos:definition>
+    <skos:definition xml:lang="es">En el contexto de DCAT 2.0 dcat:Distribution, una reglamentación conforme a ODRL expresando los derechos asociados con la distribución [ODRL-VOCAB].</skos:definition>
+    <skos:scopeNote xml:lang="cs">V kontextu DCAT 2.0 dcat:Resource, pro zdroj MŮŽE BÝT uvedena informace o právech vyjádřená pomocí pravidel slovníku ODRL [ODRL-VOCAB]. Viz také návod v sekci 'License and rights statements'.</skos:scopeNote>
+    <skos:scopeNote xml:lang="en">In the context of DCAT 2.0 dcat:Distribution, information about rights expressed as an ODRL policy [ODRL-MODEL] using the ODRL vocabulary [ODRL-VOCAB] MAY be provided for the distribution. See also guidance at the section 'License and rights statements'.</skos:scopeNote>
+    <skos:scopeNote xml:lang="es">En el contexto de DCAT 2.0 dcat:Distribution, información sobre los derechos expresados como reglamentación ODRL [ODRL-MODEL] using the ODRL vocabulary [ODRL-VOCAB] PUEDE proveerse para el Distribución. Ver también la información en la sección 'License and rights statements.'</skos:scopeNote>
+    <skos:definition xml:lang="it">Nel contesto di DCAT 2.0 dcat:Resource, una policy conforme all'ODRL che esprime i diritti associati alla risorsa.</skos:definition>
+    <skos:scopeNote xml:lang="en">In the context of DCAT 2.0 dcat:Resource, information about rights expressed as an ODRL policy [ODRL-MODEL] using the ODRL vocabulary [ODRL-VOCAB] MAY be provided for the resource. See also guidance at the section 'License and rights statements'.</skos:scopeNote>
+    <skos:definition xml:lang="cs">V kontextu DCAT 2.0 dcat:Resource, pravidlo vyjadřující práva spojená se zdrojem, pokud je použit slovník ODRL [ODRL-VOCAB].</skos:definition>
+    <skos:scopeNote xml:lang="it">Nel contesto DCAT 2.0 dcat:Resource, le informazioni sui diritti espressi come policy ODRL [ODRL-MODEL] utilizzando il vocabolario ODRL [ODRL-VOCAB] POSSONO essere fornite per la risorsa. Si veda anche la guida alla sezione 'Licenza e dichiarazioni sui diritti'.</skos:scopeNote>
+    <skos:scopeNote xml:lang="es">En el contexto de DCAT 2.0 dcat:Resource, información sobre los derechos expresados como reglamentación ODRL [ODRL-MODEL] usando el vocabulario ODRL [ODRL-VOCAB] PUEDE proveerse para el Recurso. Ver también la información en la sección 'License and rights statements'.</skos:scopeNote>
+    <skos:scopeNote xml:lang="it">Nel contesto di DCAT 2.0 dcat:Distribution, le informazioni sui diritti espressi come policy ODRL [ODRL-MODEL] utilizzando il vocabolario ODRL [ODRL-VOCAB] POSSONO essere fornite per la distribuzione. Si veda anche la guida alla sezione 'Licenza e dichiarazioni sui diritti'.</skos:scopeNote>
+    <skos:editorialNote xml:lang="en">Czech translation to be updated.</skos:editorialNote>
+    <skos:scopeNote xml:lang="cs">V kontextu DCAT 2.0 dcat:Distribution, pro distribuci MŮŽE BÝT uvedena informace o právech vyjádřená pomocí pravidel slovníku ODRL [ODRL-VOCAB]. Viz také návod v sekci 10. 'License and rights statements'.</skos:scopeNote>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.org/dc/terms/spatial">
+    <skos:definition xml:lang="en">In the context of DCAT 2.0 dcat:Dataset, the geographical area covered by the dataset.</skos:definition>
+    <skos:definition xml:lang="es">En el contexto de DCAT 2.0 dcat:Dataset, el área geográfica cubierta por el conjunto de datos.</skos:definition>
+    <skos:scopeNote xml:lang="es">En el contexto de DCAT 2.0 dcat:Dataset, la cobertura espacial de un conjunto de datos puede codificarse como una instancia de dct:Location, o puede indicarse usando una referencia URI (es decir, un enlace) a un recurso que describa la posición. Se recomienda que los enlaces sean a entradas en un diccionario geográfico bien mantenido como Geonames.</skos:scopeNote>
+    <skos:definition xml:lang="en">Spatial characteristics of the resource.</skos:definition>
+    <skos:definition xml:lang="it">Caratteristiche spaziali della risorsa.</skos:definition>
+    <skos:definition xml:lang="it">Nel contesto di DCAT 2.0 dcat:Dataset, l'area geografica coperta dal set di dati.</skos:definition>
+    <skos:scopeNote xml:lang="cs">V kontextu DCAT 2.0 dcat:Dataset, územní pokrytí datové sady může být zaznamenáno jako instance dct:Location, nebo může být indikováno jako IRI odkazující na zdroj popisující území. Je doporučeno se odkazovat na udržovaný zdroj dat jako například Geonames.</skos:scopeNote>
+    <skos:definition xml:lang="cs">V kontextu DCAT 2.0 dcat:Dataset, geografické území pokryté datovou sadou.</skos:definition>
+    <skos:scopeNote xml:lang="it">Nel contesto di DCAT 2.0 dcat:Dataset, la copertura spaziale di un set di dati può essere codificata come istanza di dct:Location, o può essere indicata utilizzando un riferimento URI (link) a una risorsa che descrive una locazione. Si raccomanda che i collegamenti siano a delle voci in un gazetteer ben mantenuto come Geonames.</skos:scopeNote>
+    <skos:scopeNote xml:lang="en">In the context of DCAT 2.0 dcat:Dataset, the spatial coverage of a dataset may be encoded as an instance of dct:Location, or may be indicated using a URI reference (link) to a resource describing a location. It is recommended that links are to entries in a well maintained gazetteer such as Geonames.</skos:scopeNote>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://www.w3.org/ns/prov#wasAttributedTo">
+    <rdfs:subPropertyOf rdf:resource="http://purl.org/dc/terms/relation"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://www.w3.org/ns/prov#wasGeneratedBy">
+    <skos:definition xml:lang="en">In the context of DCAT 2.0 dcat:Dataset, an activity that generated, or provides the business context for, the creation of the dataset.</skos:definition>
+    <rdfs:subPropertyOf rdf:resource="http://purl.org/dc/terms/relation"/>
+    <skos:scopeNote xml:lang="es">En el contexto de DCAT 2.0 dcat:Dataset, utiliza prov:qualifiedGeneration para adjuntar detalles adicionales sobre la relación entre el conjunto de datos y la actividad activity, por ejemplo, el tiempo exacto en el que se produjo el conjunto de datose durante la vida de un proyecto.</skos:scopeNote>
+    <skos:scopeNote xml:lang="it">Nel contesto di DCAT 2.0 dcat:Dataset, utilizzare prov:qualifiedGeneration per allegare ulteriori dettagli sulla relazione tra il dataset e l'attività, ad esempio l'ora esatta in cui il dataset è stato prodotto durante la vita di un progetto.</skos:scopeNote>
+    <skos:scopeNote xml:lang="cs">V kontextu DCAT 2.0 dcat:Dataset, aktivitou spojenou s tvorbou datové sady typicky bývá iniciativa, projekt, mise, rešerše, průběžná aktivita (běžný chod podniku) apod. Pro zaznamenání kontextu datové sady na více úrovních granulariy lze použít více hodnot vlastnosti prov:wasGeneratedBy.</skos:scopeNote>
+    <skos:scopeNote xml:lang="es">En el contexto de DCAT 2.0 dcat:Dataset, la actividad asociada con la generación de un conjunto de datos. Típicamente es una iniciativa, proyecto, misión, encuensta, una actividad contínua (la actividad usual) etc. Se pueden usar múltiples propiedades  prov:wasGeneratedBy para indicar el contexto de producción del conjunto de datos en disintos niveles de granularidad.</skos:scopeNote>
+    <skos:changeNote xml:lang="it">Proprietà aggiunta in questo contesto in DCAT 2.0.</skos:changeNote>
+    <skos:scopeNote xml:lang="cs">V kontextu DCAT 2.0 dcat:Dataset, pro připojení podrobností o vztahu mezi datovou sadou a aktivitou, např. přesný čas kdy byla datová sada vyprodukována během životního cyklu projektu, použijte prov:qualifiedGeneration.</skos:scopeNote>
+    <skos:changeNote xml:lang="es">Esta propiedad fue agregada en DCAT 2.0.</skos:changeNote>
+    <skos:scopeNote xml:lang="en">In the context of DCAT 2.0 dcat:Dataset, the activity associated with generation of a dataset will typically be an initiative, project, mission, survey, on-going activity ('business as usual') etc. Multiple prov:wasGeneratedBy properties can be used to indicate the dataset production context at various levels of granularity.</skos:scopeNote>
+    <skos:scopeNote xml:lang="it">Nel contesto di DCAT 2.0 dcat:Dataset, l'attività associata alla generazione di un dataset sarà tipicamente un'iniziativa, progetto, missione, indagine, attività in corso ('business as usual'), ecc. Multiple prov:wasGeneratedBy  possono essere utilizzate per indicare il contesto di produzione del dataset a vari livelli di granularità.</skos:scopeNote>
+    <skos:changeNote xml:lang="en">Property added in this context in DCAT 2.0.</skos:changeNote>
+    <skos:changeNote xml:lang="cs">Vlastnost v tomto kontextu byla přidána ve verzi DCAT 2.0</skos:changeNote>
+    <skos:scopeNote xml:lang="en">In the context of DCAT 2.0 dcat:Dataset, use prov:qualifiedGeneration to attach additional details about the relationship between the dataset and the activity, e.g. the exact time that the dataset was produced during the lifetime of a project.</skos:scopeNote>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.org/dc/terms/format">
+    <skos:scopeNote xml:lang="es">En el contexto de DCAT 2.0, dcat:mediaType DEBERÍA usarse si el tipo de distribución se define por IANA [IANA-MEDIA-TYPES].</skos:scopeNote>
+    <skos:definition xml:lang="es">En el contexto de DCAT 2.0, el formato del archivo de la distribución.</skos:definition>
+    <skos:scopeNote xml:lang="en">In the context of DCAT 2.0, dcat:mediaType SHOULD be used if the type of the distribution is defined by IANA [IANA-MEDIA-TYPES].</skos:scopeNote>
+    <skos:definition xml:lang="en">The file format, physical medium, or dimensions of the resource.</skos:definition>
+    <skos:scopeNote xml:lang="it">Nel contesto di DCAT 2.0, dcat:mediaType DEVE essere usato se il tipo di distribuzione è definito da IANA [IANA-MEDIA-TYPES].</skos:scopeNote>
+    <skos:definition xml:lang="cs">V kontextu DCAT 2.0, formát souboru distribuce.</skos:definition>
+    <skos:scopeNote xml:lang="cs">V kontextu DCAT 2.0, pokud je typ distribuce definován IANA [IANA-MEDIA-TYPES], MĚLA BY být použita vlastnost dcat:mediaType.</skos:scopeNote>
+    <skos:definition xml:lang="it">Il formato del file, il supporto fisico o le dimensioni della risorsa.</skos:definition>
+    <skos:definition xml:lang="it">Nel contesto di DCAT 2.0, il formato di file della distribuzione.</skos:definition>
+    <skos:definition xml:lang="en">In the context of DCAT 2.0, the file format of the distribution.</skos:definition>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.org/dc/terms/Location">
+    <skos:scopeNote xml:lang="en">In the context of DCAT 2.0, for the geographic center of a spatial area, or another characteristic point, the property dcat:centroid SHOULD be used.</skos:scopeNote>
+    <skos:scopeNote xml:lang="en">In the context of DCAT 2.0, for an extensive geometry (i.e., a set of coordinates denoting the vertices of the relevant geographic area), the property locn:geometry [[LOCN]] SHOULD be used.</skos:scopeNote>
+    <skos:definition xml:lang="en">A spatial region or named place.</skos:definition>
+    <skos:definition xml:lang="es">Una región espacial o un lugar con nombre.</skos:definition>
+    <skos:changeNote xml:lang="es">Esta clase se agregó en este contexto en DCAT 2.0.</skos:changeNote>
+    <skos:scopeNote xml:lang="es">En el contexto de DCAT 2.0, para el centro geográfico de un área espacial, o algún otro punto característico, se DEBE usar la propriedad dcat:centroid.</skos:scopeNote>
+    <skos:changeNote xml:lang="en">Class added in this context in DCAT 2.0.</skos:changeNote>
+    <skos:scopeNote xml:lang="es">En el contexto de DCAT 2.0, para un cuadro delimitador geográfico que delimita un área espacial se DEBE usar la propiedad dcat:bbox.</skos:scopeNote>
+    <skos:scopeNote xml:lang="cs">En el contexto de DCAT 2.0, pro geografický rámec ohraničující prostorové oblasti BY MĚLA být použita vlastnost dcat:bbox.</skos:scopeNote>
+    <skos:changeNote xml:lang="cs">Třída v tomto kontextu byla přidána ve verzi DCAT 2.0.</skos:changeNote>
+    <skos:scopeNote xml:lang="es">En el contexto de DCAT 2.0, para una geometría extensiva (es decir, un conjunto de coordinadas que denotan los vértices de un área geográfica), DEBE usarse la propiedad locn:geometry [[LOCN]].</skos:scopeNote>
+    <skos:scopeNote xml:lang="it">Nel contesto del DCAT 2.0, per una geometria estesa (cioè, un insieme di coordinate che indicano i vertici dell'area geografica rilevante), si DOVREBBE usare la  proprietà locn:geometry [[LOCN]].</skos:scopeNote>
+    <skos:scopeNote xml:lang="it">Nel contesto di DCAT 2.0, per un rettangolo di delimitazione geografica che delimita un'area territoriale si DOVREBBE utilizzare la proprietà dcat:bbox.</skos:scopeNote>
+    <skos:scopeNote xml:lang="it">Nel contesto di DCAT 2.0, per il centro geografico di un'area spaziale, o di un altro punto caratteristico, si DOVREBBE utilizzare la proprietà dcat:centroid.</skos:scopeNote>
+    <skos:definition xml:lang="cs">Prostorová oblast či pojmenované místo.</skos:definition>
+    <skos:scopeNote xml:lang="en">In the context of DCAT 2.0, for a geographic bounding box delimiting a spatial area the property dcat:bbox SHOULD be used.</skos:scopeNote>
+    <skos:scopeNote xml:lang="cs">En el contexto de DCAT 2.0, pro geografický střed prostorové oblasti či jiný charakteristický bod BY MĚLA být použita vlastnost dcat:centroid.</skos:scopeNote>
+    <skos:scopeNote xml:lang="cs">En el contexto de DCAT 2.0, pro rozsáhlé geometrie (tj. sady souřadnic určujících relevantní geografickou oblast) BY MĚLA být použita vlastnost locn:geometry [[LOCN]].</skos:scopeNote>
+    <skos:definition xml:lang="it">Una regione spaziale o un luogo designato.</skos:definition>
+    <skos:changeNote xml:lang="it">Classe aggiunta in questo contesto in DCAT 2.0.</skos:changeNote>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.org/dc/terms/description">
+    <skos:definition xml:lang="cs">V kontextu DCAT 2.0, popis položky pomocí volného textu.</skos:definition>
+    <skos:definition xml:lang="it">Un resoconto della risorsa.</skos:definition>
+    <skos:definition xml:lang="it">Nel contesto del DCAT 2.0, un resoconto a testo libero dell’ elemento.</skos:definition>
+    <skos:definition xml:lang="en">In the context of DCAT 2.0, a free-text account of the item.</skos:definition>
+    <skos:definition xml:lang="es">En el contexto de DCAT 2.0, una explicación en texto sobre el ítem.</skos:definition>
+    <skos:definition xml:lang="en">An account of the resource.</skos:definition>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.org/dc/terms/isReferencedBy">
+    <skos:scopeNote xml:lang="en">In the context of DCAT 2.0, in relation to the use case of data citation, when the catalogued resource is a dataset, the dct:isReferencedBy property allows to relate the dataset to the resources (such as scholarly publications) that cite or point to the dataset. Multiple dct:isReferencedBy properties can be used to indicate the dataset has been referenced by multiple publications, or other resources.</skos:scopeNote>
+    <skos:changeNote xml:lang="es">En el contexto de DCAT 2.0, esta propiedad fue agregada en DCAT 2.0.</skos:changeNote>
+    <skos:changeNote xml:lang="en">Property added in this context in DCAT 2.0.</skos:changeNote>
+    <skos:scopeNote xml:lang="en">In the context of DCAT 2.0, this property is used to associate a resource to the catalogued resource (of type dcat:Resource) in question. For other relations to resources not covered with this property, the more generic property dcat:qualifiedRelation can be used. See also the section about § 9. Qualified relations.</skos:scopeNote>
+    <skos:definition xml:lang="en">In the context of DCAT 2.0, a related resource, such as a publication, that references, cites, or otherwise points to the catalogued resource.</skos:definition>
+    <skos:scopeNote xml:lang="cs">V kontextu DCAT 2.0,tato vlastnost je použita k přiřazení zdroje ke katalogizovanému zdroji (typu dcat:Resource). Pro jiné typy vztahů ke zdrojům, které nejsou touto vlastností pokryty, může být použita obecnější vlastnost dcat:qualifiedRelation. Viz také sekce 9. 'Qualified relations'.</skos:scopeNote>
+    <skos:definition xml:lang="es">En el contexto de DCAT 2.0, un recurso relacionado, como por ejemplo una publicación, que referencia, cita, o apunta al recurso del catálogo.</skos:definition>
+    <skos:scopeNote xml:lang="es">En el contexto de DCAT 2.0, esta propiedad se usa para asociar un recurso a un elemento del catálogo  (de tipo dcat:Resource). Para representar otro tipo de associaciones a recursos, se puede utilizar la propiedad más genérica dcat:qualifiedRelation. Para más detalle, ver la sección en relaciones calificadas de la especificación.</skos:scopeNote>
+    <skos:definition xml:lang="it">Una risorsa correlata che fa riferimento, cita o indica in altro modo la risorsa descritta.</skos:definition>
+    <skos:changeNote xml:lang="cs">Vlastnost byla v tomto kontextu přidána ve verzi DCAT 2.0</skos:changeNote>
+    <skos:definition xml:lang="en">A related resource that references, cites, or otherwise points to the described resource.</skos:definition>
+    <skos:changeNote xml:lang="it">Proprietà aggiunte in questo contesto in DCAT 2.0.</skos:changeNote>
+    <skos:definition xml:lang="cs">V kontextu DCAT 2.0, související zdroj, např. publikace, který se odkazuje, cituje nebo jinak ukazuje na katalogizovaný zdroj.</skos:definition>
+    <skos:scopeNote xml:lang="it">Nel contesto di DCAT 2.0, in relazione al caso d'uso della citazione dei dati, quando la risorsa catalogata è un dataset, la proprietà dct:isReferencedBy permette di mettere in relazione il dataset con le risorse (come le pubblicazioni scientifiche) che citano o puntano al dataset. Molteplici proprietà dct:isReferencedBy possono essere utilizzate per indicare che il dataset è stato referenziato da più pubblicazioni, o altre risorse.</skos:scopeNote>
+    <skos:scopeNote xml:lang="it">Nel contesto di DCAT 2.0, questa proprietà viene utilizzata per associare una risorsa alla risorsa catalogata (di tipo dcat:Resource) in questione. Per le altre relazioni con risorse non coperte da questa proprietà, si può utilizzare la proprietà più generica dcat:qualifiedRelation. Si veda anche la sezione relativa al § 9. Relazioni qualificate.</skos:scopeNote>
+    <skos:scopeNote xml:lang="es">En el contexto de DCAT 2.0, en relación al caso de uso sobre cita de datos, cuando el recurso catalogado es un conjunto de datos, la propiedad dct:isReferencedBy permite relacionar el conjunto de datos a publicaciones que citan o apuntan al conjunto de datos. Se pueden utilizar múltiples propiedades dct:isReferencedBy para indicar que el conjunto de datos se ha referenciado en múltiples publicaciones u otros recursos.</skos:scopeNote>
+    <skos:scopeNote xml:lang="cs">V kontextu DCAT 2.0, ohledně případu užití vztahujícího se k citaci dat, pokud je katalogizovaný zdroj datovou sadou, vlastnost dct:isReferencedBy umožňuje vztáhnout tuto datovou sadu ke zdroji (např. odborné publikaci) která ji cituje nebo na ni odkazuje. dct:isReferencedBy lze užít vícenásobně pro zaznamenání faktu, že datová sada byla odkazována z více publikací nebo jiných zdrojů.</skos:scopeNote>
+    <skos:definition xml:lang="it">Nel contesto del DCAT 2.0, una risorsa correlata, come una pubblicazione, che rimanda, cita o indica in altro modo la risorsa catalogata.</skos:definition>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.org/dc/terms/issued">
+    <skos:scopeNote xml:lang="cs">V kontextu DCAT 2.0, tato vlastnost BY MĚLA obsahovat první známé datum vydání.</skos:scopeNote>
+    <skos:definition xml:lang="cs">V kontextu DCAT 2.0 dcat:Resource, datum formálního vydání položky.</skos:definition>
+    <skos:definition xml:lang="es">En el contexto de DCAT 2.0 dcat:Distribution, fecha de emisión formal (es decir, publicación) de la distribución.</skos:definition>
+    <skos:definition xml:lang="it">Nel contesto del DCAT 2.0 dcat:Distribution, data di emissione formale (ad esempio, pubblicazione) della distribuzione.</skos:definition>
+    <skos:definition xml:lang="en">In the context of DCAT 2.0 dcat:Distribution, date of formal issuance (e.g., publication) of the distribution.</skos:definition>
+    <skos:definition xml:lang="en">In the context of DCAT 2.0 dcat:CatalogRecord, the date of listing (i.e. formal recording) of the corresponding dataset or service in the catalog.</skos:definition>
+    <skos:definition xml:lang="es">En el contexto de DCAT 2.0 dcat:Resource, fecha de emisión formal (es decir, publicación) de un ítem.</skos:definition>
+    <skos:scopeNote xml:lang="es">En el contexto de DCAT 2.0 dcat:CatalogRecord, indica la fecha en que se lista el conjunto de datos en el catálogo, y no la fecha de publicación del propio conjunto de datos.</skos:scopeNote>
+    <skos:definition xml:lang="it">Nel contesto di DCAT 2.0 dcat:CatalogRecord, la data di inserimento (cioè la registrazione formale) del corrispondente set di dati o servizio nel catalogo.</skos:definition>
+    <skos:definition xml:lang="es">En el contexto de DCAT 2.0 dcat:CatalogRecord, la fecha en que lista (es decir, se registra formalmente) el conjunto de datos o servicio correspondiente en el catálogo.</skos:definition>
+    <skos:definition xml:lang="cs">V kontextu DCAT 2.0 dcat:CatalogRecord, datum zanesení datové sady nebo služby do katalogu.</skos:definition>
+    <skos:scopeNote xml:lang="it">Nel contesto di DCAT 2.0, questa proprietà DOVREBBE essere impostata utilizzando la prima data nota di emissione.</skos:scopeNote>
+    <skos:definition xml:lang="en">Date of formal issuance (e.g., publication) of the resource.</skos:definition>
+    <skos:scopeNote xml:lang="es">En el contexto de DCAT 2.0, esta propiedad DEBERÍA incluir como valor la primer fecha de emisión.</skos:scopeNote>
+    <skos:definition xml:lang="it">Nel contesto del DCAT 2.0 dcat:Resource, data di emissione formale (es. pubblicazione) di questo elemento.</skos:definition>
+    <skos:definition xml:lang="it">Data di emissione formale (ad esempio, pubblicazione) della risorsa.</skos:definition>
+    <skos:scopeNote xml:lang="en">In the context of DCAT 2.0 dcat:CatalogRecord, this indicates the date of listing the dataset in the catalog and not the publication date of the dataset itself.</skos:scopeNote>
+    <skos:scopeNote xml:lang="cs">V kontextu DCAT 2.0 dcat:CatalogRecord, tato vlastnost indikuje datum zanesení datové sady do katalogu a ne datum vydání datové sady samotné.</skos:scopeNote>
+    <skos:scopeNote xml:lang="en">In the context of DCAT 2.0, this property SHOULD be set using the first known date of issuance.</skos:scopeNote>
+    <skos:definition xml:lang="en">In the context of DCAT 2.0 dcat:Resource, date of formal issuance (e.g., publication) of the item.</skos:definition>
+    <skos:definition xml:lang="cs">V kontextu DCAT 2.0 dcat:Distribution, datum formálního vydání distribuce.</skos:definition>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.org/dc/terms/PeriodOfTime">
+    <skos:scopeNote xml:lang="en">In the context of DCAT 2.0, the start and end of the interval may be given by using properties dcat:startDate or time:hasBeginning, and dcat:endDate or time:hasEnd, respectively. The interval can also be open - i.e., it can have just a start or just an end.</skos:scopeNote>
+    <skos:definition xml:lang="en">An interval of time that is named or defined by its start and end dates.</skos:definition>
+    <skos:definition xml:lang="it">Nel contesto di DCAT 2.0, un intervallo di tempo che viene chiamato o definito dal suo inizio e fine.</skos:definition>
+    <skos:changeNote xml:lang="en">Class added in this context in DCAT 2.0.</skos:changeNote>
+    <skos:changeNote xml:lang="es">Esta clase se agregó en este contexto en DCAT 2.0.</skos:changeNote>
+    <skos:definition xml:lang="es">En el contexto de DCAT 2.0, un interválo de tiempo que se nombra o define por su principio y fin.</skos:definition>
+    <skos:definition xml:lang="cs">En el contexto de DCAT 2.0, časový interval který je pojmenovaný, nebo určený svým začátkem a koncem.</skos:definition>
+    <skos:changeNote xml:lang="it">Classe aggiunta in questo contesto in DCAT 2.0.</skos:changeNote>
+    <skos:definition xml:lang="en">In the context of DCAT 2.0, an interval of time that is named or defined by its start and end.</skos:definition>
+    <skos:scopeNote xml:lang="it">Nel contesto di DCAT 2.0, l'inizio e la fine dell'intervallo possono essere dati rispettivamente utilizzando le proprietà dcat:startDate o time:hasBeginning, e dcat:endDate o time:hasEnd. L'intervallo può anche essere aperto, cioè può avere solo un inizio o solo una fine.</skos:scopeNote>
+    <skos:scopeNote xml:lang="cs">En el contexto de DCAT 2.0, začátek a konec intervalu může být dán vlastnostmi dcat:startDate či time:hasBeginning a dcat:endDate či time:hasEnd. Interval také může být otevřený, tj. může mít pouze začátek či pouze konec.</skos:scopeNote>
+    <skos:changeNote xml:lang="cs">Třída v tomto kontextu byla přidána ve verzi DCAT 2.0.</skos:changeNote>
+    <skos:scopeNote xml:lang="es">En el contexto de DCAT 2.0, el comienzo y fin de un intervalo pueden representarse usando las propiedades dcat:startDate o time:hasBeginning, y dcat:endDate o time:hasEnd, respectivamente. El interválo también puede ser un interválo abierto - es decir, puede tener sólo un comienzo o un fin.</skos:scopeNote>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.org/dc/terms/hasPart">
+    <skos:definition xml:lang="en">In the context of DCAT 2.0 dcat:Catalog, an item that is listed in the catalog.</skos:definition>
+    <skos:scopeNote xml:lang="es">En el contexto de DCAT 2.0, este es el predicado más general para la membresía en un catálogo. Se recomienda usar una sub-propiedad más específica si hay una disponible.</skos:scopeNote>
+    <skos:definition xml:lang="it">Nel contesto di DCAT 2.0 dcat:Catalog, un elemento che è elencato nel catalogo.</skos:definition>
+    <skos:scopeNote xml:lang="cs">V kontextu DCAT 2.0, viz také: Podvlastnosti dct:hasPart; zejména dcat:dataset, dcat:catalog, dcat:service.</skos:scopeNote>
+    <skos:scopeNote xml:lang="es">En el contexto de DCAT 2.0, vea también: sub-propiedades de dct:hasPart; en particular dcat:dataset, dcat:catalog, dcat:service.</skos:scopeNote>
+    <skos:scopeNote xml:lang="it">Nel contesto del DCAT 2.0, vedi anche:  le sottoproprietà di dct:hasPart; in particolare dcat:dataset, dcat:catalog, dcat:service.</skos:scopeNote>
+    <skos:definition xml:lang="it">Una risorsa correlata che è inclusa fisicamente o logicamente nella risorsa descritta.</skos:definition>
+    <skos:scopeNote xml:lang="en">In the context of DCAT 2.0, this is the most general predicate for membership of a catalog. Use of a more specific sub-property is recommended when available.</skos:scopeNote>
+    <skos:scopeNote xml:lang="en">In the context of DCAT 2.0, see also: Sub-properties of dct:hasPart; in particular dcat:dataset, dcat:catalog, dcat:service.</skos:scopeNote>
+    <skos:definition xml:lang="en">A related resource that is included either physically or logically in the described resource.</skos:definition>
+    <skos:scopeNote xml:lang="cs">V kontextu DCAT 2.0, toto je nejobecnější predikát pro příslušnost do katalogu. Pokud je to možné, doporučuje se použít konkrétnější vztah.</skos:scopeNote>
+    <skos:scopeNote xml:lang="it">Nel contesto del DCAT 2.0, questo è il predicato più generale per l'appartenenza ad un catalogo. L'uso di una sottoproprietà più specifica è raccomandato se disponibile.</skos:scopeNote>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://www.w3.org/ns/prov#hadPrimarySource">
+    <rdfs:subPropertyOf rdf:resource="http://purl.org/dc/terms/relation"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.org/dc/terms/license">
+    <skos:definition xml:lang="it">Nell'ambito di DCAT 2.0 dcat:DataService, un documento legale in base al quale il servizio è reso disponibile.</skos:definition>
+    <skos:definition xml:lang="it">Un documento legale che dà il permesso ufficiale di fare qualcosa con la risorsa.</skos:definition>
+    <skos:definition xml:lang="es">En el contexto de DCAT 2.0 dcat:Resource, uh documento legal bajo el cuál se hace disponible el recurso.</skos:definition>
+    <skos:definition xml:lang="cs">V kontextu DCAT 2.0 dcat:Distribution, právní dokument popisující podmínky užití distribuce.</skos:definition>
+    <skos:scopeNote xml:lang="en">In the context of DCAT 2.0, information about licenses and rights SHOULD be provided on the level of Distribution. Information about licenses and rights MAY be provided for a Dataset in addition to but not instead of the information provided for the Distributions of that Dataset. Providing license or rights information for a Dataset that is different from information provided for a Distribution of that Dataset SHOULD be avoided as this can create legal conflicts. See also guidance in the section 'License and rights statements'.</skos:scopeNote>
+    <skos:scopeNote xml:lang="en">In the context of DCAT 2.0 dcat:Resource, information about licenses and rights MAY be provided for the Resource. See also guidance in the section 'License and rights statements'.</skos:scopeNote>
+    <skos:definition xml:lang="en">In the context of DCAT 2.0 dcat:Resource, a legal document under which the resource is made available.</skos:definition>
+    <skos:scopeNote xml:lang="it">Nel contesto di DCAT 2.0 dcat:Resource, le informazioni sulle licenze e i diritti POSSONO essere fornite per la risorsa. Si veda anche la guida nella sezione 'Licenze e dichiarazioni dei diritti'.</skos:scopeNote>
+    <skos:scopeNote xml:lang="it">Nell'ambito del DCAT 2.0, le informazioni su licenze e diritti dovrebbero essere fornite a livello di distribuzione. Le informazioni su licenze e diritti POSSONO essere fornite per un set di dati in aggiunta ma non in alternativa alle informazioni fornite per le distribuzioni di tale set di dati. La fornitura di informazioni sulla licenza o sui diritti per un set di dati che è diverso dalle informazioni fornite per una distribuzione di quel set di dati DOVREBBBE essere evitato in quanto ciò può creare conflitti legali. Si veda anche la guida nella sezione 'Licenze e dichiarazioni dei diritti'.</skos:scopeNote>
+    <skos:definition xml:lang="es">En el contexto de DCAT 2.0 dcat:DataService, uh documento legal bajo el cuál se hace disponible el servicio.</skos:definition>
+    <skos:definition xml:lang="en">In the context of DCAT 2.0 dcat:DataService, a legal document under which the service is made available.</skos:definition>
+    <skos:definition xml:lang="it">Nel contesto di DCAT 2.0 dcat:Distribution, un documento legale in base al quale viene resa disponibile la distribuzione.</skos:definition>
+    <skos:definition xml:lang="en">A legal document giving official permission to do something with the resource.</skos:definition>
+    <skos:scopeNote xml:lang="cs">V kontextu DCAT 2.0, informace o podmínkách užití (licencích a právech) BY MĚLY být poskytnuty na úrovni distribuce. Navíc, nikoliv místo, MOHOU BÝT informace o podmínkách užití (licencích a právech) poskytnuty na úrovni datové sady. NEMĚLY BY SE poskytnout různé podmínky užití pro datovou sadu a pro její distribuci, jelikož to může vést ke sporům v právním výkladu. Viz také návod v sekci 'License and rights statements'.</skos:scopeNote>
+    <skos:definition xml:lang="cs">V kontextu DCAT 2.0 dcat:Resource, právní dokument popisující podmínky užití zdroje.</skos:definition>
+    <skos:definition xml:lang="en">In the context of DCAT 2.0 dcat:Distribution, a legal document under which the distribution is made available.</skos:definition>
+    <skos:definition xml:lang="cs">V kontextu DCAT 2.0 dcat:DataService, právní dokument popisující podmínky užití služby.</skos:definition>
+    <skos:definition xml:lang="it">Nel contesto di DCAT 2.0 dcat:Resource, un documento legale in base al quale la risorsa è resa disponibile.</skos:definition>
+    <skos:scopeNote xml:lang="es">En el contexto de DCAT 2.0, la información sobre licencias y derechos DEBERÍA darse a nivel de la Distribución. La información sobre licencias y derechos PUEDE proveerse también para un conjunto de datos pero no en lugar de la información para la distribución del conjunto de datos. Se DEBERÍA evitar dar información de licencia o derechos para un conjunto de datos que es diferente de la de su distribución ya que en este caso puede haber conflictos legales. Ver más información en la sección 'License and rights statements'.</skos:scopeNote>
+    <skos:scopeNote xml:lang="cs">V kontextu DCAT 2.0 dcat:Resource, pro Zdroj MŮŽE BÝT uvedena informace o podmínkách užití (licencích a právech). Viz návod v sekci 'License and rights statements'.</skos:scopeNote>
+    <skos:scopeNote xml:lang="es">En el contexto de DCAT 2.0 dcat:Resource, PUEDE proveerse información sobre licencias y derechos para el Recurso. Vea también información en la sección 'License and rights statements'.</skos:scopeNote>
+    <skos:definition xml:lang="es">En el contexto de DCAT 2.0 dcat:Distribution, uh documento legal bajo el cuál se hace disponible la distribución.</skos:definition>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.org/dc/terms/title">
+    <skos:definition xml:lang="es">En el contexto de DCAT 2.0 dcat:Distribution, un nombre o título dado a la distribución.</skos:definition>
+    <skos:definition xml:lang="en">A name given to the resource.</skos:definition>
+    <skos:definition xml:lang="it">Nel contesto di DCAT 2.0 dcat:Distribution, un nome o titolo dato alla distribuzione.</skos:definition>
+    <skos:definition xml:lang="es">En el contexto de DCAT 2.0 dcat:Resource, un nombre o título dado al elemento del catálogo.</skos:definition>
+    <skos:definition xml:lang="en">In the context of DCAT 2.0 dcat:Resource, a name given to the item.</skos:definition>
+    <skos:definition xml:lang="it">Nel contesto di DCAT 2.0 dcat:Resource, un nome dato alla elemento.</skos:definition>
+    <skos:definition xml:lang="cs">V kontextu DCAT 2.0 dcat:Distribution, název distribuce</skos:definition>
+    <skos:definition xml:lang="cs">V kontextu DCAT 2.0 dcat:Resource, název položky</skos:definition>
+    <skos:definition xml:lang="en">In the context of DCAT 2.0 dcat:Distribution, a name given to the distribution.</skos:definition>
+    <skos:definition xml:lang="it">Un nome dato alla risorsa.</skos:definition>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://www.w3.org/ns/prov#wasRevisionOf">
+    <rdfs:subPropertyOf rdf:resource="http://purl.org/dc/terms/relation"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.org/dc/terms/temporal">
+    <skos:definition xml:lang="it">Nel contesto di DCAT 2.0 dcat:Dataset, il periodo temporale coperto dal set di dati.</skos:definition>
+    <skos:definition xml:lang="en">In the context of DCAT 2.0 dcat:Dataset, the temporal period that the dataset covers.</skos:definition>
+    <skos:scopeNote xml:lang="it">Nel contesto di DCAT 2.0 dcat:Dataset, la copertura temporale di un dataset può essere codificata come istanza di dct:PeriodOfTime, o può essere indicata utilizzando un riferimento URI (link) ad una risorsa che descrive un periodo o intervallo di tempo.</skos:scopeNote>
+    <skos:scopeNote xml:lang="en">In the context of DCAT 2.0 dcat:Dataset, the temporal coverage of a dataset may be encoded as an instance of dct:PeriodOfTime, or may be indicated using a URI reference (link) to a resource describing a time period or interval.</skos:scopeNote>
+    <skos:definition xml:lang="cs">V kontextu DCAT 2.0 dcat:Dataset, časové pokrytí datové sady.</skos:definition>
+    <skos:scopeNote xml:lang="es">En el contexto de DCAT 2.0 dcat:Dataset, la cobertura temporal del conjunto de datos puede codificarse como una instancia de dct:PeriodOfTime, o puede indicarse usando una referencia URI (es decir, un enlace) a un recurso que describa el período o interválo de tiempo.</skos:scopeNote>
+    <skos:scopeNote xml:lang="cs">V kontextu DCAT 2.0 dcat:Dataset, časové pokrytí datové sady může být zaznamenáno jako instance dct:PeriodOfTime, nebo může být indikováno jako IRI odkazující na zdroj popisující či časový interval.</skos:scopeNote>
+    <skos:definition xml:lang="es">En el contexto de DCAT 2.0 dcat:Dataset, el período temporal cubierto por el conjunto de datos.</skos:definition>
+    <skos:definition xml:lang="it">Caratteristiche temporali della risorsa.</skos:definition>
+    <skos:definition xml:lang="en">Temporal characteristics of the resource.</skos:definition>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://xmlns.com/foaf/0.1/primaryTopic">
+    <skos:scopeNote xml:lang="es">La propiedad foaf:primaryTopic es funcional: en el contexto de DCAT 2.0,  cada registro del catálogo puede tener a lo sumo un tópico principal, es decir un tópico que describa el conjunto de datos o servicio.</skos:scopeNote>
+    <skos:definition xml:lang="es">En el contexto de DCAT 2.0 dcat:CatalogRecord, el dcat:Resource (conjunto de datos o servicio) descripto en el registro.</skos:definition>
+    <skos:scopeNote xml:lang="it">foaf:primaryTopic property è funzionale: nel contesto di DCAT 2.0, ogni record di catalogo può avere al massimo un argomento primario, cioè descrive un set di dati o un servizio.</skos:scopeNote>
+    <skos:scopeNote xml:lang="cs">Vlastnost foaf:primaryTopic je funkce: v kontextu DCAT 2.0, každý katalogizační záznam může mít nejvýše jednu hodnotu foaf:primaryTopic, tj. popisuje nejvýše jednu datovou sadu či službu.</skos:scopeNote>
+    <skos:definition xml:lang="cs">V kontextu DCAT 2.0 dcat:CatalogRecord, dcat:Resource (datová sada či služba) popsaná katalogizačním záznamem.</skos:definition>
+    <skos:definition xml:lang="it">Nel contesto di DCAT 2.0 dcat:CatalogRecord, il dcat:Resource (set di dati o servizio) descritto nel record.</skos:definition>
+    <skos:definition xml:lang="en">The primary topic of some page or document.</skos:definition>
+    <skos:scopeNote xml:lang="en">foaf:primaryTopic property is functional: in the context of DCAT 2.0, each catalog record can have at most one primary topic i.e. describes one dataset or service.</skos:scopeNote>
+    <skos:definition xml:lang="it">L'argomento principale di qualche pagina o documento.</skos:definition>
+    <skos:definition xml:lang="en">In the context of DCAT 2.0 dcat:CatalogRecord, the dcat:Resource (dataset or service) described in the record.</skos:definition>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://xmlns.com/foaf/0.1/homepage">
+    <skos:scopeNote xml:lang="it">foaf:homepage è una proprietà funzionale inversa (IFP), il che significa che DEVE essere unica e identificare con precisione la pagina web della risorsa. Nel contesto di DCAT 2.0, questa proprietà indica la pagina web canonica, che potrebbe essere utile nei casi in cui ci sia più di una pagina web sulla risorsa.</skos:scopeNote>
+    <skos:scopeNote xml:lang="cs">foaf:homepage je inverzní funkčí vlastnost, což znamená, že MUSÍ být unikátní a MUSÍ přesně označovat webovou stránku zdroje. V kontextu DCAT 2.0, označuje hlavní webovou stránku, což se může hodit v případě, že webových stránek o zdroji existuje více.</skos:scopeNote>
+    <skos:scopeNote xml:lang="en">foaf:homepage is an inverse functional property (IFP), which means that it MUST be unique and precisely identify the web-page for the resource. In the context of DCAT 2.0, this property indicates the canonical web-page, which might be helpful in cases where there is more than one web-page about the resource.</skos:scopeNote>
+    <skos:scopeNote xml:lang="es">foaf:homepage es la propiedad funcional inversa (IFP por sus siglas en inglés), lo que significa que DEBE ser única y identificar la página web del recurso percisamente. En el contexto de DCAT 2.0, esta propiedad indica la página web canónica, que pude ser útil en casos en los que hay más de una página web para el recurso.</skos:scopeNote>
+    <skos:definition xml:lang="it">Una homepage per qualche cosa.</skos:definition>
+    <skos:definition xml:lang="it">Nel contesto di DCAT 2.0 dcat:Catalog, una homepage del catalogo (un documento Web pubblico solitamente disponibile in HTML).</skos:definition>
+    <skos:definition xml:lang="en">In the context of DCAT 2.0 dcat:Catalog, a homepage of the catalog (a public Web document usually available in HTML).</skos:definition>
+    <skos:definition xml:lang="en">A homepage for some thing.</skos:definition>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.org/dc/terms/type">
+    <skos:definition xml:lang="cs">Podstata či žánr zdroje.</skos:definition>
+    <skos:scopeNote xml:lang="es">Usa el elemento dct:format para describir el formato del archivo, el medio físico, o las dimensiones del recurso.</skos:scopeNote>
+    <skos:scopeNote xml:lang="en">To describe the file format, physical medium, or dimensions of the resource, use the dct:format element.</skos:scopeNote>
+    <skos:definition xml:lang="es">La naturaleza, género o tipo del recurso.</skos:definition>
+    <skos:scopeNote xml:lang="it">Per descrivere il formato del file, il supporto fisico o le dimensioni della risorsa, utilizzare l'elemento dct:format.</skos:scopeNote>
+    <skos:scopeNote xml:lang="cs">Pro popis formátu souboru, fyzického média či dimenzí zdroje použijte dct:format.</skos:scopeNote>
+    <skos:scopeNote xml:lang="en">In the context of DCAT 2.0, the value SHOULD be taken from a well governed and broadly recognised controlled vocabulary, such as: 1. DCMI Type vocabulary [DCTERMS]; 2. ISO 19115 scope codes [ISO-19115-1]; 3. Datacite resource types [DataCite]; 4. PARSE.Insight content-types used by re3data.org [RE3DATA-SCHEMA] (see item 15 contentType); 5. MARC intellectual resource types ; Some members of these controlled vocabularies are not strictly suitable for datasets or data services (e.g. DCMI Type Event, PhysicalObject; ISO 19115 CollectionHardware, CollectionSession, Initiative, Sample, Repository), but might be used in the context of other kinds of catalogs defined in DCAT profiles or applications.</skos:scopeNote>
+    <skos:scopeNote xml:lang="es">En el contexto de DCAT 2.0, el valor DEBERÍA tomarse de un vocabulario controlado bien gobernado y ampliamente reconocido, como por ejemplo: 1. DCMI Type vocabulary [DCTERMS]; 2. códigos de alcance de ISO 19115 [ISO-19115-1]; 3. tipos de recursos de Datacite [DataCite]; 4. tipos de contenido de PARSE.Insight usados por re3data.org [RE3DATA-SCHEMA] (see item 15 contentType); 5. tipos de recurso intelectual de MARC. Algunos elementos de estos vocabularios controlados son estrictamente no apropiados para conjuntos de datos o servicios de datos (por ejemplo: DCMI Type Event, PhysicalObject; ISO 19115 CollectionHardware, CollectionSession, Initiative, Sample, Repository), pero pueden usarse en este contexto para otros tipos de catálogos definidos en perfiles de DCAT o aplicaciones.</skos:scopeNote>
+    <skos:definition xml:lang="it">La natura o il tipo di risorsa.</skos:definition>
+    <skos:scopeNote xml:lang="cs">V kontextu DCAT 2.0, hodnota BY MĚLA být z dobře řízeného a široce uznávaného slovníku, např.: 1. Slovník DCMI Type [DCTERMS]; 2. Kódy ISO 19115 [ISO-19115-1]; 3. Typy zdrojů Datacite [DataCite]; 4. Typy obsahu PARSE.Insight, které jsou používány re3data.org [RE3DATA-SCHEMA] (viz položka 15 contentType); 5. Typy duševních zdrojů MARC; Některé položky těchto slovníků nejsou zcela vhodné pro datové sady nebo datové služby (např. DCMI Type Event, PhysicalObject; ISO 19115 CollectionHardware, CollectionSession, Initiative, Sample, Repository), ale mohou být použity v kontextu jiných typů katalogů, které jsou definovány v profilech či aplikacích DCAT.</skos:scopeNote>
+    <skos:definition xml:lang="en">The nature or genre of the resource.</skos:definition>
+    <skos:scopeNote xml:lang="it">Il valore DOVREBBE essere tratto da un vocabolario ben governato e ampiamente riconosciuto e controllato, come ad esempio: 1. Vocabolario dei  DCMI Type [DCTERMS]; 2. Codici di scopo ISO 19115 [ISO-19115-1];  3. Tipi di risorse del Datacite [DataCite]. 4. PARSE.Insight content-type utilizzati da re3data.org [RE3DATA-SCHEMA] (vedi punto 15 contentType); 5. Tipi di risorse intellettuali del MARC. Alcuni membri di questi vocabolari controllati non sono strettamente adatti a insiemi di dati o servizi di dati (ad es. DCMI Type Event, PhysicalObject; ISO 19115 CollectionHardware, CollectionSession, Initiative, Sample, Repository), ma possono essere utilizzati nel contesto di altri tipi di cataloghi definiti in profili o applicazioni DCAT.</skos:scopeNote>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.org/dc/terms/creator">
+    <skos:scopeNote xml:lang="cs">V kontextu DCAT 2.0, doporučovanou hodnotou této vlastnosti jsou zdroje typu foaf:Agent.</skos:scopeNote>
+    <skos:changeNote xml:lang="it">Proprietà aggiunta in questo contesto in DCAT 2.0, in particolare per soddisfare i requisiti di citazione dei dati.</skos:changeNote>
+    <skos:definition xml:lang="en">An entity primarily responsible for making the resource.</skos:definition>
+    <skos:definition xml:lang="it">Nel contesto del DCAT 2.0, l'entità responsabile della produzione della risorsa.</skos:definition>
+    <skos:changeNote xml:lang="es">Esta propiedad fue agregada en DCAT 2.0, específicamente para tratar los requerimientos de cita de datos.</skos:changeNote>
+    <skos:changeNote xml:lang="en">Property added in this context in DCAT 2.0, specifically to address data citation requirements.</skos:changeNote>
+    <skos:definition xml:lang="cs">V kontextu DCAT 2.0, entita zodpovědná za tvorbu zdroje.</skos:definition>
+    <skos:scopeNote xml:lang="it">Nel contesto di DCAT 2.0, si raccomandano come valori per questa proprietà le risorse di tipo foaf:Agent.</skos:scopeNote>
+    <skos:definition xml:lang="it">Un'entità principalmente responsabile della creazione della risorsa.</skos:definition>
+    <skos:changeNote xml:lang="cs">Vlastnost v tomto kontextu byla přidána ve verzi DCAT 2.0 zejména za účelem uspokojení požadavků na citace dat.</skos:changeNote>
+    <skos:definition xml:lang="es">En el contexto de DCAT 2.0, la entidad responsable de producier el recurso.</skos:definition>
+    <skos:scopeNote xml:lang="en">In the context of DCAT 2.0, resources of type foaf:Agent are recommended as values for this property.</skos:scopeNote>
+    <skos:scopeNote xml:lang="es">En el contexto de DCAT 2.0, se recomienda que los valores de esta propiedad sean recurso de tipo foaf:Agent.</skos:scopeNote>
+    <skos:definition xml:lang="en">In the context of DCAT 2.0, the entity responsible for producing the resource.</skos:definition>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.org/dc/terms/accessRights">
+    <skos:scopeNote xml:lang="en">In the context of DCAT 2.0 dcat:Resource, information about licenses and rights MAY be provided for the Resource. See also guidance in the section 'License and rights statements'.</skos:scopeNote>
+    <skos:definition xml:lang="en">Information about who can access the resource or an indication of its security status.</skos:definition>
+    <skos:scopeNote xml:lang="it">Nell'ambito di DCAT 2.0 dcat:Distribution, le informazioni su licenze e diritti POSSONO essere fornite per la distribuzione. Si vedano anche le indicazioni nella sezione 'Licenze e dichiarazioni sui diritti'.</skos:scopeNote>
+    <skos:definition xml:lang="it">Informazioni su chi può accedere alla risorsa o un'indicazione del suo stato di sicurezza.</skos:definition>
+    <skos:definition xml:lang="cs">V kontextu DCAT 2.0 dcat:Distribution, podmínky užití řešící způsob přístupu k distribuci.</skos:definition>
+    <skos:scopeNote xml:lang="es">En el contexto de DCAT 2.0 dcat:Resource, información sobre las licencias y derechos que PUEDEN proveerse para un Recurso. Ver también la información en la sección 'License and rights statements'.</skos:scopeNote>
+    <skos:definition xml:lang="en">In the context of DCAT 2.0 dcat:Distribution, a rights statement that concerns how the distribution is accessed.</skos:definition>
+    <skos:scopeNote xml:lang="it">Nel contesto di DCAT 2.0 dcat:Resource, le informazioni sulle licenze e i diritti POSSONO essere fornite per la risorsa. Si vedano anche le indicazioni nella sezione 'Licenze e dichiarazioni sui diritti'.</skos:scopeNote>
+    <skos:scopeNote xml:lang="it">Nel contesto di DCAT 2.0 dcat:DataService, i diritti di accesso POSSONO includere informazioni riguardanti l'accesso o restrizioni basate su privacy, sicurezza o altre policy.</skos:scopeNote>
+    <skos:scopeNote xml:lang="es">En el contexto de DCAT 2.0 dcat:Distribution, información sobre licencias y derechos que PUEDE proveerse para una Distribución. Ver también la información en la sección 'License and rights statements'.</skos:scopeNote>
+    <skos:scopeNote xml:lang="en">In the context of DCAT 2.0 dcat:DataService, access Rights MAY include information regarding access or restrictions based on privacy, security, or other policies.</skos:scopeNote>
+    <skos:scopeNote xml:lang="cs">V kontextu DCAT 2.0 dcat:DataService, podmínky užití MOHOU obsahovat informace o přístupu nebo omezení z hlediska soukromí, bezpečnosti nebo jiných pravidel.</skos:scopeNote>
+    <skos:scopeNote xml:lang="cs">V kontextu DCAT 2.0 dcat:Distribution, pro Distribuci MŮŽE BÝT uvedena informace o podmínkách užití (licencích a právech). Viz návod v sekci 'License and rights statements'.</skos:scopeNote>
+    <skos:definition xml:lang="it">Nel contesto di DCAT 2.0 dcat:Distribution, una dichiarazione dei diritti che riguarda le modalità di accesso alla distribuzione.</skos:definition>
+    <skos:scopeNote xml:lang="cs">V kontextu DCAT 2.0 dcat:Resource, pro Zdroj MŮŽE BÝT uvedena informace o podmínkách užití (licencích a právech). Viz návod v sekci 'License and rights statements'.</skos:scopeNote>
+    <skos:scopeNote xml:lang="en">In the context of DCAT 2.0 dcat:Distribution, information about licenses and rights MAY be provided for the Distribution. See also guidance in the section 'License and rights statements'.</skos:scopeNote>
+    <skos:definition xml:lang="es">En el contexto de DCAT 2.0 dcat:Distribution, una declaración de derechos sobre cómo se puede acceder la distribución.</skos:definition>
+    <skos:scopeNote xml:lang="es">En el contexto de DCAT 2.0 dcat:DataService, los derechos de acceso PUEDEN incluir información sobre acceso o restricciones basadas en privacidad, seguridad, u otras reglamentaciones.</skos:scopeNote>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.org/dc/terms/publisher">
+    <skos:definition xml:lang="es">En el contexto de DCAT 2.0, la entidad responsable de hacer el item disponible.</skos:definition>
+    <skos:scopeNote xml:lang="cs">V kontextu DCAT 2.0, doporučovanou hodnotou této vlastnosti jsou zdroje typu foaf:Agent.</skos:scopeNote>
+    <skos:scopeNote xml:lang="es">En el contexto de DCAT 2.0, se recomienda usar recursos del tipo foaf:Agent para los valores de esta propiedad.</skos:scopeNote>
+    <skos:definition xml:lang="cs">V kontextu DCAT 2.0, entita zodpovědná za zpřístupnění položky.</skos:definition>
+    <skos:definition xml:lang="en">An entity responsible for making the resource available.</skos:definition>
+    <skos:definition xml:lang="en">In the context of DCAT 2.0, the entity responsible for making the item available.</skos:definition>
+    <skos:definition xml:lang="it">Nell'ambito del DCAT 2.0, l'entità responsabile della messa a disposizione dell'elemento.</skos:definition>
+    <skos:scopeNote xml:lang="it">Nel contesto di DCAT 2.0, si raccomandano risorse di tipo foaf:Agent come valori per questa proprietà.</skos:scopeNote>
+    <skos:definition xml:lang="it">Un'entità responsabile della messa a disposizione della risorsa.</skos:definition>
+    <skos:scopeNote xml:lang="en">In the context of DCAT 2.0, resources of type foaf:Agent are recommended as values for this property.</skos:scopeNote>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://www.w3.org/ns/prov#wasDerivedFrom">
+    <rdfs:subPropertyOf rdf:resource="http://purl.org/dc/terms/relation"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.org/dc/terms/identifier">
+    <skos:definition xml:lang="it">Nel contesto del DCAT 2.0, un identificatore unico dell'elemento.</skos:definition>
+    <skos:scopeNote xml:lang="it">Nel contesto di DCAT 2.0, l'identificatore può essere usato come parte dell'URI dell'elemento, ma comunque è utile averlo rappresentato esplicitamente.</skos:scopeNote>
+    <skos:scopeNote xml:lang="en">In the context of DCAT 2.0, the identifier might be used as part of the URI of the item, but still having it represented explicitly is useful.</skos:scopeNote>
+    <skos:definition xml:lang="it">Un riferimento univoco alla risorsa in un dato contesto.</skos:definition>
+    <skos:definition xml:lang="cs">V kontextu DCAT 2.0, unikátní identifikátor položky.</skos:definition>
+    <skos:scopeNote xml:lang="es">En el contexto de DCAT 2.0, el identificador puede usarse como parte de la URI del ítem, pero es útil tenerlo representado de forma explícita.</skos:scopeNote>
+    <skos:definition xml:lang="en">In the context of DCAT 2.0, a unique identifier of the item.</skos:definition>
+    <skos:definition xml:lang="en">An unambiguous reference to the resource within a given context.</skos:definition>
+    <skos:definition xml:lang="es">En el contexto de DCAT 2.0, un identificador único para el ítem.</skos:definition>
+    <skos:scopeNote xml:lang="cs">V kontextu DCAT 2.0, identifikátor může být použit jako součást IRI položky. I přesto je užitečné mít jeho explicitní reprezentaci.</skos:scopeNote>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.org/dc/terms/language">
+    <skos:scopeNote xml:lang="es">En el contexto de DCAT 2.0, si las representaciones de un conjunto de datos están disponibles por separado para cada idioma, defina una instancia de dcat:Distribution para cada idioma y describa el lenguaje específico de cada distribución usando dct:language (es decir, el conjunto de datos tendrá múltiples valores para dct:language y cada distribución tendrá sólo un valor de la propiedad dct:language).</skos:scopeNote>
+    <skos:scopeNote xml:lang="en">In the context of DCAT 2.0, repeat this property if the resource is available in multiple languages.</skos:scopeNote>
+    <skos:scopeNote xml:lang="cs">V kontextu DCAT 2.0, pokud jsou reprezentace datové sady k dispozici pro každý jazyk zvlášť, definujte pro každý jazyk jednu instanci dcat:Distribution a popište jazyk dané distribuce pomocí dct:language. (tj. datová sada bude mít více hodnot dct:language a každá distribuce bude mít pouze jednu hodnotu její vlastnosti dct:language).</skos:scopeNote>
+    <skos:definition xml:lang="cs">V kontextu DCAT 2.0, jazyk položky. Tato vlastnost úvádí přirozený jazyk použitý pro textová metadata, tj. názvy, popisy apod., katalogizovaného zdroje, tj. datové sady nebo služby, nebo textový obsah distribuce datové sady.</skos:definition>
+    <skos:scopeNote xml:lang="it">Nel contesto di DCAT 2.0, ripetere questa proprietà se la risorsa è disponibile in più lingue.</skos:scopeNote>
+    <skos:definition xml:lang="it">Una lingua della risorsa.</skos:definition>
+    <skos:scopeNote xml:lang="en">In the context of DCAT 2.0, the value(s) provided for members of a catalog (i.e. dataset or service) override the value(s) provided for the catalog if they conflict.</skos:scopeNote>
+    <skos:definition xml:lang="es">En el contexto de DCAT 2.0, el idioma del ítem. Este se refiere al lenguaje natural que se usa para los metadatos textuales (es decir, títulos, descripciones, etc) de un recurso catalogado (como ser un conjunto o servicio de datos) o los valores textuales de las distribuciones de un conjunto de datos.</skos:definition>
+    <skos:scopeNote xml:lang="en">In the context of DCAT 2.0, if representations of a dataset are available for each language separately, define an instance of dcat:Distribution for each language and describe the specific language of each distribution using dct:language (i.e. the dataset will have multiple dct:language values and each distribution will have just one as the value of its dct:language property).</skos:scopeNote>
+    <skos:definition xml:lang="en">In the context of DCAT 2.0, a language of the item. This refers to the natural language used for textual metadata (i.e. titles, descriptions, etc) of a catalogued resource (i.e. dataset or service) or the textual values of a dataset distribution.</skos:definition>
+    <skos:scopeNote xml:lang="cs">V kontextu DCAT 2.0, tuto vlastnost opakujte, pokud je zdroj k dispozici ve více jazycích.</skos:scopeNote>
+    <skos:definition xml:lang="it">Nel contesto del DCAT 2.0, una lingua dell'elemento. Si riferisce al linguaggio naturale utilizzato per i metadati testuali (titoli, descrizioni, ecc.) di una risorsa catalogata (dataset o servizio) o ai valori testuali di una distribuzione di un dataset.</skos:definition>
+    <skos:scopeNote xml:lang="cs">V kontextu DCAT 2.0, hodnoty uvedené pro katalogizované položky, tj. datové sady či služby, mají přednost před hodnotami uvedenými pro katalog, pokud jsou ve sporu.</skos:scopeNote>
+    <skos:scopeNote xml:lang="it">Nel contesto del DCAT 2.0, i valori forniti per i membri di un catalogo (cioè set di dati o servizio) sostituiscono i valori forniti per il catalogo in caso di conflitto.</skos:scopeNote>
+    <skos:definition xml:lang="en">A language of the resource.</skos:definition>
+    <skos:scopeNote xml:lang="es">En el contexto de DCAT 2.0, repetir esta propiedad si el recurso está disponible un múltiples idiomas.</skos:scopeNote>
+    <skos:scopeNote xml:lang="it">Nel contesto di DCAT 2.0, se le rappresentazioni di un dataset sono disponibili separatamente per ogni lingua, definire un'istanza di dcat:Distribution per ogni lingua e descrivere la lingua specifica di ogni distribuzione usando dct:language (cioè il dataset avrà valori multipli di dct:language e ogni distribuzione avrà uno solo come valore della sua proprietà dct:language).</skos:scopeNote>
+    <skos:scopeNote xml:lang="es">En el contexto de DCAT 2.0, en el caso de conflictos, el valor (o los valores) datos para miembros del catálogo (es decir, conjunto de datos o servicios) sobreescribe el valor (o los valores) dados apra el catálogo.</skos:scopeNote>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://www.w3.org/ns/prov#wasInfluencedBy">
+    <rdfs:subPropertyOf rdf:resource="http://purl.org/dc/terms/relation"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://purl.org/dc/terms/modified">
+    <skos:definition xml:lang="it">Nel contesto di DCAT 2.0 dcat:Distribution, la data più recente in cui la distribuzione è stata cambiata, aggiornata o modificata.</skos:definition>
+    <skos:definition xml:lang="en">Date on which the resource was changed.</skos:definition>
+    <skos:definition xml:lang="cs">V kontextu DCAT 2.0 dcat:Distribution, poslední datum kdy byla distribuce změněna či aktualizována.</skos:definition>
+    <skos:scopeNote xml:lang="it">Nel contesto di DCAT 2.0 dcat:CatalogRecord, indica la data dell'ultima modifica di una voce di catalogo, cioè la descrizione dei metadati di catalogo del dataset, e non la data del dataset stesso.</skos:scopeNote>
+    <skos:definition xml:lang="en">In the context of DCAT 2.0 dcat:CatalogRecord, most recent date on which the catalog entry was changed, updated or modified.</skos:definition>
+    <skos:scopeNote xml:lang="en">In the context of DCAT 2.0 dcat:CatalogRecord, this indicates the date of last change of a catalog entry, i.e. the catalog metadata description of the dataset, and not the date of the dataset itself.</skos:scopeNote>
+    <skos:definition xml:lang="it">Data in cui la risorsa è stata cambiata.</skos:definition>
+    <skos:scopeNote xml:lang="es">En el contexto de DCAT 2.0 dcat:Resource, el valor de esta propiedad indica un cambio del ítem, no un cambio en el registro del catálogo. La ausencia de valor PUEDE indicar que el ítem nunca se modificó después de su publicación inicial, o que no se conoce la fecha de su última modificación, o que el ítem se actualiza contínuamente.</skos:scopeNote>
+    <skos:scopeNote xml:lang="es">En el contexto de DCAT 2.0 dcat:CatalogRecord, indica la fecha en que se hizo la última modificación a la entrada del catálogo, es decir, de los metadatos en el catálogo sobre el conjunto de datos, y no sobre el mismo conjunto de datos.</skos:scopeNote>
+    <skos:scopeNote xml:lang="cs">V kontextu DCAT 2.0 dcat:Resource, hodnota této vlastnosti udává změnu položky, nikoliv změnu jejího katalogizačního záznamu. Pokud hodnota chybí, MŮŽE to znamenat, že po publikaci položka již nebyla měněna, že datum změny není známo, nebo že je položka aktualizována neustále.</skos:scopeNote>
+    <skos:definition xml:lang="es">En el contexto de DCAT 2.0 dcat:Distribution, la fecha más reciente en la que se modificó o actualizó la distribución.</skos:definition>
+    <skos:definition xml:lang="en">In the context of DCAT 2.0 dcat:Distribution, most recent date on which the distribution  was changed, updated or modified.</skos:definition>
+    <skos:scopeNote xml:lang="en">In the context of DCAT 2.0 dcat:Resource, the value of this property indicates a change to the actual item, not a change to the catalog record. An absent value MAY indicate that the item has never changed after its initial publication, or that the date of last modification is not known, or that the item is continuously updated.</skos:scopeNote>
+    <skos:definition xml:lang="es">En el contexto de DCAT 2.0 dcat:CatalogRecord, la fecha más reciente en la que se modificó o actualizó la entrada del catálogo.</skos:definition>
+    <skos:scopeNote xml:lang="it">Nel contesto di DCAT 2.0 dcat:Resource, il valore di questa proprietà indica una modifica all'elemento effettivo, non una modifica al record del catalogo. Un valore assente PUÒ indicare che l'articolo non è mai cambiato dopo la sua pubblicazione iniziale, o che la data dell'ultima modifica non è nota, o che l'articolo viene continuamente aggiornato.</skos:scopeNote>
+    <skos:scopeNote xml:lang="cs">V kontextu DCAT 2.0 dcat:CatalogRecord, tato vlastnost indikuje datum poslední změny katalogizačního záznamu, nikoliv datum změny datové sady samotné.</skos:scopeNote>
+    <skos:definition xml:lang="cs">V kontextu DCAT 2.0 dcat:Resource, poslední datum kdy byla položka změněna či aktualizována.</skos:definition>
+    <skos:definition xml:lang="es">En el contexto de DCAT 2.0 dcat:Resource, la fecha más reciente en la que se modificó o actualizó el ítem del catálogo.</skos:definition>
+    <skos:definition xml:lang="en">In the context of DCAT 2.0 dcat:Resource, most recent date on which the item was changed, updated or modified.</skos:definition>
+    <skos:definition xml:lang="it">Nel contesto di DCAT 2.0 dcat:Resource, la data più recente in cui l'elemento è stato cambiato, aggiornato o modificato.</skos:definition>
+    <skos:definition xml:lang="cs">V kontextu DCAT 2.0 dcat:CatalogRecord, poslední datum kdy byl katalogizační záznam změněn či aktualizován.</skos:definition>
+    <skos:definition xml:lang="it">Nel contesto di DCAT 2.0 dcat:CatalogRecord, la data più recente in cui la voce di catalogo è stata cambiata, aggiornata o modificata.</skos:definition>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://www.w3.org/ns/locn#geometry">
+    <skos:scopeNote xml:lang="es">El rango de esta propiedad (locn:Geometry) permite cualquier tipo de especificación de la geometría. Por ejemplo, la geometría podría estar codificada por un literal, como WKT (geosparql:wktLiteral [GeoSPARQL]), o representada por una clase, como geosparql:Geometry (o cualquiera de sus subclases) [GeoSPARQL].</skos:scopeNote>
+    <skos:definition xml:lang="es">Asocia cualquier recurso con la geometría correspondiente.</skos:definition>
+    <skos:scopeNote xml:lang="cs">Rozsah této vlastnosti (locn: Geometry) umožňuje jakýkoli typ specifikace geometrie. Například geometrie může být kódována literálem, jako WKT (geosparql: wktLiteral [GeoSPARQL]), nebo reprezentována třídou, jako geosparql: Geometry (nebo jakoukoli z jeho podtříd) [GeoSPARQL].</skos:scopeNote>
+    <skos:definition xml:lang="en">Associates any resource with the corresponding geometry.</skos:definition>
+    <skos:scopeNote xml:lang="en">The range of this property (locn:Geometry) allows for any type of geometry specification. E.g., the geometry could be encoded by a literal, as WKT (geosparql:wktLiteral [GeoSPARQL]), or represented by a class, as geosparql:Geometry (or any of its subclasses) [GeoSPARQL].</skos:scopeNote>
+    <rdfs:range rdf:resource="http://www.w3.org/ns/locn#Geometry"/>
+    <skos:changeNote xml:lang="es">Esta propiedad fue agregada en DCAT 2.0.</skos:changeNote>
+    <skos:definition xml:lang="cs">Přiřazuje geometrii jakémukoliv zdroji.</skos:definition>
+    <skos:changeNote xml:lang="en">Property added in this context in DCAT 2.0.</skos:changeNote>
+    <skos:changeNote xml:lang="it">Proprietà aggiunta in questo contesto in DCAT 2.0.</skos:changeNote>
+    <skos:scopeNote xml:lang="it">Il range di questa proprietà (locn:Geometry) permette di specificare ogni tipo di geometria.  Ad esempio, la geometria potrebbe essere codificata da un letterale, come WKT (geosparql:wktLiteral [GeoSPARQL]), o rappresentata da una classe, come geosparql:Geometry (o una delle sue sottoclassi) [GeoSPARQL].</skos:scopeNote>
+    <skos:definition xml:lang="it">Associa qualsiasi risorsa alla geometria corrispondente.</skos:definition>
+    <skos:changeNote xml:lang="cs">Vlastnost v tomto kontextu byla přidána ve verzi DCAT 2.0.</skos:changeNote>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://www.w3.org/ns/prov#alternateOf">
+    <rdfs:subPropertyOf rdf:resource="http://purl.org/dc/terms/relation"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://www.w3.org/2006/time#hasEnd">
+    <skos:definition xml:lang="it">Nel contesto del DCAT 2.0, fine di un periodo o intervallo.</skos:definition>
+    <skos:definition xml:lang="en">In the context of DCAT 2.0, end of a period or interval.</skos:definition>
+    <skos:scopeNote xml:lang="es">En el contexto de DCAT 2.0, el uso de la propiedad time:hasEnd implica que el valor de la propiedad dct:temporal es un miembro de la clase time:TemporalEntity de [OWL-TIME]. En este contexto, esto puede interpretarse como que implica que dct:PeriodOfTime es equivalente a la subclase time:ProperInterval.</skos:scopeNote>
+    <skos:definition xml:lang="it">Fine di un'entità temporale.</skos:definition>
+    <skos:changeNote xml:lang="it">Proprietà aggiunte in questo contesto in DCAT 2.0.</skos:changeNote>
+    <skos:scopeNote xml:lang="en">In the context of DCAT 2.0, use of the property time:hasEnd entails that value of the dct:temporal property is a member of the time:TemporalEntity class from [OWL-TIME]. In this context this could be taken to imply that dct:PeriodOfTime is equivalent to the subclass time:ProperInterval.</skos:scopeNote>
+    <skos:changeNote xml:lang="en">Property added in this context in DCAT 2.0.</skos:changeNote>
+    <skos:changeNote xml:lang="cs">Vlastnost v tomto kontextu byla přidána ve verzi DCAT 2.0</skos:changeNote>
+    <skos:scopeNote xml:lang="cs">V kontextu DCAT 2.0, použití vlastnosti time:hasEnd znamená, že hodnota vlastnosti dct:temporal je instancí třídy time:TemporalEntity ze slovníku [OWL-TIME]. V tomto kontextu to může znamenat, že dct:PeriodOfTime je ekvivalentní podtřídě time:ProperInterval.</skos:scopeNote>
+    <skos:scopeNote xml:lang="it">Nel contesto di DCAT 2.0, l'uso della proprietà time:hasEnd comporta che il valore della proprietà dct:temporal è un membro della classe time:TemporalEntity di [OWL-TIME]. In questo contesto ciò potrebbe essere interpretato nel senso che dct:PeriodOfTime è equivalente alla sottoclasse time:ProperInterval.</skos:scopeNote>
+    <skos:definition xml:lang="en">End of a temporal entity.</skos:definition>
+    <skos:changeNote xml:lang="es">Esta propiedad fue agregada en DCAT 2.0.</skos:changeNote>
+  </rdf:Description>
 </rdf:RDF>
-
-
-
-<!-- Generated by the OWL API (version 4.2.8.20170104-2310) https://github.com/owlcs/owlapi -->
-

--- a/dcat/rdf/dcat-external.ttl
+++ b/dcat/rdf/dcat-external.ttl
@@ -521,7 +521,7 @@ time:hasEnd
   owl:imports <http://www.w3.org/ns/prov-o#> ;
 .
 locn:geometry
-  rdfs:range rdfs:Literal ;
+  rdfs:range locn:Geometry ;
   skos:changeNote "Esta propiedad fue agregada en DCAT 2.0."@es ;
   skos:changeNote "Property added in this context in DCAT 2.0."@en ;
   skos:changeNote "Proprietà aggiunta in questo contesto in DCAT 2.0."@it ;
@@ -530,10 +530,10 @@ locn:geometry
   skos:definition "Associa qualsiasi risorsa alla geometria corrispondente."@it ;
   skos:definition "Associates any resource with the corresponding geometry."@en ;
   skos:definition "Přiřazuje geometrii jakémukoliv zdroji."@cs ;
-  skos:scopeNote " el contexto de DCAT 2.0, el rango de esta propiedad es intencionalmente genérico con el propósito de permitir distintas codificaciones de la geometría. Por ejemplo, la geometría puede codificarse como WKT (geosparql:wktLiteral [GeoSPARQL])."@es ;
-  skos:scopeNote "In the context of DCAT 2.0, the range of this property is intentionally generic, with the purpose of allowing different geometry encodings. E.g., the geometry could be encoded as WKT (geosparql:wktLiteral [GeoSPARQL])."@en ;
-  skos:scopeNote "Nel contesto del DCAT 2.0, il range di questa proprietà è volutamente generico, con lo scopo di consentire diverse codifiche geometriche. Ad esempio, la geometria potrebbe essere codificata come WKT (geosparql:wktLiteral [GeoSPARQL])."@it ;
-  skos:scopeNote "V kontextu DCAT 2.0, obor hodnot této vlastnosti je úmyslně obecný, aby umožnil různé kódování geometrií. Geometrie by kupříkladu mohla být kódována jako WKT (geosparql:wktLiteral [GeoSPARQL])."@cs ;
+  skos:scopeNote "El rango de esta propiedad (locn:Geometry) permite cualquier tipo de especificación de la geometría. Por ejemplo, la geometría podría estar codificada por un literal, como WKT (geosparql:wktLiteral [GeoSPARQL]), o representada por una clase, como geosparql:Geometry (o cualquiera de sus subclases) [GeoSPARQL]."@es ;
+  skos:scopeNote "The range of this property (locn:Geometry) allows for any type of geometry specification. E.g., the geometry could be encoded by a literal, as WKT (geosparql:wktLiteral [GeoSPARQL]), or represented by a class, as geosparql:Geometry (or any of its subclasses) [GeoSPARQL]."@en;
+  skos:scopeNote "Il range di questa proprietà (locn:Geometry) permette di specificare ogni tipo di geometria.  Ad esempio, la geometria potrebbe essere codificata da un letterale, come WKT (geosparql:wktLiteral [GeoSPARQL]), o rappresentata da una classe, come geosparql:Geometry (o una delle sue sottoclassi) [GeoSPARQL]."@it ;
+  skos:scopeNote "Rozsah této vlastnosti (locn: Geometry) umožňuje jakýkoli typ specifikace geometrie. Například geometrie může být kódována literálem, jako WKT (geosparql: wktLiteral [GeoSPARQL]), nebo reprezentována třídou, jako geosparql: Geometry (nebo jakoukoli z jeho podtříd) [GeoSPARQL]."@cs ;
 .
 odrl:hasPolicy
   skos:definition "En el contexto de DCAT 2.0 dcat:Distribution, una reglamentación conforme a ODRL expresando los derechos asociados con la distribución [ODRL-VOCAB]."@es ;
@@ -571,7 +571,7 @@ prov:qualifiedAttribution
   skos:definition "Nel contesto di DCAT 2.0, collegamento a un agente che ha una qualche forma di responsabilità per la risorsa."@it ;
   skos:definition "V kontextu DCAT 2.0, odkaz na Agenta, který má nějaký typ odpovědnosti za zdroj."@cs ;
   skos:scopeNote "En el contexto de DCAT 2.0, se usa para asociar un Agente cuando la naturaleza de la relación es conocida pero no es ninguna de las asociaciones estándares descriptas con propiedades de Dublin Core (dct:creator, dct:publisher). Se usa dcat:hadRole en la prov:Attribution para capturar la responsabilidad del Agente con respecto al Recurso. Ver https://w3c.github.io/dxwg/dcat/#qualified-attribution para más ejemplos de uso."@es ;
-  skos:scopeNote "In the context of DCAT 2.0, used to link to an Agent where the nature of the relationship is known but does not match one of the standard Dublin Core properties (dct:creator, dct:publisher). Use dcat:hadRole on the prov:Attribution to capture the responsibility of the Agent with respect to the Resource. See https://w3c.github.io/dxwg/dcat/#qualified-attribution for usage examples."@en ; 
+  skos:scopeNote "In the context of DCAT 2.0, used to link to an Agent where the nature of the relationship is known but does not match one of the standard Dublin Core properties (dct:creator, dct:publisher). Use dcat:hadRole on the prov:Attribution to capture the responsibility of the Agent with respect to the Resource. See https://w3c.github.io/dxwg/dcat/#qualified-attribution for usage examples."@en ;
   skos:scopeNote "Nel contesto di DCAT 2.0, utilizzato per collegarsi a un agente in cui la natura della relazione è nota ma non corrisponde a una delle proprietà Dublin Core standard (dct: creatore, dct: editore). Si usi dcat:hadRole su prov:Attribution per rappresentare la responsabilità dell'Agente in relazione alla Risorsa. Si veda https://w3c.github.io/dxwg/dcat/#qualified-attribution per gli esempi di utilizzo."@it ;
   skos:scopeNote "V kontextu DCAT 2.0, vlastnost se používá pro odkaz na Agenta tam, kde typ vztahu je znám, ale neodpovídá žádné ze standardních vlastností Dublin Core (dct:creator, dct:publisher). Pro reprezentaci vztahu Agenta ke zdroji použijte vlastnost dcat:hadRole na třídě prov:Attribution. Viz  https://w3c.github.io/dxwg/dcat/#qualified-attribution pro příklady užití."@cs ;
 .


### PR DESCRIPTION
This PR is a reminder; we need to update the RDF dcat-external.* in the PR #1303.
At the moment, it defines   `locn:geometry rdfs:range locn:Geometry`  and updates Italian, Spanish, English, Czech usage notes accordingly. It needs updates in case the range changes.

The ttl is manually updated, while the json-ld and rdf are as usual regenerated via JENA starting from the ttl.


