### PR TITLE
replacing  title(s) without namespaces  with dcterms:title in some examples

### DIFF
--- a/dcat/index.html
+++ b/dcat/index.html
@@ -4344,23 +4344,23 @@ mycity-bus:stops-2015-01-01
 <pre>
 ex:budget a dcat:Dataset ;
   dcterms:type &lt;http://inspire.ec.europa.eu/metadata-codelist/ResourceType/series&gt: ;
-  title "Budget data"@en ;
+  dcterms:title "Budget data"@en ;
   dcterms:hasPart ex:budget-2018 ,
     ex:budget-2019 , ex:budget-2020 ;
   .
   
 ex:budget-2018 a dcat:Dataset ;
-  title "Budget data for year 2018"@en ;
+  dcterms:title "Budget data for year 2018"@en ;
   dcterms:isPartOf ex:budget ;
   .
   
 ex:budget-2019 a dcat:Dataset ;
-  title "Budget data for year 2019"@en ;
+  dcterms:title "Budget data for year 2019"@en ;
   dcterms:isPartOf ex:budget ;
   .
   
 ex:budget-2020 a dcat:Dataset ;
-  title "Budget data for year 2020"@en ;
+  dcterms:title "Budget data for year 2020"@en ;
   dcterms:isPartOf ex:budget ;
   .
 </pre>
@@ -4377,20 +4377,20 @@ following the approach described in <a href="#version-types"></a>,
 <pre>
 ex:budget a dcat:Dataset ;
   dcterms:type &lt;http://inspire.ec.europa.eu/metadata-codelist/ResourceType/series&gt: ;
-  title "Budget data"@en ;
+  dcterms:title "Budget data"@en ;
   dcterms:hasPart ex:budget-2018 ,
     ex:budget-2019 , ex:budget-2020 ;
   .
   
 ex:budget-2018 a dcat:Dataset ;
-  title "Budget data for year 2018"@en ;
+  dcterms:title "Budget data for year 2018"@en ;
   dcterms:isPartOf ex:budget ;
   dcterms:issued "2019-01-01"^^xsd:date ;
   adms:next ex:budget-2019 ;
   .
   
 ex:budget-2019 a dcat:Dataset ;
-  title "Budget data for year 2019"@en ;
+  dcterms:title "Budget data for year 2019"@en ;
   dcterms:isPartOf ex:budget ;
   dcterms:issued "2020-01-01"^^xsd:date ;
   adms:prev ex:budget-2018 ;
@@ -4398,7 +4398,7 @@ ex:budget-2019 a dcat:Dataset ;
   .
   
 ex:budget-2020 a dcat:Dataset ;
-  title "Budget data for year 2020"@en ;
+  dcterms:title "Budget data for year 2020"@en ;
   dcterms:isPartOf ex:budget ;
   dcterms:issued "2021-01-01"^^xsd:date ;
   adms:prev ex:budget-2019 ;
@@ -4446,7 +4446,7 @@ ex:budget-2020 a dcat:Dataset ;
 <pre>
 ex:budget a dcat:Dataset ;
   dcterms:type &lt;http://inspire.ec.europa.eu/metadata-codelist/ResourceType/series&gt: ;
-  title "Budget data"@en ;
+  dcterms:title "Budget data"@en ;
   dcterms:hasPart ex:budget-2018-be , ex:budget-2019-be , ex:budget-2020-be ,
     ex:budget-2018-fr , ex:budget-2019-fr , ex:budget-2020-fr , 
     ex:budget-2018-it , ex:budget-2019-it , ex:budget-2020-it ,
@@ -4466,7 +4466,7 @@ ex:budget a dcat:Dataset ;
   .
   
 ex:budget-2018-be a dcat:Dataset ;
-  title "Belgium budget data for year 2018"@en ;
+  dcterms:title "Belgium budget data for year 2018"@en ;
   dcterms:isPartOf ex:budget ;
   dcterms:issued "2019-01-01"^^xsd:date ;
   adms:next ex:budget-2019-be ;
@@ -4482,7 +4482,7 @@ ex:budget-2018-be a dcat:Dataset ;
 ...
   
 ex:budget-2018-fr a dcat:Dataset ;
-  title "France budget data for year 2018"@en ;
+  dcterms:title "France budget data for year 2018"@en ;
   dcterms:isPartOf ex:budget ;
   dcterms:issued "2019-01-01"^^xsd:date ;
   adms:next ex:budget-2019-fr ;
@@ -4498,7 +4498,7 @@ ex:budget-2018-fr a dcat:Dataset ;
 ...
   
 ex:budget-2018-it a dcat:Dataset ;
-  title "Italy budget data for year 2018"@en ;
+  dcterms:title "Italy budget data for year 2018"@en ;
   dcterms:isPartOf ex:budget ;
   dcterms:issued "2019-01-01"^^xsd:date ;
   adms:next ex:budget-2019-it ;


### PR DESCRIPTION
This PR fixes some examples where some dct:title(s) had lost their 'dct:'. It adds 'dcterms:' instead of 'dct:' as in the meanwhile we have decided to used 'dcterms:'.