### PR TITLE
Removing reference to closed issue 1258

### DIFF
--- a/dcat/index.html
+++ b/dcat/index.html
@@ -4165,8 +4165,7 @@ mycity-bus:stops-2015-12-07 a dcat:Dataset ;
 <ul>
 <li><a href="#Property:resource_version"><code>dcat:version</code></a> (equivalent to <a data-cite="?PAV#d4e395"><code>pav:version</code></a> [[?PAV]]), for the version name / identifier;</li>
 <li><a href="#Property:resource_release_date"><code>dcterms:issued</code></a> [[?DCTERMS]], for the version release date;</li>
-<li><p><a href="#Property:resource_version_notes"><code>adms:versionNotes</code></a> [[?VOCAB-ADMS]], for a textual description of the changes, including backward compatibility issues with the previous version of the resource.</p>
-<div class="issue" data-number="1258"></div>    
+<li><p><a href="#Property:resource_version_notes"><code>adms:versionNotes</code></a> [[?VOCAB-ADMS]], for a textual description of the changes, including backward compatibility issues with the previous version of the resource.</p>    
 <div class="issue" data-number="1271"></div>
 </li>
 </ul>


### PR DESCRIPTION
removing the red box for issues 1258 which is closed and redundant as it is already mentioned in the above editors' note.