### PR TITLE
DatasetSeries: adding dcat:inSeries and its inverse, updating the  dataset examples. 

### DIFF
--- a/dcat/index.html
+++ b/dcat/index.html
@@ -4438,6 +4438,10 @@ mycity-bus:stops-2015-01-01
 <aside class="example" id="ex-dataset-series-containment" title="Yearly budget datasets grouped into a series"> 
 <p>In the following example, yearly budget data are grouped into a series. The series is typed as <code>dcat:DatasetSeries</code>, the child datasets are typed as <code>dcat:Dataset</code>. The series and the datasets are linked by using both <code>dcat:hasSeriesMember</code> and <code>dcat:inSeries</code>.</p>
 <pre>
+ex:EUCatalogue a dcat:Catalog ;
+  dcterms:title "European Data Catalogue"@en ;
+  dcat:dataset ex:budget , ex:employment , ex:finance ;
+  .
 
 ex:budget a dcat:DatasetSeries ;
   dcterms:title "Budget data"@en ;

--- a/dcat/index.html
+++ b/dcat/index.html
@@ -2543,6 +2543,9 @@
 <!--			
            <div class="issue" data-number="1307"> </div>
 -->
+           <aside class="note">
+               <p>Property added in DCAT 3.</p>
+           </aside>
             <table class="definition">
                 <thead><tr><th>RDF Property:</th><th><a href="http://www.w3.org/ns/dcat#DatasetSeries">dcat:hasSeriesMember</a></th></tr></thead>
                 <tbody>

--- a/dcat/index.html
+++ b/dcat/index.html
@@ -4432,7 +4432,7 @@ mycity-bus:stops-2015-01-01
 
 <h2>How to specify dataset series</h2>
 
-<p>DCAT makes dataset series first class citizens of data catalogs by minting a new class <a href="#Class:Dataset_Series"><code>dcat:DatasetSeries</code></a>, defined as subclass of <a href="#Class:Dataset"><code>dcat:Dataset</code></a>. The dataset series and the child datasets are linked by using the [[DCTERMS]] property <a href="http://www.w3.org/ns/dcat#DatasetSeries">dcat:hasSeriesMember</a> and/or its inverse <a href="#Property:dataset_in_series"><code title="http://www.w3.org/dcat#inSeries">dcat:inSeries</code></a>. Note that a dataset series can also be the child of another dataset series.</p>
+<p>DCAT makes dataset series first class citizens of data catalogs by minting a new class <a href="#Class:Dataset_Series"><code>dcat:DatasetSeries</code></a>, defined as subclass of <a href="#Class:Dataset"><code>dcat:Dataset</code></a>. The dataset series and the child datasets are linked by using the [[DCTERMS]] property <a href="#Property:dataset_series_has_series_member"><code>dcat:hasSeriesMember</code></a> and/or its inverse <a href="#Property:dataset_in_series"><code>dcat:inSeries</code></a>. Note that a dataset series can also be the child of another dataset series.</p>
   <div class="issue" data-number="1307"> </div>
   
 <aside class="example" id="ex-dataset-series-containment" title="Yearly budget datasets grouped into a series"> 

--- a/dcat/index.html
+++ b/dcat/index.html
@@ -5931,8 +5931,9 @@ ga-courts:jc-wms
 <p>The other sections include only editorial changes.</p>
 </li>
 <li><a href="#Class:Resource"></a> has been updated to include the definition of the properties illustrated in <a href="#dataset-versions"></a>.</li>
+<li><p><a href="#dataset-series"></a> has been revised making dataset series first class citizens of data catalogs and introducing new properties for linking dataset series and datasets (see issues <a href="https://github.com/w3c/dxwg/issues/1272">1272</a> and <a href="https://github.com/w3c/dxwg/issues/1307">1307</a>). In particular, the class <code>dcat:DatasetSeries</code> and property <code>dcat:hasSeriesMember</code> have been minted (see <a href="#Class:Dataset_Series"></a>), the property <code>dcat:inSeries</code> has been added to <a href="#Class:Dataset"></a>.</p>
+</li>
 </ul>
-
 </section>
 	
     <section id="changes-since-20200204">
@@ -5945,7 +5946,7 @@ ga-courts:jc-wms
         <li>
         Section <a href="#dataset-versions"></a> was extended with draft guidelines to deal with version delta (<a href="https://github.com/w3c/dxwg/issues/#89">Issue #89</a>), version release date (<a href="https://github.com/w3c/dxwg/issues/#91">Issue #91</a>),  version identifier (<a href="https://github.com/w3c/dxwg/issues/#92">Issue #92</a>),  version compatibility (<a href="https://github.com/w3c/dxwg/issues/#1258">Issue #1258</a>) and resource status (<a href="https://github.com/w3c/dxwg/issues/#1238">Issue #1238</a>). 
         </li>
-        <li> A new class <a href="#Class:Dataset_Series"><code>dcat:DatasetSeries</code></a> was added (<a href="https://github.com/w3c/dxwg/issues/#1272">Issue #1272</a>). Section <a href="#dataset-series"></a> drafts guidelines on dataset series (<a href="https://github.com/w3c/dxwg/issues/#868">Issue #868</a>) and to show related examples (<a href="https://github.com/w3c/dxwg/issues/#806">Issue #806</a>). 
+        <li> A new section <a href="#dataset-series"></a> was added to draft guidelines on dataset series (<a href="https://github.com/w3c/dxwg/issues/#868">Issue #868</a>) and to show related examples (<a href="https://github.com/w3c/dxwg/issues/#806">Issue #806</a>). 
         </li>    
         </ul>
 

--- a/dcat/index.html
+++ b/dcat/index.html
@@ -2513,19 +2513,25 @@
             </tbody>
         </table>
 
-       <section id="Property:dataset_series_has_part">
-            <h4>Property: has part</h4>
+       <section id="Property:dataset_series_has_series_member">
+            <h4>Property: has series member</h4>
 <!--			
            <div class="issue" data-number="1307"> </div>
 -->
             <table class="definition">
-                <thead><tr><th>RDF Property:</th><th><a href="http://purl.org/dc/terms/hasPart">dcterms:hasPart</a></th></tr></thead>
+                <thead><tr><th>RDF Property:</th><th><a href="http://www.w3.org/ns/dcat#DatasetSeries">dcat:hasSeriesMember</a></th></tr></thead>
                 <tbody>
                 <tr><td class="prop">Definition:</td><td>A child dataset that is part of the dataset series.</td></tr>
-<!--                    
-                <tr><td class="prop">Domain:</td><td><a href="#Class:Catalog"><code>dcat:Catalog</code></a></td></tr>
-                <tr><td class="prop">Range:</td><td><a href="#Class:Resource"><code>dcat:Resource</code></a></td></tr>
+                    
+                <tr><td class="prop">Domain:</td><td><a href="#Class:DatasetSeries"><code>dcat:DatasetSeries</code></a></td></tr>
+<!--                <tr><td class="prop">Range:</td><td><a href="#Class:Dataset"><code>dcat:Dataset</code></a></td></tr>
 -->
+                <tr><td class="prop">Sub-property of:</td>
+                    <td><a href="http://purl.org/dc/terms/hasPart"><code>dcterms:hasPart</code></a></td>
+</tr>
+                <tr><td class="prop">Inverse property of:</td>
+                <td><a href="#Property:dataset_in_series"><code title="http://www.w3.org/dcat#inSeries">dcat:inSeries</code></a></td>
+                </tr>
                 <tr><td class="prop">Usage note:</td><td> Normally, child datasets in dataset series are represented as <code>dcat:Dataset</code>. The use of <code>dcat:Distribution</code> for typing child datasets is however recognized as a possible alternative, whenever it addresses more effectively the requirements of a given application scenario.</td></tr>
                 <!--tr><td class="prop">See also:</td><td>Sub-properties of <code>dcterms:hasPart</code> in particular <a href="#Property:catalog_dataset"><code>dcat:dataset</code></a>, <a href="#Property:catalog_catalog"><code>dcat:catalog</code></a>, <a href="#Property:catalog_service"><code>dcat:service</code></a>. </td></tr-->
                 </tbody>
@@ -4398,16 +4404,16 @@ mycity-bus:stops-2015-01-01
 
 <h2>How to specify dataset series</h2>
 
-<p>DCAT makes dataset series first class citizens of data catalogs by minting a new class <a href="#Class:Dataset_Series"><code>dcat:DatasetSeries</code></a>, defined as subclass of <a href="#Class:Dataset"><code>dcat:Dataset</code></a>. The dataset series and the child datasets are linked by using the [[DCTERMS]] property <a href="#Property:dataset_series_has_part"><code>dcterms:hasPart</code></a> and/or its inverse <a href="#Property:dataset_series_is_part_of"><code>dcterms:isPartOf</code></a>. Note that a dataset series can also be the child of another dataset series.</p>
+<p>DCAT makes dataset series first class citizens of data catalogs by minting a new class <a href="#Class:Dataset_Series"><code>dcat:DatasetSeries</code></a>, defined as subclass of <a href="#Class:Dataset"><code>dcat:Dataset</code></a>. The dataset series and the child datasets are linked by using the [[DCTERMS]] property <a href="http://www.w3.org/ns/dcat#DatasetSeries">dcat:hasSeriesMember</a> and/or its inverse <a href="#Property:dataset_series_is_part_of"><code>dcterms:isPartOf</code></a>. Note that a dataset series can also be the child of another dataset series.</p>
   <div class="issue" data-number="1307"> </div>
   
 <aside class="example" id="ex-dataset-series-containment" title="Yearly budget datasets grouped into a series"> 
-<p>In the following example, yearly budget data are grouped into a series. The series is typed as <code>dcat:DatasetSeries</code>, the child datasets are typed as <code>dcat:Dataset</code>. The series and the datasets are linked by using both <code>dcterms:hasPart</code> and <code>dcterms:isPartOf</code>.</p>
+<p>In the following example, yearly budget data are grouped into a series. The series is typed as <code>dcat:DatasetSeries</code>, the child datasets are typed as <code>dcat:Dataset</code>. The series and the datasets are linked by using both <code>dcat:hasSeriesMember</code> and <code>dcterms:isPartOf</code>.</p>
 <pre>
 
 ex:budget a dcat:DatasetSeries ;
   dcterms:title "Budget data"@en ;
-  dcterms:hasPart ex:budget-2018 ,
+  dcat:hasSeriesMember ex:budget-2018 ,
     ex:budget-2019 , ex:budget-2020 ;
   .
   
@@ -4437,7 +4443,7 @@ ex:budget-2020 a dcat:Dataset ;
 
 ex:budget a dcat:DatasetSeries ;
   dcterms:title "Budget data"@en ;
-  dcterms:hasPart ex:budget-2018 ,
+  dcat:hasSeriesMember ex:budget-2018 ,
     ex:budget-2019 , ex:budget-2020 ;
   .
   
@@ -4513,7 +4519,7 @@ ex:budget-2020 a dcat:Dataset ;
 <pre>
 ex:budget a dcat:DatasetSeries ;
   dcterms:title "Budget data"@en ;
-  dcterms:hasPart ex:budget-2018-be , ex:budget-2019-be , ex:budget-2020-be ,
+  dcat:hasSeriesMember ex:budget-2018-be , ex:budget-2019-be , ex:budget-2020-be ,
     ex:budget-2018-fr , ex:budget-2019-fr , ex:budget-2020-fr , 
     ex:budget-2018-it , ex:budget-2019-it , ex:budget-2020-it ,
     ... ;

--- a/dcat/index.html
+++ b/dcat/index.html
@@ -2222,6 +2222,7 @@
         <p>The following properties are specific to this class:
             <a href="#Property:dataset_distribution">distribution</a>,
             <a href="#Property:dataset_frequency">frequency</a>,
+            <a href="#Property:dataset_in_series">in series</a>
             <a href="#Property:dataset_spatial">spatial/geographic coverage</a>,
             <a href="#Property:dataset_spatial_resolution">spatial resolution</a>,
             <a href="#Property:dataset_temporal">temporal coverage</a>,
@@ -2326,6 +2327,9 @@
         
 <section id="Property:dataset_in_series">
             <h4>Property: in series</h4>
+    <aside class="note">
+        <p>Property added in DCAT 3.</p>
+    </aside>
         <table class="definition">
                 <thead><tr><th>RDF Property:</th><th><a href="http://www.w3.org/ns/dcat#inSeries">dcat:inSeries</a></th></tr></thead>
                 <tbody>
@@ -2338,7 +2342,7 @@
                     <td><a href="http://purl.org/dc/terms/isPartOf"><code>dcterms:isPartOf</code></a></td>
 </tr>
                 <tr><td class="prop">Inverse property of:</td>
-                <td><a href="#Property:dataset_series_has_series_member"><code title="http://www.w3.org/dcat#inSeries">dcat:hasSeriesMember</code></a></td>
+                <td><a href="#Property:dataset_series_has_series_member"><code>dcat:hasSeriesMember</code></a></td>
                 </tr>
                 <tr><td class="prop">Usage note:</td><td> Normally, child datasets in dataset series are represented as <code>dcat:Dataset</code>. The use of <code>dcat:Distribution</code> for typing child datasets is however recognized as a possible alternative, whenever it addresses more effectively the requirements of a given application scenario.</td></tr>
                 <!--tr><td class="prop">See also:</td><td>Sub-properties of <code>dcterms:hasPart</code> in particular <a href="#Property:catalog_dataset"><code>dcat:dataset</code></a>, <a href="#Property:catalog_catalog"><code>dcat:catalog</code></a>, <a href="#Property:catalog_service"><code>dcat:service</code></a>. </td></tr-->
@@ -2551,7 +2555,7 @@
                     <td><a href="http://purl.org/dc/terms/hasPart"><code>dcterms:hasPart</code></a></td>
 </tr>
                 <tr><td class="prop">Inverse property of:</td>
-                <td><a href="#Property:dataset_in_series"><code title="http://www.w3.org/dcat#inSeries">dcat:inSeries</code></a></td>
+                <td><a href="#Property:dataset_in_series"><code>dcat:inSeries</code></a></td>
                 </tr>
                 <tr><td class="prop">Usage note:</td><td> Normally, child datasets in dataset series are represented as <code>dcat:Dataset</code>. The use of <code>dcat:Distribution</code> for typing child datasets is however recognized as a possible alternative, whenever it addresses more effectively the requirements of a given application scenario.</td></tr>
                 <!--tr><td class="prop">See also:</td><td>Sub-properties of <code>dcterms:hasPart</code> in particular <a href="#Property:catalog_dataset"><code>dcat:dataset</code></a>, <a href="#Property:catalog_catalog"><code>dcat:catalog</code></a>, <a href="#Property:catalog_service"><code>dcat:service</code></a>. </td></tr-->

--- a/dcat/index.html
+++ b/dcat/index.html
@@ -2323,7 +2323,28 @@
               Examples showing how <code>dcterms:accrualPeriodicity</code> and <a href="#Property:dataset_temporal_resolution"><code>dcat:temporalResolution</code></a> may be combined are given in <a href="#temporal-properties"></a>.
             </p>
         </section>
+        
+<section id="Property:dataset_in_series">
+            <h4>Property: in series</h4>
+        <table class="definition">
+                <thead><tr><th>RDF Property:</th><th><a href="http://www.w3.org/ns/dcat#inSeries">dcat:inSeries</a></th></tr></thead>
+                <tbody>
+                <tr><td class="prop">Definition:</td><td>A dataset series of which the dataset is part.</td></tr>
+                    
+ <!--                <tr><td class="prop">Domain:</td><td><a href="#Class:Dataset_Series"><code>dcat:DatasetSeries</code></a></td></tr> -->
+               <tr><td class="prop">Range:</td><td><a href="#Class:Dataset_Series"><code>dcat:DatasetSeries</code></a></td></tr>
 
+                <tr><td class="prop">Sub-property of:</td>
+                    <td><a href="http://purl.org/dc/terms/isPartOf"><code>dcterms:isPartOf</code></a></td>
+</tr>
+                <tr><td class="prop">Inverse property of:</td>
+                <td><a href="#Property:dataset_series_has_series_member"><code title="http://www.w3.org/dcat#inSeries">dcat:hasSeriesMember</code></a></td>
+                </tr>
+                <tr><td class="prop">Usage note:</td><td> Normally, child datasets in dataset series are represented as <code>dcat:Dataset</code>. The use of <code>dcat:Distribution</code> for typing child datasets is however recognized as a possible alternative, whenever it addresses more effectively the requirements of a given application scenario.</td></tr>
+                <!--tr><td class="prop">See also:</td><td>Sub-properties of <code>dcterms:hasPart</code> in particular <a href="#Property:catalog_dataset"><code>dcat:dataset</code></a>, <a href="#Property:catalog_catalog"><code>dcat:catalog</code></a>, <a href="#Property:catalog_service"><code>dcat:service</code></a>. </td></tr-->
+                </tbody>
+            </table>
+    </section>
         <section id="Property:dataset_spatial">
             <h4>Property: spatial/geographical coverage</h4>
 
@@ -2468,7 +2489,7 @@
         </aside>
         
         <p>The following property is specific to this class:
-            <a href="#Property:dataset_series_has_part">hasPart</a>.
+            <a href="http://www.w3.org/ns/dcat#DatasetSeries">dcat:hasSeriesMember</a>.
             
         </p>
         <p>The following properties of the super-classes <a href="#Class:Resource"><code>dcat:Resource</code></a> and <a href="#Class:Dataset"><code>dcat:Dataset</code></a>  are also available for use:
@@ -2523,7 +2544,7 @@
                 <tbody>
                 <tr><td class="prop">Definition:</td><td>A child dataset that is part of the dataset series.</td></tr>
                     
-                <tr><td class="prop">Domain:</td><td><a href="#Class:DatasetSeries"><code>dcat:DatasetSeries</code></a></td></tr>
+                <tr><td class="prop">Domain:</td><td><a href="#Class:Dataset_Series"><code>dcat:DatasetSeries</code></a></td></tr>
 <!--                <tr><td class="prop">Range:</td><td><a href="#Class:Dataset"><code>dcat:Dataset</code></a></td></tr>
 -->
                 <tr><td class="prop">Sub-property of:</td>
@@ -4404,11 +4425,11 @@ mycity-bus:stops-2015-01-01
 
 <h2>How to specify dataset series</h2>
 
-<p>DCAT makes dataset series first class citizens of data catalogs by minting a new class <a href="#Class:Dataset_Series"><code>dcat:DatasetSeries</code></a>, defined as subclass of <a href="#Class:Dataset"><code>dcat:Dataset</code></a>. The dataset series and the child datasets are linked by using the [[DCTERMS]] property <a href="http://www.w3.org/ns/dcat#DatasetSeries">dcat:hasSeriesMember</a> and/or its inverse <a href="#Property:dataset_series_is_part_of"><code>dcterms:isPartOf</code></a>. Note that a dataset series can also be the child of another dataset series.</p>
+<p>DCAT makes dataset series first class citizens of data catalogs by minting a new class <a href="#Class:Dataset_Series"><code>dcat:DatasetSeries</code></a>, defined as subclass of <a href="#Class:Dataset"><code>dcat:Dataset</code></a>. The dataset series and the child datasets are linked by using the [[DCTERMS]] property <a href="http://www.w3.org/ns/dcat#DatasetSeries">dcat:hasSeriesMember</a> and/or its inverse <a href="#Property:dataset_in_series"><code title="http://www.w3.org/dcat#inSeries">dcat:inSeries</code></a>. Note that a dataset series can also be the child of another dataset series.</p>
   <div class="issue" data-number="1307"> </div>
   
 <aside class="example" id="ex-dataset-series-containment" title="Yearly budget datasets grouped into a series"> 
-<p>In the following example, yearly budget data are grouped into a series. The series is typed as <code>dcat:DatasetSeries</code>, the child datasets are typed as <code>dcat:Dataset</code>. The series and the datasets are linked by using both <code>dcat:hasSeriesMember</code> and <code>dcterms:isPartOf</code>.</p>
+<p>In the following example, yearly budget data are grouped into a series. The series is typed as <code>dcat:DatasetSeries</code>, the child datasets are typed as <code>dcat:Dataset</code>. The series and the datasets are linked by using both <code>dcat:hasSeriesMember</code> and <code>dcat:inSeries</code>.</p>
 <pre>
 
 ex:budget a dcat:DatasetSeries ;
@@ -4419,17 +4440,17 @@ ex:budget a dcat:DatasetSeries ;
   
 ex:budget-2018 a dcat:Dataset ;
   dcterms:title "Budget data for year 2018"@en ;
-  dcterms:isPartOf ex:budget ;
+  dcat:inSeries ex:budget ;
   .
   
 ex:budget-2019 a dcat:Dataset ;
   dcterms:title "Budget data for year 2019"@en ;
-  dcterms:isPartOf ex:budget ;
+  dcat:inSeries ex:budget ;
   .
   
 ex:budget-2020 a dcat:Dataset ;
   dcterms:title "Budget data for year 2020"@en ;
-  dcterms:isPartOf ex:budget ;
+  dcat:inSeries ex:budget ;
   .
 </pre>
 </aside>
@@ -4449,14 +4470,14 @@ ex:budget a dcat:DatasetSeries ;
   
 ex:budget-2018 a dcat:Dataset ;
   dcterms:title "Budget data for year 2018"@en ;
-  dcterms:isPartOf ex:budget ;
+  dcat:inSeries ex:budget ;
   dcterms:issued "2019-01-01"^^xsd:date ;
   adms:next ex:budget-2019 ;
   .
   
 ex:budget-2019 a dcat:Dataset ;
   dcterms:title "Budget data for year 2019"@en ;
-  dcterms:isPartOf ex:budget ;
+  dcat:inSeries ex:budget ;
   dcterms:issued "2020-01-01"^^xsd:date ;
   adms:prev ex:budget-2018 ;
   adms:next ex:budget-2020 ;
@@ -4464,7 +4485,7 @@ ex:budget-2019 a dcat:Dataset ;
   
 ex:budget-2020 a dcat:Dataset ;
   dcterms:title "Budget data for year 2020"@en ;
-  dcterms:isPartOf ex:budget ;
+  dcat:inSeries ex:budget ;
   dcterms:issued "2021-01-01"^^xsd:date ;
   adms:prev ex:budget-2019 ;
   .
@@ -4539,7 +4560,7 @@ ex:budget a dcat:DatasetSeries ;
   
 ex:budget-2018-be a dcat:Dataset ;
   dcterms:title "Belgium budget data for year 2018"@en ;
-  dcterms:isPartOf ex:budget ;
+  dcat:inSeries ex:budget ;
   dcterms:issued "2019-01-01"^^xsd:date ;
   adms:next ex:budget-2019-be ;
   dcterms:accrualPeriodicity &lt;http://purl.org/cld/freq/annual&gt; ;
@@ -4555,7 +4576,7 @@ ex:budget-2018-be a dcat:Dataset ;
   
 ex:budget-2018-fr a dcat:Dataset ;
   dcterms:title "France budget data for year 2018"@en ;
-  dcterms:isPartOf ex:budget ;
+  dcat:inSeries ex:budget ;
   dcterms:issued "2019-01-01"^^xsd:date ;
   adms:next ex:budget-2019-fr ;
   dcterms:accrualPeriodicity &lt;http://purl.org/cld/freq/annual&gt; ;
@@ -4571,7 +4592,7 @@ ex:budget-2018-fr a dcat:Dataset ;
   
 ex:budget-2018-it a dcat:Dataset ;
   dcterms:title "Italy budget data for year 2018"@en ;
-  dcterms:isPartOf ex:budget ;
+  dcat:inSeries ex:budget ;
   dcterms:issued "2019-01-01"^^xsd:date ;
   adms:next ex:budget-2019-it ;
   dcterms:accrualPeriodicity &lt;http://purl.org/cld/freq/annual&gt; ;
@@ -4601,7 +4622,7 @@ ex:budget-2018-it a dcat:Dataset ;
 
 <ol>
 <li>The dataset series is typed as a <code>dcat:Dataset</code>, whereas its child datasets are typed as <code>dcat:Distribution</code>'s.</li>
-<li>Both the dataset series and its child datasets are typed as a <code>dcat:Dataset</code>'s, and the two are usually linked by using the [[DCTERMS]] properties <code>dcterms:hasPart</code> / <code>dcterms:isPartOf</code>.</li>
+<li>Both the dataset series and its child datasets are typed as a <code>dcat:Dataset</code>'s, and the two are usually linked by using the [[DCTERMS]] properties <code>dcat:hasSeriesMember</code> / <code>dcat:inSeries</code>.</li>
 </ol>
 
 <p>In both cases, the dataset series is sometimes soft-typed by using the [[DCTERMS]] property <code>dcterms:type</code> (e.g., this is the approach used in [[GeoDCAT-AP]], and adopted in [[DCAT-AP-IT]] and [[GeoDCAT-AP-IT]]).</p>


### PR DESCRIPTION
Updating the PR #1292 on dataset series to include the result of the discussion we had in issue #1307 

This  PR replaces `dcterms:isPartOf`  and its inverse `dcterms:hasPart` with `dcat:inSeries` and its inverse `dcat:hasSeriesMember`.

Some people insist on keeping both directions,  and the examples in #1292 are using both `dcterms:isPartOf`  and its inverse `dcterms:hasPart`,  so for the moment,  the PR maintains both directions. 

DIFF with PR #1292 https://services.w3.org/htmldiff?doc1=https%3A%2F%2Fraw.githubusercontent.com%2Fw3c%2Fdxwg%2Fdcat-dataseries-issue1272%2Fdcat%2Findex.html&doc2=https%3A%2F%2Fraw.githubusercontent.com%2Fw3c%2Fdxwg%2Fdcat-dataseries-issue1272UpdatedWithDiscussionOn1307%2Fdcat%2Findex.html

