### PR TITLE
Old attempt to solve  1246 - points 1 and 2

### DIFF
--- a/dcat/index.html
+++ b/dcat/index.html
@@ -2522,6 +2522,7 @@
             <a href="#Property:resource_type">type/genre</a>,
             <a href="#Property:resource_update_date">update/modification date</a>,
             <a href="#Property:resource_qualified_attribution">qualified attribution</a>,
+            <a href="#Property:dataset_distribution">has distribution</a>,
             <a href="#Property:dataset_frequency">frequency</a>,
             <a href="#Property:dataset_spatial">spatial/geographic coverage</a>,
             <a href="#Property:dataset_spatial_resolution">spatial resolution</a>,

--- a/dcat/index.html
+++ b/dcat/index.html
@@ -802,9 +802,10 @@
         <table class="definition">
             <thead><tr><th>RDF Class:</th><th><a href="http://www.w3.org/ns/dcat#Catalog">dcat:Catalog</a></th></tr></thead>
             <tbody>
-            <tr><td class="prop">Definition:</td><td>A curated collection of metadata about resources (e.g., datasets and data services in the context of a data catalog)</td></tr>
+            <tr><td class="prop">Definition:</td><td>A curated collection of metadata about resources.</td></tr>
             <tr><td class="prop">Sub-class of:</td><td><a href="#Class:Dataset"><code>dcat:Dataset</code></a></td></tr>
             <tr><td class="prop">Usage note:</td><td>A Web-based data catalog is typically represented as a single instance of this class.</td></tr>
+            <tr><td class="prop">Usage note:</td><td>Datasets and data services are examples of resources in the context of a data catalog.</td></tr>
             <tr><td class="prop">See also:</td><td> <a href="#Class:Catalog_Record"></a>, <a href="#Class:Dataset"></a></td></tr>
             </tbody>
         </table>
@@ -2521,8 +2522,7 @@
             <a href="#Property:resource_title">title</a>,
             <a href="#Property:resource_type">type/genre</a>,
             <a href="#Property:resource_update_date">update/modification date</a>,
-            <a href="#Property:resource_qualified_attribution">qualified attribution</a>,
-            <a href="#Property:dataset_distribution">has distribution</a>,
+            <a href="#Property:resource_qualified_attribution">qualified attribution</a>. 
             <a href="#Property:dataset_frequency">frequency</a>,
             <a href="#Property:dataset_spatial">spatial/geographic coverage</a>,
             <a href="#Property:dataset_spatial_resolution">spatial resolution</a>,

--- a/dcat/index.html
+++ b/dcat/index.html
@@ -759,14 +759,14 @@
         <p>The following properties are specific to this class:
             <a href="#Property:catalog_catalog_record">catalog record</a>,
             <a href="#Property:catalog_has_part">has part</a>,
-            <a href="#Property:catalog_dataset">dataset</a>,
-            <a href="#Property:catalog_service">service</a>,
-            <a href="#Property:catalog_catalog">catalog</a>,
+            <a href="#Property:catalog_dataset">has dataset</a>,
+            <a href="#Property:catalog_service">has service</a>,
+            <a href="#Property:catalog_catalog">has catalog</a>,
             <a href="#Property:catalog_homepage">homepage</a>,
             <a href="#Property:catalog_themes">themes</a>.
         </p>
         <p>The following properties of the super-class <a href="#Class:Dataset"><code>dcat:Dataset</code></a> are also available for use:
-            <a href="#Property:dataset_distribution">distribution</a>,
+            <a href="#Property:dataset_distribution">has distribution</a>,
             <a href="#Property:dataset_frequency">frequency</a>,
             <a href="#Property:dataset_spatial">spatial/geographic coverage</a>,
             <a href="#Property:dataset_spatial_resolution">spatial resolution</a>,
@@ -867,7 +867,7 @@
         </section>
 
         <section id="Property:catalog_dataset">
-            <h4>Property: dataset</h4>
+            <h4>Property: has dataset</h4>
 
             <table class="definition">
                 <thead><tr><th>RDF Property:</th><th><a href="http://www.w3.org/ns/dcat#dataset">dcat:dataset</a></th></tr></thead>
@@ -881,7 +881,7 @@
         </section>
 
         <section id="Property:catalog_service">
-            <h4>Property: service</h4>
+            <h4>Property: has service</h4>
 
             <aside class="note">
               <p>
@@ -901,7 +901,7 @@
         </section>
 
         <section id="Property:catalog_catalog">
-            <h4>Property: catalog</h4>
+            <h4>Property: has catalog</h4>
 
             <aside class="note">
               <p>
@@ -2223,7 +2223,7 @@
         </aside>
         
         <p>The following properties are specific to this class:
-            <a href="#Property:dataset_distribution">distribution</a>,
+            <a href="#Property:dataset_distribution">has distribution</a>,
             <a href="#Property:dataset_frequency">frequency</a>,
             <a href="#Property:dataset_in_series">in series</a>
             <a href="#Property:dataset_spatial">spatial/geographic coverage</a>,
@@ -2296,7 +2296,7 @@
         </table>
 
         <section id="Property:dataset_distribution">
-            <h4>Property: dataset distribution</h4>
+            <h4>Property: has distribution</h4>
 
             <table class="definition">
                 <thead><tr><th>RDF Property:</th><th><a href="http://www.w3.org/ns/dcat#distribution">dcat:distribution</a></th></tr></thead>
@@ -2521,7 +2521,7 @@
             <a href="#Property:resource_title">title</a>,
             <a href="#Property:resource_type">type/genre</a>,
             <a href="#Property:resource_update_date">update/modification date</a>,
-            <a href="#Property:resource_qualified_attribution">qualified attribution</a>. 
+            <a href="#Property:resource_qualified_attribution">qualified attribution</a>,
             <a href="#Property:dataset_frequency">frequency</a>,
             <a href="#Property:dataset_spatial">spatial/geographic coverage</a>,
             <a href="#Property:dataset_spatial_resolution">spatial resolution</a>,

--- a/dcat/rdf/dcat3.ttl
+++ b/dcat/rdf/dcat3.ttl
@@ -157,7 +157,7 @@
 dcat:Catalog
   a rdfs:Class ;
   a owl:Class ;
-  rdfs:comment "A curated collection of metadata about resources (e.g., datasets and data services in the context of a data catalog)."@en ;
+  rdfs:comment "A curated collection of metadata about resources."@en ;
   rdfs:comment "Una colección curada de metadatos sobre recursos (por ejemplo, conjuntos de datos y servicios de datos en el contexto de un catálogo de datos)."@es ;
   rdfs:comment "Una raccolta curata di metadati sulle risorse (ad es. sui dataset e relativi servizi nel contesto di cataloghi di dati)."@it ;
   rdfs:comment "Une collection élaborée de métadonnées sur les jeux de données"@fr ;
@@ -182,7 +182,7 @@ dcat:Catalog
       owl:allValuesFrom dcat:Resource ;
       owl:onProperty dcterms:hasPart ;
     ] ;
-  skos:definition "A curated collection of metadata about resources (e.g., datasets and data services in the context of a data catalog)."@en ;
+  skos:definition "A curated collection of metadata about resources."@en ;
   skos:definition "Una colección curada de metadatos sobre recursos (por ejemplo, conjuntos de datos y servicios de datos en el contexto de un catálogo de datos)."@es ;
   skos:definition "Una raccolta curata di metadati sulle risorse (ad es. sui dataset e relativi servizi nel contesto di cataloghi di dati)."@it ;
   skos:definition "Une collection élaborée de métadonnées sur les jeux de données."@fr ;
@@ -199,6 +199,7 @@ dcat:Catalog
   skos:scopeNote "Συνήθως, ένας κατάλογος δεδομένων στον Παγκόσμιο Ιστό αναπαρίσταται ως ένα στιγμιότυπο αυτής της κλάσης."@el ;
   skos:scopeNote "通常、ウェブ・ベースのデータ・カタログは、このクラスの1つのインスタンスとして表わされます。"@ja ;
   skos:scopeNote "Et webbaseret datakatalog repræsenteres typisk ved en enkelt instans af denne klasse."@da ;
+  skos:scopeNote "Datasets and data services are examples of resources in the context of a data catalog."@en ;
 .
 dcat:CatalogRecord
   a rdfs:Class ;

--- a/dcat/rdf/dcat3.ttl
+++ b/dcat/rdf/dcat3.ttl
@@ -121,6 +121,7 @@
   dcterms:modified "2019" ;
   dcterms:modified "2020-11-30"^^xsd:date ;
   dcterms:modified "2021-03-09"^^xsd:date ;
+  dcterms:modified "2021-03-25"^^xsd:date ;
   rdfs:comment "DCAT es un vocabulario RDF diseñado para facilitar la interoperabilidad entre catálogos de datos publicados en la Web. Utilizando DCAT para describir datos disponibles en catálogos se aumenta la posibilidad de que sean descubiertos y se permite que las aplicaciones consuman fácilmente los metadatos de varios catálogos."@es ;
   rdfs:comment "DCAT est un vocabulaire développé pour faciliter l'interopérabilité entre les jeux de données publiées sur le Web. En utilisant DCAT pour décrire les jeux de données dans les catalogues de données, les fournisseurs de données augmentent leur découverte et permettent que les applications facilement les métadonnées de plusieurs catalogues. Il permet en plus la publication décentralisée des catalogues et facilitent la recherche fédérée des données entre plusieurs sites. Les métadonnées DCAT aggrégées peuvent servir comme un manifeste pour faciliter la préservation digitale des ressources. DCAT est définie à l'adresse http://www.w3.org/TR/vocab-dcat/. Une quelconque version de ce document normatif et ce vocabulaire est une erreur dans ce vocabulaire."@fr ;
   rdfs:comment "DCAT is an RDF vocabulary designed to facilitate interoperability between data catalogs published on the Web. By using DCAT to describe datasets in data catalogs, publishers increase discoverability and enable applications easily to consume metadata from multiple catalogs. It further enables decentralized publishing of catalogs and facilitates federated dataset search across sites. Aggregated DCAT metadata can serve as a manifest file to facilitate digital preservation. DCAT is defined at http://www.w3.org/TR/vocab-dcat/. Any variance between that normative document and this schema is an error in this schema."@en ;
@@ -640,7 +641,7 @@ dcat:catalog
   rdfs:comment "Un catálogo cuyo contenido es de interés en el contexto del catálogo que está siendo descripto."@es ;
   rdfs:comment "Et katalog hvis indhold er relevant i forhold til det aktuelle katalog."@da ;
   rdfs:domain dcat:Catalog ;
-  rdfs:label "catalog"@en ;
+  rdfs:label "has catalog"@en ;
   rdfs:label "catalogo"@it ;
   rdfs:label "catálogo"@es ;
   rdfs:label "katalog"@cs ;
@@ -768,7 +769,7 @@ dcat:dataset
   rdfs:domain dcat:Catalog ;
   rdfs:isDefinedBy <http://www.w3.org/TR/vocab-dcat/> ;
   rdfs:label "conjunto de datos"@es ;
-  rdfs:label "dataset"@en ;
+  rdfs:label "has dataset"@en ;
   rdfs:label "dataset"@it ;
   rdfs:label "datová sada"@cs ;
   rdfs:label "jeu de données"@fr ;
@@ -808,7 +809,7 @@ dcat:distribution
   rdfs:isDefinedBy <http://www.w3.org/TR/vocab-dcat/> ;
   rdfs:label "distribuce"@cs ;
   rdfs:label "distribución"@es ;
-  rdfs:label "distribution"@en ;
+  rdfs:label "has distribution"@en ;
   rdfs:label "distribution"@fr ;
   rdfs:label "distribuzione"@it ;
   rdfs:label "distribution"@da ;
@@ -1261,7 +1262,7 @@ dcat:service
   rdfs:comment "Un sito o endpoint elencato nel catalogo."@it ;
   rdfs:comment "Et websted eller et endpoint som er opført i kataloget."@da ;
   rdfs:domain dcat:Catalog ;
-  rdfs:label "service"@en ;
+  rdfs:label "has service"@en ;
   rdfs:label "servicio"@es ;
   rdfs:label "servizio"@it ;
   rdfs:label "služba"@cs ;


### PR DESCRIPTION

This PR addresses the first two points  of the issue https://github.com/w3c/dxwg/issues/1246

As for point 1 of the issue,
this PR changes `rdfs:label` for object properties named after the class they range to but with an uncapitalized starting letter. 
 
Relations labels whose  refs:label changed  from “ X “  to “has X” are  
- dcat:dataset  
- dcat:service 
- dcat:catalog 
- dcat:distribution 

Labels for the other properties are not changed as they do not ‘clash' with their range classes.

As for point 2, examples of resources in catalog definition are moved in usage note.


**Still to discuss**
Translations of labels for languages different from English are not provided, I wonder if we want to guess them via automatic translation services, leave them as they are, or ask native-speaking people to provide translations.

We will add new stuff in DCAT 3, so I would suggest planning language revisions of the translation when delivering the last version of DCAT3.
Perhaps we need a separate issue to track translations? 

**TODO (once we have agreed on the changes)**
-To Update other RDF serializations 


