### PR TITLE
Add examples in licensing section

### DIFF
--- a/dcat/config.js
+++ b/dcat/config.js
@@ -210,7 +210,7 @@ var respecConfig = {
             date: "31 May 2012",
             href : "http://patterns.dataincubator.org/book/"
         },
-        "MDR-AR":{
+        "EUV-AR":{
             "href":"https://publications.europa.eu/en/web/eu-vocabularies/at-dataset/-/resource/dataset/access-right",
             "title":"Named Authority List: Access rights",
             "publisher":"Publications Office of the European Union"

--- a/dcat/index.html
+++ b/dcat/index.html
@@ -6259,7 +6259,7 @@ ga-courts:jc-wms
 <li>The introductory text has been revised according to the new scope.</li>
 <li>The section on <a href="https://www.w3.org/TR/2020/WD-vocab-dcat-3-20201217/#version-types">version types</a> (link to previous version) has been removed, and <a href="#version-relationships">a new section</a> has been added to describe how to specify relationships between versions.</li>
 <li>Dropped support to the specification of backward (in)compatibility between versions by using properties <code>owl:backwardCompatibleWith</code> and <code>owl:incompatibleWith</code>, originally included in <a href="#version-info"></a>.</li>
-<li><a href="#versioning-complementary-approaches">A new section</a> has been added at the end to compare the DCAT versioning approach with those used in OWL and [[?DCTERMS]].</li>
+<li><a href="#versioning-complementary-approaches">A new section</a> has been added at the end to compare the DCAT versioning approach with those used in OWL, [[?DCTERMS]], and [[?PROV-O]].</li>
 </ul>
 <p>The other sections include only editorial changes.</p>
 </li>
@@ -6267,6 +6267,8 @@ ga-courts:jc-wms
 <li><p><a href="#dataset-series"></a> has been revised making dataset series first class citizens of data catalogs and introducing new properties for linking dataset series and datasets (see Issues <a href="https://github.com/w3c/dxwg/issues/1272">#1272</a> and <a href="https://github.com/w3c/dxwg/issues/1307">#1307</a>). In particular, the class <code>dcat:DatasetSeries</code> has been minted (see <a href="#Class:Dataset_Series"></a>), the property <code>dcat:inSeries</code> has been added to <a href="#Class:Dataset"></a>.</p>
 </li>
 <li>Added property <a href="#Property:distribution_checksum"><code>spdx:checksum</code></a> to <code>dcat:Distribution</code>, class <a href="#Class:Checksum"><code>spdx:Checksum</code></a>, and properties <a href="#Property:checksum_algorithm"><code>spdx:algorithm</code></a> and <a href="#Property:checksum_checksum_value"><code>spdx:checksumValue</code></a> - see Issue <a href="https://github.com/w3c/dxwg/issues/1287">#1287</a>.</li>
+<li>Added examples to <a href="#license-rights"></a> - see Issues <a href="https://github.com/w3c/dxwg/issues/676">#676</a> and <a href="https://github.com/w3c/dxwg/issues/1333">#1333</a>.</li>
+<li>Replaced [[?DCTERMS]] namespace prefix <code>dct:</code> with <code>dcterms:</code> throughout the document - see Issue <a href="https://github.com/w3c/dxwg/issues/1314">#1314</a>.</li>
 </ul>
 </section>
 	

--- a/dcat/index.html
+++ b/dcat/index.html
@@ -6,7 +6,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
     <script class="remove" src="https://www.w3.org/Tools/respec/respec-w3c" defer></script>
     <script class="remove" src="config.js"></script>
-<!--	
+<!--	 
     <link rel="stylesheet" type="text/css" href="style.css">
     <link rel="stylesheet" type="text/css" href="small.css" media="only all and (max-width: 649px)">
 -->

--- a/dcat/index.html
+++ b/dcat/index.html
@@ -3855,7 +3855,7 @@ ex:InternationalDOIFundation a foaf:Organization ;
 
         <aside class="note">
           <p>
-          Access rights can also be expressed as code lists / taxonomies. Examples include the access rights code list  [[?MDR-AR]] used in [[?DCAT-AP]] and the <a href="http://purl.org/eprint/accessRights/">Eprints Access Rights Vocabulary Encoding Scheme</a>.
+          Access rights can also be expressed as code lists / taxonomies. Examples include the access rights code list  [[?EUV-AR]] used in [[?DCAT-AP]] and the <a href="http://purl.org/eprint/accessRights/">Eprints Access Rights Vocabulary Encoding Scheme</a>.
         </p>
         </aside>
       </li>
@@ -3871,7 +3871,7 @@ ex:InternationalDOIFundation a foaf:Organization ;
     </ol>
 
 <aside class="example" id="ex-license-and-access-rights" title="License and access rights">
-<p>The following example shows a dataset publicly available (with no access restriction) and whose distribution is released by using the Creative Commons Attribution (CC-BY) 4.0 license.</p>
+<p>The following example is about a dataset publicly available (with no access restriction) and whose distribution is released by using a standard license - namely, the Creative Commons Attribution (CC-BY) 4.0 license. Access rights are specified by using the [[?EUV-AR]] code list.</p>
 <pre>
 :ds7890 a dcat:Dataset ;
 # other dataset properties...
@@ -3885,34 +3885,68 @@ ex:InternationalDOIFundation a foaf:Organization ;
 </pre>
 </aside>
 
+<aside class="example" id="ex-rights" title="Non-standard license and access conditions">
+<p>This example illustrates the use of property <code>dcterms:rights</code> for a dataset with very specific usage rules, and not using a standard licence. Here use and access conditions are specified with a textual description, by using property <code>rdfs:label</code> (following the <a href="https://www.dublincore.org/resources/userguide/publishing_metadata/">Dublin Core™ User Guide</a>).</p>
+<p>On how to express the same information in a machine-readable way, see <a href="#ex-odrl-policy"></a>.</p>
+<pre>
+:ds4242 a dcat:Dataset ;
+# other dataset properties...
+  dcat:distribution [ a dcat:Distribution ;
+# other distribution properties...
+    dcterms:rights [ a dcterms:RightsStatement ;
+      rdfs:label """
+	    The data can be read and derivatives can be created, 
+	    but no commercial use of the dataset is allowed. In 
+	    addition, it is a requirement to register before the 
+	    permissions are granted.
+	  """@en
+    ] ;
+  ] ;
+.
+</pre>
+</aside>
+
   <p>Finally, in the particular case when rights are expressed via <a data-cite="?ODRL-VOCAB#term-Policy">ODRL policies</a>, it is recommended to use the <a data-cite="?ODRL-VOCAB#term-hasPolicy"><code>odrl:hasPolicy</code></a> property as the link from the description of the cataloged resource or distribution to the ODRL policy, in addition to the corresponding [[DCTERMS]] property that matches the same ODRL policy type.</p>
   
 <aside class="note">
 <p>The Open Digital Rights Language (ODRL) [[!ODRL-VOCAB]] is a policy expression language that provides a flexible and interoperable information model, vocabulary, and encoding mechanisms for representing statements about usage (i.e. permissions, prohibitions, and obligations) of content and services.</p>
 </aside>
 
+<!--
+  <p>Recommendations on the use of these properties on the different types of resources defined in DCAT are provided in the relevant class descriptions.</p>
+-->
+
 <aside class="example" id="ex-odrl-policy" title="ODRL policy">
-<p>This example shows how to express a dataset policy expressing very specific usage rules. In this case, the dataset can be read and derivatives can be created, but no commercial use of the dataset is allowed. In addition, it is a requirement to register before the permissions are granted.</p>
+<p>This example shows how to use [[ODRL]] to specify in a machine-readable way the use and access conditions in <a href="#ex-rights"></a>.</p>
 <pre>
 :ds4242 a dcat:Dataset ;
-# other dataset properties here...
+# other dataset properties...
   dcat:distribution [ a dcat:Distribution ;
+# other distribution properties...
+    dcterms:rights [ a dcterms:RightsStatement ;
+      rdfs:label """
+	    The data can be read and derivatives can be created, 
+	    but no commercial use of the dataset is allowed. In 
+	    addition, it is a requirement to register before the 
+	    permissions are granted.
+	  """@en
+    ] ;
     odrl:hasPolicy [ a odrl:Policy ;
       odrl:permission [ a odrl:Permission ;
         odrl:action ( &lt;http://www.w3.org/ns/odrl/2/read&gt;
-                      &lt;http://www.w3.org/ns/odrl/2/derive&gt; ) ];
-      odrl:obligation   [ a odrl:Duty ;
-        odrl:action &lt;https://schema.org/RegisterAction&gt; ];
-      odrl:prohibition   [ a odrl:Prohibition ;
-        odrl:action &lt;http://creativecommons.org/ns#CommercialUse&gt; ] ;
+                      &lt;http://www.w3.org/ns/odrl/2/derive&gt; ) 
+      ];
+      odrl:obligation [ a odrl:Duty ;
+        odrl:action &lt;https://schema.org/RegisterAction&gt; 
+      ];
+      odrl:prohibition [ a odrl:Prohibition ;
+        odrl:action &lt;http://creativecommons.org/ns#CommercialUse&gt;
+      ] ;
     ] ;
   ] ;
-] ;
 .
 </pre>
 </aside>
-
-  <p>Recommendations on the use of these properties on the different types of resources defined in DCAT are provided in the relevant class descriptions.</p>
 
 </section>
 

--- a/dcat/index.html
+++ b/dcat/index.html
@@ -3870,10 +3870,46 @@ ex:InternationalDOIFundation a foaf:Organization ;
       </li>
     </ol>
 
+<aside class="example" id="ex-license-and-access-rights" title="License and access rights">
+<p>The following example shows a dataset publicly available (with no access restriction) and whose distribution is released by using the Creative Commons Attribution (CC-BY) 4.0 license.</p>
+<pre>
+:ds7890 a dcat:Dataset ;
+# other dataset properties...
+  dcterms:accessRights 
+    &lt;http://publications.europa.eu/resource/authority/access-right/PUBLIC&gt; ;
+  dcat:distribution [ a dcat:Distribution ;
+# other distribution properties...
+    dcterms:license &lt;https://creativecommons.org/licenses/by/4.0/&gt;
+  ] ;
+.
+</pre>
+</aside>
+
   <p>Finally, in the particular case when rights are expressed via <a data-cite="?ODRL-VOCAB#term-Policy">ODRL policies</a>, it is recommended to use the <a data-cite="?ODRL-VOCAB#term-hasPolicy"><code>odrl:hasPolicy</code></a> property as the link from the description of the cataloged resource or distribution to the ODRL policy, in addition to the corresponding [[DCTERMS]] property that matches the same ODRL policy type.</p>
   
 <aside class="note">
 <p>The Open Digital Rights Language (ODRL) [[!ODRL-VOCAB]] is a policy expression language that provides a flexible and interoperable information model, vocabulary, and encoding mechanisms for representing statements about usage (i.e. permissions, prohibitions, and obligations) of content and services.</p>
+</aside>
+
+<aside class="example" id="ex-odrl-policy" title="ODRL policy">
+<p>This example shows how to express a dataset policy expressing very specific usage rules. In this case, the dataset can be read and derivatives can be created, but no commercial use of the dataset is allowed. In addition, it is a requirement to register before the permissions are granted.</p>
+<pre>
+:ds4242 a dcat:Dataset ;
+# other dataset properties here...
+  dcat:distribution [ a dcat:Distribution ;
+    odrl:hasPolicy [ a odrl:Policy ;
+      odrl:permission [ a odrl:Permission ;
+        odrl:action ( &lt;http://www.w3.org/ns/odrl/2/read&gt;
+                      &lt;http://www.w3.org/ns/odrl/2/derive&gt; ) ];
+      odrl:obligation   [ a odrl:Duty ;
+        odrl:action &lt;https://schema.org/RegisterAction&gt; ];
+      odrl:prohibition   [ a odrl:Prohibition ;
+        odrl:action &lt;http://creativecommons.org/ns#CommercialUse&gt; ] ;
+    ] ;
+  ] ;
+] ;
+.
+</pre>
 </aside>
 
   <p>Recommendations on the use of these properties on the different types of resources defined in DCAT are provided in the relevant class descriptions.</p>
@@ -3916,7 +3952,7 @@ ex:InternationalDOIFundation a foaf:Organization ;
 
 <aside class="example" id="ex-time-series-1" title="15-minute time-series published daily">
 <pre class="nohighlight turtle">
-&lt;ds913&gt;
+:ds913
   a dcat:Dataset ;
   dcterms:accrualPeriodicity &lt;http://purl.org/cld/freq/daily&gt; ;
   dcat:temporalResolution "PT15M"^^xsd:duration ;
@@ -3926,7 +3962,7 @@ ex:InternationalDOIFundation a foaf:Organization ;
 
 <aside class="example" id="ex-time-series-2" title="Hourly data published immediately">
 <pre class="nohighlight turtle">
-&lt;ds782&gt;
+:ds782
   a dcat:Dataset ;
   dcterms:accrualPeriodicity &lt;http://purl.org/cld/freq/continuous&gt; ;
   dcat:temporalResolution "PT1H"^^xsd:duration ;
@@ -3936,7 +3972,7 @@ ex:InternationalDOIFundation a foaf:Organization ;
 
 <aside class="example" id="ex-temporal-coverage-closed-interval" title="Temporal coverage as closed interval">
 <pre class="nohighlight turtle">
-&lt;ds257&gt; a dcat:Dataset ;
+:ds257 a dcat:Dataset ;
   dcterms:temporal [ a dcterms:PeriodOfTime ;
     dcat:startDate "2016-03-04"^^xsd:date ;
     dcat:endDate   "2018-08-05"^^xsd:date ;
@@ -3947,7 +3983,7 @@ ex:InternationalDOIFundation a foaf:Organization ;
 <aside class="example" id="ex-temporal-coverage-closed-proper-interval" title="Temporal coverage as closed interval, using time:ProperInterval">
 <p>The following dataset specification is equivalent to the one in <a href="#ex-temporal-coverage-closed-interval"></a>, but it uses [[OWL-TIME]]:</p>
 <pre class="nohighlight turtle">
-&lt;ds348&gt; a dcat:Dataset ;
+:ds348 a dcat:Dataset ;
   dcterms:temporal [ a dcterms:PeriodOfTime , time:ProperInterval ;
     time:hasBeginning [ a time:Instant ;
       time:inXSDDate "2016-03-04"^^xsd:date ;
@@ -3961,7 +3997,7 @@ ex:InternationalDOIFundation a foaf:Organization ;
 
 <aside class="example" id="ex-temporal-coverage-closed-proper-interval-gyear" title="Temporal coverage as proper interval using gYear">
 <pre class="nohighlight turtle">
-&lt;ds429&gt; a dcat:Dataset ;
+:ds429 a dcat:Dataset ;
   dcterms:temporal [ a dcterms:PeriodOfTime , time:ProperInterval ;
     time:hasBeginning [ a time:Instant ;
       time:inXSDgYear "1914"^^xsd:gYear ;
@@ -3975,7 +4011,7 @@ ex:InternationalDOIFundation a foaf:Organization ;
 
 <aside class="example" id="ex-temporal-coverage-geologic" title="Temporal coverage for a geologic dataset">
 <pre class="nohighlight turtle">
-&lt;ds850&gt; a dcat:Dataset ;
+:ds850 a dcat:Dataset ;
   dcterms:temporal [ a dcterms:PeriodOfTime , time:ProperInterval ;
     time:hasBeginning [ a time:Instant ;
       time:inTimePosition [ a time:TimePosition ;
@@ -3995,7 +4031,7 @@ ex:InternationalDOIFundation a foaf:Organization ;
 
 <aside class="example" id="ex-temporal-coverage-open-end-interval" title="Temporal coverage as open interval (no end date)">
 <pre class="nohighlight turtle">
-&lt;ds127&gt; a dcat:Dataset ;
+:ds127 a dcat:Dataset ;
   dcterms:temporal [ a dcterms:PeriodOfTime ;
     dcat:startDate "2016-03-04"^^xsd:date ;
   ] .
@@ -4004,7 +4040,7 @@ ex:InternationalDOIFundation a foaf:Organization ;
 
 <aside class="example" id="ex-temporal-coverage-open-begin-interval" title="Temporal coverage as open interval (no beginning)">
 <pre class="nohighlight turtle">
-&lt;ds586&gt; a dcat:Dataset ;
+:ds586 a dcat:Dataset ;
   dcterms:temporal [ a dcterms:PeriodOfTime , time:ProperInterval ;
     time:hasEnd [ time:inXSDDate "2018-08-05"^^xsd:date ] ;
   ] .
@@ -4099,27 +4135,27 @@ ex:InternationalDOIFundation a foaf:Organization ;
 <img src="./images/ex-spatial-coverage-centroid-anne-frank-house.png"/>
 <figcaption>Map preview of a spatial coverage specified with a centroid</figcaption>
 </figure>
-<div class="note">
+<aside class="note">
 <p>This point location could be expressed using the [[W3C-BASIC-GEO]] vocabulary. 
 If it is required to provide the <code>w3cgeo:Point</code> formulation, then it should be in addition to, not in place of, a <code>dcat:centroid</code> containing a <abbr title="Well-known Text">WKT</abbr> literal (<a href="http://www.opengis.net/ont/geosparql#wktLiteral"><code title="http://www.opengis.net/ont/geosparql#wktLiteral">geosparql:wktLiteral</code></a> [[GeoSPARQL]]). 
 This ensures interoperability with other DCAT dataset descriptions. 
-For example:
+For example:</p>
 <pre class="nohighlight turtle">
-  &lt;AnneFrank_3&gt; a dcat:Dataset ;
-    dcterms:spatial [
-      a dcterms:Location , w3cgeo:Point ;
-      dcat:centroid "POINT(4.88412 52.37509)"^^geosparql:wktLiteral ;
-      w3cgeo:lat  "52.37509"^^xsd:decimal ;
-      w3cgeo:long "4.88412"^^xsd:decimal ;
-    ] .
-  </pre>
-</div>
+:AnneFrank_3 a dcat:Dataset ;
+  dcterms:spatial [
+    a dcterms:Location , w3cgeo:Point ;
+    dcat:centroid "POINT(4.88412 52.37509)"^^geosparql:wktLiteral ;
+    w3cgeo:lat  "52.37509"^^xsd:decimal ;
+    w3cgeo:long "4.88412"^^xsd:decimal ;
+  ] .
+</pre>
+</aside>
 </aside>
 
 <aside class="example" id="ex-spatial-coverage-bbox" title="Spatial coverage as bounding box">
 <p>The Dutch dataset of postal addresses, with its spatial coverage (Netherlands) specified as a bounding box.</p>
 <pre class="nohighlight turtle">
-&lt;Dutch-postal&gt; a dcat:Dataset ;
+:Dutch-postal a dcat:Dataset ;
   dcterms:title "Adressen"@nl ;
   dcterms:title "Addresses"@en ;
   dcterms:description """INSPIRE Adressen afkomstig uit de basisregistratie Adressen,

--- a/dcat/index.html
+++ b/dcat/index.html
@@ -3812,6 +3812,10 @@ ex:InternationalDOIFundation a foaf:Organization ;
 
     <h2>License and rights statements</h2>
 
+<aside class="ednote">
+<p>The following NOTE should probably be dropped from DCAT3.</p>
+</aside>
+
   <aside class="note">
     <p>
     DCAT 1 handling of license and rights do not appear to satisfy all requirements [[?VOCAB-DCAT-20140116]].
@@ -3870,37 +3874,19 @@ ex:InternationalDOIFundation a foaf:Organization ;
       </li>
     </ol>
 
-<aside class="example" id="ex-license-and-access-rights" title="License and access rights">
-<p>The following example is about a dataset publicly available (with no access restriction) and whose distribution is released by using a standard license - namely, the Creative Commons Attribution (CC-BY) 4.0 license. Access rights are specified by using the [[?EUV-AR]] code list.</p>
+<aside class="example" id="ex-license-and-access-rights" title="License, access rights, and copyright statement">
+<p>The following example is about a dataset publicly available (with no access restriction) and whose distribution is released by using a standard license - namely, the Creative Commons Attribution (CC-BY) 4.0 license. Access rights are specified by using the [[?EUV-AR]] code list. Property <code>dcterms:rights</code> is used for the copyright statement, which is specified with a textual description, by using property <code>rdfs:label</code> (following the <a href="https://www.dublincore.org/resources/userguide/publishing_metadata/">Dublin Core™ User Guide</a>).</p>
 <pre>
 :ds7890 a dcat:Dataset ;
 # other dataset properties...
   dcterms:accessRights 
     &lt;http://publications.europa.eu/resource/authority/access-right/PUBLIC&gt; ;
+  dcterms:rights [ a dcterms:RightsStatement ;
+    rdfs:label "&copy; 2021 ACME Inc."@en
+  ] ;
   dcat:distribution [ a dcat:Distribution ;
 # other distribution properties...
     dcterms:license &lt;https://creativecommons.org/licenses/by/4.0/&gt;
-  ] ;
-.
-</pre>
-</aside>
-
-<aside class="example" id="ex-rights" title="Non-standard license and access conditions">
-<p>This example illustrates the use of property <code>dcterms:rights</code> for a dataset with very specific usage rules, and not using a standard licence. Here use and access conditions are specified with a textual description, by using property <code>rdfs:label</code> (following the <a href="https://www.dublincore.org/resources/userguide/publishing_metadata/">Dublin Core™ User Guide</a>).</p>
-<p>On how to express the same information in a machine-readable way, see <a href="#ex-odrl-policy"></a>.</p>
-<pre>
-:ds4242 a dcat:Dataset ;
-# other dataset properties...
-  dcat:distribution [ a dcat:Distribution ;
-# other distribution properties...
-    dcterms:rights [ a dcterms:RightsStatement ;
-      rdfs:label """
-	    The data can be read and derivatives can be created, 
-	    but no commercial use of the dataset is allowed. In 
-	    addition, it is a requirement to register before the 
-	    permissions are granted.
-	  """@en
-    ] ;
   ] ;
 .
 </pre>
@@ -3917,7 +3903,7 @@ ex:InternationalDOIFundation a foaf:Organization ;
 -->
 
 <aside class="example" id="ex-odrl-policy" title="ODRL policy">
-<p>This example shows how to use [[ODRL]] to specify the use and access conditions in <a href="#ex-rights"></a> in a machine-readable way.</p>
+<p>This example shows how to use [[ODRL]] for a dataset with very specific usage rules. In this case, the data can be read and derivatives can be created, but no commercial use of the dataset is allowed. In addition, it is a requirement to register before the permissions are granted.</p>
 <pre>
 :ds4242 a dcat:Dataset ;
 # other dataset properties...

--- a/dcat/index.html
+++ b/dcat/index.html
@@ -3892,10 +3892,10 @@ ex:InternationalDOIFundation a foaf:Organization ;
 </pre>
 </aside>
 
-  <p>Finally, in the particular case when rights are expressed via <a data-cite="?ODRL-VOCAB#term-Policy">ODRL policies</a>, it is recommended to use the <a data-cite="?ODRL-VOCAB#term-hasPolicy"><code>odrl:hasPolicy</code></a> property as the link from the description of the cataloged resource or distribution to the ODRL policy, in addition to the corresponding [[DCTERMS]] property that matches the same ODRL policy type.</p>
+  <p>Finally, in the particular case when rights are expressed via <a data-cite="ODRL-VOCAB#term-Policy">ODRL policies</a>, it is recommended to use the <a data-cite="ODRL-VOCAB#term-hasPolicy"><code>odrl:hasPolicy</code></a> property as the link from the description of the cataloged resource or distribution to the ODRL policy, in addition to the corresponding [[DCTERMS]] property that matches the same ODRL policy type.</p>
   
 <aside class="note">
-<p>The Open Digital Rights Language (ODRL) [[!ODRL-VOCAB]] is a policy expression language that provides a flexible and interoperable information model, vocabulary, and encoding mechanisms for representing statements about usage (i.e. permissions, prohibitions, and obligations) of content and services.</p>
+<p>The Open Digital Rights Language (ODRL) is a policy expression language that provides a flexible and interoperable information model [[ODRL-MODEL]], vocabulary [[ODRL-VOCAB]], and encoding mechanisms for representing statements about usage (i.e. permissions, prohibitions, and obligations) of content and services.</p>
 </aside>
 
 <!--
@@ -3903,7 +3903,7 @@ ex:InternationalDOIFundation a foaf:Organization ;
 -->
 
 <aside class="example" id="ex-odrl-policy" title="ODRL policy">
-<p>This example shows how to use [[ODRL]] for a dataset with very specific usage rules. In this case, the data can be read and derivatives can be created, but no commercial use of the dataset is allowed. In addition, it is a requirement to register before the permissions are granted.</p>
+<p>This example shows how to use [[ODRL-VOCAB]] for a dataset with very specific usage rules. In this case, the data can be read and derivatives can be created, but no commercial use of the dataset is allowed. In addition, it is a requirement to register before the permissions are granted.</p>
 <pre>
 :ds4242 a dcat:Dataset ;
 # other dataset properties...
@@ -3926,6 +3926,7 @@ ex:InternationalDOIFundation a foaf:Organization ;
   ] ;
 .
 </pre>
+<p>The above example does not explicitly define the ODRL Asset, so assumes the enclosing identified entity is the subject of the policy as per <a data-cite="ODRL-MODEL#policy-has">&sect;&nbsp;<span class="secno">2.2.3 </span>Target Policy Property</a> in [[ODRL-MODEL]]. In addition, the example above follows the ODRL <em>compact policy</em> rules as per <a data-cite="ODRL-MODEL#composition-compact">&sect;&nbsp;<span class="secno">2.7.1 </span>Compact Policy</a> in [[ODRL-MODEL]].</p>
 </aside>
 
 </section>

--- a/dcat/index.html
+++ b/dcat/index.html
@@ -3909,14 +3909,6 @@ ex:InternationalDOIFundation a foaf:Organization ;
 # other dataset properties...
   dcat:distribution [ a dcat:Distribution ;
 # other distribution properties...
-    dcterms:rights [ a dcterms:RightsStatement ;
-      rdfs:label """
-	    The data can be read and derivatives can be created, 
-	    but no commercial use of the dataset is allowed. In 
-	    addition, it is a requirement to register before the 
-	    permissions are granted.
-	  """@en
-    ] ;
     odrl:hasPolicy [ a odrl:Policy ;
       odrl:permission [ a odrl:Permission ;
         odrl:action ( 

--- a/dcat/index.html
+++ b/dcat/index.html
@@ -12,6 +12,8 @@
 -->
 <style>
 table.simple {width:100%;}
+#table-sdo-mapping th:first-child ,
+#table-sdo-mapping td:first-child {text-align:right;}
 </style>	
 </head>
 <body>
@@ -195,7 +197,7 @@ table.simple {width:100%;}
         </section>
         <section class="informative">
           <h3>Non-normative namespaces</h3>
-          <p>Namespaces and prefixes used in examples and guidelines  in the document and not from normative parts of the recommendation are shown in the following table.</p>
+          <p>Namespaces and prefixes used in examples and guidelines in the document and not from normative parts of the recommendation are shown in the following table.</p>
 
           <table id="table-namespaces-examples" class="simple">
             <thead><tr><th>Prefix</th><th>Namespace IRI</th><th>Source</th></tr></thead>
@@ -352,12 +354,12 @@ table.simple {width:100%;}
     <h3>RDF considerations</h3>
       <p id="owl2">
         The DCAT vocabulary is an OWL2 ontology [[?OWL2-OVERVIEW]] formalized using [[?RDF-SCHEMA]].
-        Each class and property in DCAT is denoted by an [[?IRI]].
+        Each class and property in DCAT is denoted by an <abbr title="Internationalized Resource Identifier">IRI</abbr> [[?RFC3987]].
         Locally defined elements are in the namespace <a href="http://www.w3.org/ns/dcat#"><code>http://www.w3.org/ns/dcat#</code></a>.
         Elements are also adopted from several external vocabularies, in particular [[?FOAF]], [[?DCTERMS]] and [[?PROV-O]]
       </p>
       <p id="blankNodes">
-        RDF allows resources to have global identifiers (IRIs) or to be blank nodes.
+        RDF allows resources to have global identifiers (<abbr title="Internationalized Resource Identifiers">IRIs</abbr>) or to be blank nodes.
         Blank nodes can be used to denote resources without explicitly naming them with an IRI.
         They can appear in the subject and object position of a triple [[?RDF11-PRIMER]].
         For example, in many actual DCAT catalogs, distributions are represented as blank nodes nested inside the related dataset description.
@@ -5089,7 +5091,7 @@ ex:budget-2018-it a dcat:Dataset ;
 
 <p>The following table shows the URIs of some of the standards used in the examples included in this document.</p>
 
-<table>
+<table class="simple" id="table-uris-for-standards">
 <thead>
 <tr>
 <th>URI</th>
@@ -5598,161 +5600,161 @@ ex:Test543L
             This alignment of DCAT with schema.org is provisional and non-normative. Feedback is invited in the <a href="https://github.com/w3c/dxwg/issues/251">issue tracker</a>.
         </p-->
 
-        <table>
+        <table class="simple" id="table-sdo-mapping">
             <thead>
             <tr>
-                <th style="text-align: right">DCAT element</th>
-                <th>target element from schema.org</th>
+                <th>DCAT element</th>
+                <th>Target element from schema.org</th>
             </tr>
             </thead>
             <tbody>
             <tr>
-                <td style="text-align: right"><b>dcat:Resource</b></td>
+                <td><b>dcat:Resource</b></td>
                 <td><b>sdo:Thing</b></td>
             </tr>
             <tr>
-                <td style="text-align: right">dcterms:title</td>
+                <td>dcterms:title</td>
                 <td>sdo:name</td>
             </tr>
             <tr>
-                <td style="text-align: right">dcterms:description</td>
+                <td>dcterms:description</td>
                 <td>sdo:description</td>
             </tr>
             <tr>
-                <td style="text-align: right">dcat:keyword <br/>
+                <td>dcat:keyword <br/>
                   <em>dcat:keyword is singular, sdo:keywords is plural</em></td>
                 <td>sdo:keywords</td>
             </tr>
             <tr>
-                <td style="text-align: right">dcat:theme</td>
+                <td>dcat:theme</td>
                 <td>sdo:about</td>
             </tr>
             <tr>
-                <td style="text-align: right">dcterms:identifier</td>
+                <td>dcterms:identifier</td>
                 <td>sdo:identifier</td>
             </tr>
             <tr>
-                <td style="text-align: right">dcterms:type</td>
+                <td>dcterms:type</td>
                 <td>sdo:additionalType</td>
             </tr>
             <tr>
-                <td style="text-align: right">dcterms:issued</td>
+                <td>dcterms:issued</td>
                 <td>sdo:datePublished</td>
             </tr>
             <tr>
-                <td style="text-align: right">dcterms:modified</td>
+                <td>dcterms:modified</td>
                 <td>sdo:dateModified</td>
             </tr>
             <tr>
-                <td style="text-align: right">dcterms:language</td>
+                <td>dcterms:language</td>
                 <td>sdo:inLanguage</td>
             </tr>
             <tr>
-                <td style="text-align: right">dcterms:relation</td>
+                <td>dcterms:relation</td>
                 <td>sdo:isRelatedTo</td>
             </tr>
             <tr>
-                <td style="text-align: right">dcat:landingPage</td>
+                <td>dcat:landingPage</td>
                 <td>sdo:url</td>
             </tr>
             <tr>
-                <td style="text-align: right">dcterms:publisher</td>
+                <td>dcterms:publisher</td>
                 <td>sdo:publisher</td>
             </tr>
             <tr>
-                <td style="text-align: right">dcat:contactPoint</td>
+                <td>dcat:contactPoint</td>
                 <td>sdo:contactPoint</td>
             </tr>
             <tr>
-                <td style="text-align: right"><b>dcat:Catalog</b></td>
+                <td><b>dcat:Catalog</b></td>
                 <td><b>sdo:DataCatalog</b></td>
             </tr>
             <tr>
-                <td style="text-align: right">dcterms:hasPart</td>
+                <td>dcterms:hasPart</td>
                 <td>sdo:hasPart</td>
             </tr>
             <tr>
-                <td style="text-align: right">dcat:dataset</td>
+                <td>dcat:dataset</td>
                 <td>sdo:dataset</td>
             </tr>
             <tr>
-                <td style="text-align: right">dcat:distribution</td>
+                <td>dcat:distribution</td>
                 <td>sdo:distribution</td>
             </tr>
             <tr>
-                <td style="text-align: right"><b>dcat:Dataset</b></td>
+                <td><b>dcat:Dataset</b></td>
                 <td><b>sdo:Dataset</b></td>
             </tr>
             <tr>
-                <td style="text-align: right"><b>dcat:Dataset</b> <br/> <i>dcterms:accrualPeriodicity fixed to <br/> &lt;http://purl.org/cld/freq/continuous&gt;</i></td>
+                <td><b>dcat:Dataset</b> <br/> <i>dcterms:accrualPeriodicity fixed to <br/> &lt;http://purl.org/cld/freq/continuous&gt;</i></td>
                 <td><b>sdo:DataFeed</b></td>
             </tr>
             <tr>
-                <td style="text-align: right">dcterms:spatial</td>
+                <td>dcterms:spatial</td>
                 <td>sdo:spatialCoverage</td>
             </tr>
             <tr>
-                <td style="text-align: right">dcterms:temporal</td>
+                <td>dcterms:temporal</td>
                 <td>sdo:temporalCoverage</td>
             </tr>
             <tr>
-                <td style="text-align: right">dcterms:accrualPeriodicity</td>
+                <td>dcterms:accrualPeriodicity</td>
                 <td>sdo:repeatFrequency</td>
             </tr>
             <tr>
-                <td style="text-align: right">prov:wasGeneratedBy</td>
+                <td>prov:wasGeneratedBy</td>
                 <td>[ owl:inverseOf sdo:result ]</td>
             </tr>
             <tr>
-                <td style="text-align: right"><b>dcat:Distribution</b></td>
+                <td><b>dcat:Distribution</b></td>
                 <td><b>sdo:DataDownload</b></td>
             </tr>
             <tr>
-                <td style="text-align: right">dcterms:format</td>
+                <td>dcterms:format</td>
                 <td>sdo:encodingFormat</td>
             </tr>
             <tr>
-                <td style="text-align: right">dcat:mediaType</td>
+                <td>dcat:mediaType</td>
                 <td>sdo:encodingFormat</td>
             </tr>
             <tr>
-                <td style="text-align: right">dcat:byteSize</td>
+                <td>dcat:byteSize</td>
                 <td>sdo:contentSize</td>
             </tr>
             <tr>
-                <td style="text-align: right">dcat:accessURL</td>
+                <td>dcat:accessURL</td>
                 <td>sdo:contentUrl</td>
             </tr>
             <tr>
-                <td style="text-align: right">dcat:downloadURL</td>
+                <td>dcat:downloadURL</td>
                 <td>sdo:contentUrl</td>
             </tr>
             <tr>
-                <td style="text-align: right">dcterms:license</td>
+                <td>dcterms:license</td>
                 <td>sdo:license</td>
             </tr>
             <tr>
-                <td style="text-align: right"><b>dcat:DataService</b></td>
+                <td><b>dcat:DataService</b></td>
                 <td><b>sdo:WebAPI</b></td>
             </tr>
             <tr>
-                <td style="text-align: right">dcat:endPointURL</td>
+                <td>dcat:endPointURL</td>
                 <td>sdo:url</td>
             </tr>
             <tr>
-                <td style="text-align: right">dcat:endPointDescription</td>
+                <td>dcat:endPointDescription</td>
                 <td>sdo:documentation, sdo:hasOfferCatalog</td>
             </tr>
             <tr>
-                <td style="text-align: right">dcterms:type <br /> <i>in context of a dcat:DataService</i></td>
+                <td>dcterms:type <br /> <i>in context of a dcat:DataService</i></td>
                 <td>sdo:serviceType</td>
             </tr>
             <tr>
-                <td style="text-align: right">dcat:servesDataset</td>
+                <td>dcat:servesDataset</td>
                 <td>sdo:serviceOutput</td>
             </tr>
             <tr>
-                <td style="text-align: right"><b>dcat:Relationship</b></td>
+                <td><b>dcat:Relationship</b></td>
                 <td><b>sdo:Role</b></td>
             </tr>
           </tbody>

--- a/dcat/index.html
+++ b/dcat/index.html
@@ -3916,12 +3916,12 @@ ex:InternationalDOIFundation a foaf:Organization ;
           &lt;http://www.w3.org/ns/odrl/2/derive&gt; 
         ) 
       ];
-      odrl:obligation [ a odrl:Duty ;
-        odrl:action &lt;https://schema.org/RegisterAction&gt; 
-      ];
       odrl:prohibition [ a odrl:Prohibition ;
         odrl:action &lt;http://creativecommons.org/ns#CommercialUse&gt;
       ] ;
+      odrl:obligation [ a odrl:Duty ;
+        odrl:action &lt;https://schema.org/RegisterAction&gt; 
+      ];
     ] ;
   ] ;
 .

--- a/dcat/index.html
+++ b/dcat/index.html
@@ -3917,7 +3917,7 @@ ex:InternationalDOIFundation a foaf:Organization ;
 -->
 
 <aside class="example" id="ex-odrl-policy" title="ODRL policy">
-<p>This example shows how to use [[ODRL]] to specify in a machine-readable way the use and access conditions in <a href="#ex-rights"></a>.</p>
+<p>This example shows how to use [[ODRL]] to specify the use and access conditions in <a href="#ex-rights"></a> in a machine-readable way.</p>
 <pre>
 :ds4242 a dcat:Dataset ;
 # other dataset properties...
@@ -3933,8 +3933,10 @@ ex:InternationalDOIFundation a foaf:Organization ;
     ] ;
     odrl:hasPolicy [ a odrl:Policy ;
       odrl:permission [ a odrl:Permission ;
-        odrl:action ( &lt;http://www.w3.org/ns/odrl/2/read&gt;
-                      &lt;http://www.w3.org/ns/odrl/2/derive&gt; ) 
+        odrl:action ( 
+          &lt;http://www.w3.org/ns/odrl/2/read&gt;
+          &lt;http://www.w3.org/ns/odrl/2/derive&gt; 
+        ) 
       ];
       odrl:obligation [ a odrl:Duty ;
         odrl:action &lt;https://schema.org/RegisterAction&gt; 

--- a/dcat/index.html
+++ b/dcat/index.html
@@ -6,8 +6,10 @@
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
     <script class="remove" src="https://www.w3.org/Tools/respec/respec-w3c" defer></script>
     <script class="remove" src="config.js"></script>
+<!--	
     <link rel="stylesheet" type="text/css" href="style.css">
     <link rel="stylesheet" type="text/css" href="small.css" media="only all and (max-width: 649px)">
+-->	
 </head>
 <body>
 
@@ -163,7 +165,7 @@
           <h3>Normative namespaces</h3>
           <p>Namespaces and prefixes used in normative parts of this recommendation are shown in the following table.</p>
 
-          <table id="table-namespaces">
+          <table id="table-namespaces" class="simple">
             <thead><tr><th>Prefix</th><th>Namespace IRI</th><th>Source</th></tr></thead>
             <tbody>
             <tr><td><code>dc</code></td><td><code>http://purl.org/dc/elements/1.1/</code></td><td>[[DCTERMS]]</td></tr>
@@ -192,7 +194,7 @@
           <h3>Non-normative namespaces</h3>
           <p>Namespaces and prefixes used in examples and guidelines  in the document and not from normative parts of the recommendation are shown in the following table.</p>
 
-          <table id="table-namespaces-examples">
+          <table id="table-namespaces-examples" class="simple">
             <thead><tr><th>Prefix</th><th>Namespace IRI</th><th>Source</th></tr></thead>
             <tbody>
             <tr><td><code>adms</code></td><td><code>https://www.w3.org/ns/adms#</code></td><td>[[?VOCAB-ADMS]]</td></tr>
@@ -799,7 +801,7 @@
             <a href="#Property:resource_qualified_attribution">qualified attribution</a>.
         </p>
 
-        <table class="definition">
+        <table class="def">
             <thead><tr><th>RDF Class:</th><th><a href="http://www.w3.org/ns/dcat#Catalog">dcat:Catalog</a></th></tr></thead>
             <tbody>
             <tr><td class="prop">Definition:</td><td>A curated collection of metadata about resources (e.g., datasets and data services in the context of a data catalog)</td></tr>
@@ -811,7 +813,7 @@
 
         <section id="Property:catalog_homepage">
             <h4>Property: homepage</h4>
-            <table class="definition">
+            <table class="def">
                 <thead><tr><th>RDF Property:</th><th><a href="http://xmlns.com/foaf/0.1/homepage">foaf:homepage</a></th></tr></thead>
                 <tbody>
                 <tr><td class="prop">Definition:</td><td>A homepage of the catalog  (a public Web document usually available in HTML).</td></tr>
@@ -824,7 +826,7 @@
         <section id="Property:catalog_themes">
             <h4>Property: themes</h4>
 
-            <table class="definition">
+            <table class="def">
                 <thead><tr><th>RDF Property:</th><th><a href="http://www.w3.org/ns/dcat#themeTaxonomy">dcat:themeTaxonomy</a></th></tr></thead>
                 <tbody>
                 <tr><td class="prop">Definition:</td><td>A knowledge organization system (KOS) used to classify catalog's datasets and services.</td></tr>
@@ -852,7 +854,7 @@
             </aside>
 
 
-            <table class="definition">
+            <table class="def">
                 <thead><tr><th>RDF Property:</th><th><a href="http://purl.org/dc/terms/hasPart">dcterms:hasPart</a></th></tr></thead>
                 <tbody>
                 <tr><td class="prop">Definition:</td><td>An item that is listed in the catalog.</td></tr>
@@ -869,7 +871,7 @@
         <section id="Property:catalog_dataset">
             <h4>Property: dataset</h4>
 
-            <table class="definition">
+            <table class="def">
                 <thead><tr><th>RDF Property:</th><th><a href="http://www.w3.org/ns/dcat#dataset">dcat:dataset</a></th></tr></thead>
                 <tbody>
                 <tr><td class="prop">Definition:</td><td>A collection of data that is listed in the catalog.</td></tr>
@@ -889,7 +891,7 @@
               </p>
             </aside>
 
-            <table class="definition">
+            <table class="def">
                 <thead><tr><th>RDF Property:</th><th><a href="http://www.w3.org/ns/dcat#service">dcat:service</a></th></tr></thead>
                 <tbody>
                 <tr><td class="prop">Definition:</td><td>A site or end-point that is listed in the catalog.</td></tr>
@@ -909,7 +911,7 @@
               </p>
             </aside>
 
-            <table class="definition">
+            <table class="def">
                 <thead><tr><th>RDF Property:</th><th><a href="http://www.w3.org/ns/dcat#catalog">dcat:catalog</a></th></tr></thead>
                 <tbody>
                 <tr><td class="prop">Definition:</td><td>A catalog whose contents are of interest in the context of this catalog.</td></tr>
@@ -923,7 +925,7 @@
         <section id="Property:catalog_catalog_record">
             <h4>Property: catalog record</h4>
 
-            <table class="definition">
+            <table class="def">
                 <thead><tr><th>RDF Property:</th><th><a href="http://www.w3.org/ns/dcat#record">dcat:record</a></th></tr></thead>
                 <tbody>
                 <tr><td class="prop">Definition:</td><td>A record describing the registration of a single dataset or data service that is part of the catalog.</td></tr>
@@ -989,7 +991,7 @@
             The need to be able to describe the business or project context related to production of a cataloged resource has been identified as a requirement to be satisfied in the revision of DCAT.
         </p-->
 
-        <table class="definition">
+        <table class="def">
             <thead><tr><th>RDF Class:</th><th><a href="http://www.w3.org/ns/dcat#Resource">dcat:Resource</a></th></tr></thead>
             <tbody>
             <tr><td class="prop">Definition:</td><td>Resource published or curated by a single agent.</td></tr>
@@ -1014,7 +1016,7 @@
               </p>
             </aside>
 
-            <table class="definition">
+            <table class="def">
                 <thead><tr><th>RDF Property:</th><th><a href="http://purl.org/dc/terms/accessRights">dcterms:accessRights</a></th></tr></thead>
                 <tbody>
                 <tr><td class="prop">Definition:</td><td>Information about who can access the resource or an indication of its security status.</td></tr>
@@ -1035,7 +1037,7 @@
               </p>
             </aside>
 
-            <table class="definition">
+            <table class="def">
                 <thead><tr><th>RDF Property:</th><th><a href="http://purl.org/dc/terms/conformsTo">dcterms:conformsTo</a></th></tr></thead>
                 <tbody>
                 <tr><td class="prop">Definition:</td><td>An established standard to which the described resource conforms.</td></tr>
@@ -1062,7 +1064,7 @@
               </p>
             </aside>
 
-            <table class="definition">
+            <table class="def">
                 <thead><tr><th>RDF Property:</th><th><a href="http://www.w3.org/ns/dcat#contactPoint">dcat:contactPoint</a></th></tr></thead>
                 <tbody>
                 <tr><td class="prop">Definition:</td><td>Relevant contact information for the cataloged resource. Use of vCard is recommended [[?VCARD-RDF]]. </td></tr>
@@ -1081,7 +1083,7 @@
               </p>
             </aside>
             
-            <table class="definition">
+            <table class="def">
                 <thead><tr><th>RDF Property:</th><th><a href="http://purl.org/dc/terms/creator">dcterms:creator</a></th></tr></thead>
                 <tbody>
                 <tr><td class="prop">Definition:</td><td>The entity responsible for producing the resource.</td></tr>
@@ -1105,7 +1107,7 @@
 
         <section id="Property:resource_description">
             <h4>Property: description</h4>
-            <table class="definition">
+            <table class="def">
                 <thead><tr><th>RDF Property:</th><th><a href="http://purl.org/dc/terms/description">dcterms:description</a></th></tr></thead>
                 <tbody>
                 <tr><td class="prop">Definition:</td><td>A free-text account of the item.</td></tr>
@@ -1117,7 +1119,7 @@
 
         <section id="Property:resource_title">
             <h4>Property: title</h4>
-            <table class="definition">
+            <table class="def">
                 <thead><tr><th>RDF Property:</th><th><a href="http://purl.org/dc/terms/title">dcterms:title</a></th></tr></thead>
                 <tbody>
                 <tr><td class="prop">Definition:</td><td>A name given to the item.</td></tr>
@@ -1128,7 +1130,7 @@
 
         <section id="Property:resource_release_date">
             <h4>Property: release date</h4>
-            <table class="definition">
+            <table class="def">
                 <thead><tr><th>RDF Property:</th><th><a href="http://purl.org/dc/terms/issued">dcterms:issued</a></th></tr></thead>
                 <tbody>
                 <tr><td class="prop">Definition:</td><td>Date of formal issuance (e.g., publication) of the item.</td></tr>
@@ -1143,7 +1145,7 @@
 
         <section id="Property:resource_update_date">
             <h4>Property: update/modification date</h4>
-            <table class="definition">
+            <table class="def">
                 <thead><tr><th>RDF Property:</th><th><a href="http://purl.org/dc/terms/modified">dcterms:modified</a></th></tr></thead>
                 <tbody>
                 <tr><td class="prop">Definition:</td><td>Most recent date on which the item was changed, updated or modified.</td></tr>
@@ -1158,7 +1160,7 @@
 
         <section id="Property:resource_language">
             <h4>Property: language</h4>
-            <table class="definition">
+            <table class="def">
                 <thead><tr><th>RDF Property:</th><th><a href="http://purl.org/dc/terms/language">dcterms:language</a></th></tr></thead>
                 <tbody>
                 <tr><td class="prop">Definition:</td><td>A language of the item. This refers to the natural language used for textual metadata (i.e. titles, descriptions, etc) of a cataloged resource (i.e. dataset or service) or the textual values of a dataset distribution</td></tr>
@@ -1184,7 +1186,7 @@
               </p>
             </aside>
 
-            <table class="definition">
+            <table class="def">
                 <thead><tr><th>RDF Property:</th><th><a href="http://purl.org/dc/terms/publisher">dcterms:publisher</a></th></tr></thead>
                 <tbody>
                 <tr><td class="prop">Definition:</td><td>The entity responsible for making the item available.</td></tr>
@@ -1197,7 +1199,7 @@
 
         <section id="Property:resource_identifier">
             <h4>Property: identifier</h4>
-            <table class="definition">
+            <table class="def">
                 <thead><tr><th>RDF Property:</th><th><a href="http://purl.org/dc/terms/identifier">dcterms:identifier</a></th></tr></thead>
                 <tbody>
                 <tr><td class="prop">Definition:</td><td>A unique identifier of the item.</td></tr>
@@ -1217,7 +1219,7 @@
               </p>
             </aside>
 
-            <table class="definition">
+            <table class="def">
                 <thead><tr><th>RDF Property:</th><th><a href="http://www.w3.org/ns/dcat#theme">dcat:theme</a></th></tr></thead>
                 <tbody>
                 <tr><td class="prop">Definition:</td><td>A main category of the resource. A resource can have multiple themes.</td></tr>
@@ -1239,7 +1241,7 @@
               </p>
             </aside>
 
-            <table class="definition">
+            <table class="def">
               <thead><tr><th>RDF Property:</th><th><a href="http://purl.org/dc/terms/type">dcterms:type</a></th></tr></thead>
               <tbody>
                 <tr><td class="prop">Definition:</td><td>The nature or genre of the resource.</td></tr>
@@ -1268,7 +1270,7 @@
               </p>
             </aside>
 
-            <table class="definition">
+            <table class="def">
                 <thead><tr><th>RDF Property:</th><th><a href="http://purl.org/dc/terms/relation">dcterms:relation</a></th></tr></thead>
                 <tbody>
                 <tr><td class="prop">Definition:</td><td>A resource with an unspecified relationship to the cataloged item.</td></tr>
@@ -1315,7 +1317,7 @@
               </p>
             </aside>
 
-            <table class="definition">
+            <table class="def">
               <thead><tr><th>RDF Property:</th><th><a href="http://www.w3.org/ns/dcat#qualifiedRelation">dcat:qualifiedRelation</a></th></tr></thead>
               <tbody>
               <tr><td class="prop">Definition:</td><td>Link to a description of a relationship with another resource</td></tr>
@@ -1370,7 +1372,7 @@
               </p>
             </aside>
 
-            <table class="definition">
+            <table class="def">
                 <thead><tr><th>RDF Property:</th><th><a href="http://www.w3.org/ns/dcat#keyword">dcat:keyword</a></th></tr></thead>
                 <tbody>
                 <tr><td class="prop">Definition:</td><td>A keyword or tag describing the resource.</td></tr>
@@ -1389,7 +1391,7 @@
               </p>
             </aside>
 
-            <table class="definition">
+            <table class="def">
                 <thead><tr><th>RDF Property:</th><th><a href="http://www.w3.org/ns/dcat#landingPage">dcat:landingPage</a></th></tr></thead>
                 <tbody>
                 <tr><td class="prop">Definition:</td><td>A Web page that can be navigated to in a Web browser to gain access to the catalog, a dataset, its distributions and/or additional information.</td></tr>
@@ -1412,7 +1414,7 @@
               </p>
             </aside>
         
-            <table class="definition">
+            <table class="def">
               <thead><tr><th>RDF Property:</th><th><a data-cite="PROV-O#qualifiedAttribution">prov:qualifiedAttribution</a></th></tr></thead>
               <tbody>
               <tr><td class="prop">Definition:</td><td>Link to an Agent having some form of responsibility for the resource</td></tr>
@@ -1441,7 +1443,7 @@
         <section id="Property:resource_license">
             <h4>Property: license</h4>
 
-            <table class="definition">
+            <table class="def">
                 <thead><tr><th>RDF Property:</th><th><a href="http://purl.org/dc/terms/license">dcterms:license</a></th></tr></thead>
                 <tbody>
                 <tr><td class="prop">Definition:</td><td>A legal document under which the resource is made available.</td></tr>
@@ -1456,7 +1458,7 @@
         <section id="Property:resource_rights">
             <h4>Property: rights</h4>
 
-            <table class="definition">
+            <table class="def">
                 <thead><tr><th>RDF Property:</th><th><a href="http://purl.org/dc/terms/rights">dcterms:rights</a></th></tr></thead>
                 <tbody>
                 <tr><td class="prop">Definition:</td><td>A statement that concerns all rights not addressed with <a href="#Property:resource_license">dcterms:license</a> or <a href="#Property:resource_access_rights">dcterms:accessRights</a>, such as copyright statements.</td></tr>
@@ -1477,7 +1479,7 @@
               </p>
             </aside>
             
-            <table class="definition">
+            <table class="def">
                 <thead><tr><th>RDF Property:</th><th><a data-cite="ODRL-VOCAB#term-hasPolicy">odrl:hasPolicy</a></th></tr></thead>
                 <tbody>
                 <tr><td class="prop">Definition:</td><td>An <abbr title="Open Digital Rights Language">ODRL</abbr> conformant policy expressing the rights associated with the resource.</td></tr>
@@ -1498,7 +1500,7 @@
               </p>
             </aside>
 
-            <table class="definition">
+            <table class="def">
                 <thead><tr><th>RDF Property:</th><th><a href="http://purl.org/dc/terms/isReferencedBy">dcterms:isReferencedBy</a></th></tr></thead>
                 <tbody>
                 <tr><td class="prop">Definition:</td><td>A related resource, such as a publication, that references, cites, or otherwise points to the cataloged resource.</td></tr>
@@ -1522,7 +1524,7 @@
 <p>Property added in DCAT 3.</p>
 </aside>
 
-<table class="definition">
+<table class="def">
 <thead>
 <tr>
 <th>RDF Property:</th>
@@ -1578,7 +1580,7 @@
 <p>Property added in DCAT 3.</p>
 </aside>
 
-<table class="definition">
+<table class="def">
 <thead>
 <tr>
 <th>RDF Property:</th>
@@ -1637,7 +1639,7 @@
 <p>Property added in DCAT 3.</p>
 </aside>
 
-<table class="definition">
+<table class="def">
 <thead>
 <tr>
 <th>RDF Property:</th>
@@ -1696,7 +1698,7 @@
 <p>Property added in DCAT 3.</p>
 </aside>
 
-<table class="definition">
+<table class="def">
 <thead>
 <tr>
 <th>RDF Property:</th>
@@ -1756,7 +1758,7 @@
 <p>Property added in DCAT 3.</p>
 </aside>
 
-<table class="definition">
+<table class="def">
 <thead>
 <tr>
 <th>RDF Property:</th>
@@ -1810,7 +1812,7 @@
 <p>Property added in DCAT 3.</p>
 </aside>
 
-<table class="definition">
+<table class="def">
 <thead>
 <tr>
 <th>RDF Property:</th>
@@ -1864,7 +1866,7 @@
 <p>Property added in DCAT 3.</p>
 </aside>
 
-<table class="definition">
+<table class="def">
 <thead>
 <tr>
 <th>RDF Property:</th>
@@ -1922,7 +1924,7 @@
 <p>Property added in DCAT 3.</p>
 </aside>
 
-<table class="definition">
+<table class="def">
 <thead>
 <tr>
 <th>RDF Property:</th>
@@ -1977,7 +1979,7 @@
 <p>Property added in DCAT 3.</p>
 </aside>
 
-<table class="definition">
+<table class="def">
 <thead>
 <tr>
 <th>RDF Property:</th>
@@ -2028,7 +2030,7 @@
 <p>Property added in DCAT 3.</p>
 </aside>
 
-<table class="definition">
+<table class="def">
 <thead>
 <tr>
 <th>RDF Property:</th>
@@ -2092,7 +2094,7 @@
             The need to be able to link a metadata record to its original source has been identified as a requirement to be satisfied in the revision of DCAT.
         </p-->
 
-        <table class="definition">
+        <table class="def">
             <thead><tr><th>RDF Class:</th><th><a href="http://www.w3.org/ns/dcat#CatalogRecord">dcat:CatalogRecord</a></th></tr></thead>
             <tbody>
             <tr><td class="prop">Definition:</td><td>A record in a catalog, describing the registration of a single <a href="#Class:Resource"><code>dcat:Resource</code></a>.</td></tr>
@@ -2115,7 +2117,7 @@
 
         <section id="Property:record_title">
             <h4>Property: title</h4>
-            <table class="definition">
+            <table class="def">
                 <thead><tr><th>RDF Property:</th><th><a href="http://purl.org/dc/terms/title">dcterms:title</a></th></tr></thead>
                 <tbody>
                 <tr><td class="prop">Definition:</td><td>A name given to the record.</td></tr>
@@ -2126,7 +2128,7 @@
 
         <section id="Property:record_description">
             <h4>Property: description</h4>
-            <table class="definition">
+            <table class="def">
                 <thead><tr><th>RDF Property:</th><th><a href="http://purl.org/dc/terms/description">dcterms:description</a></th></tr></thead>
                 <tbody>
                 <tr><td class="prop">Definition:</td><td>A free-text account of the record.</td></tr>
@@ -2137,7 +2139,7 @@
 
         <section id="Property:record_listing_date">
             <h4>Property: listing date</h4>
-            <table class="definition">
+            <table class="def">
                 <thead><tr><th>RDF Property:</th><th><a href="http://purl.org/dc/terms/issued">dcterms:issued</a></th></tr></thead>
                 <tbody>
                 <tr><td class="prop">Definition:</td><td>The date of listing (i.e. formal recording) of the corresponding dataset or service in the catalog.</td></tr>
@@ -2152,7 +2154,7 @@
 
         <section id="Property:record_update_date">
             <h4>Property: update/modification date</h4>
-            <table class="definition">
+            <table class="def">
                 <thead><tr><th>RDF Property:</th><th><a href="http://purl.org/dc/terms/modified">dcterms:modified</a></th></tr></thead>
                 <tbody>
                 <tr><td class="prop">Definition:</td><td>Most recent date on which the catalog entry was changed, updated or modified.</td></tr>
@@ -2168,7 +2170,7 @@
         <section id="Property:record_primary_topic">
             <h4>Property: primary topic</h4>
 
-            <table class="definition">
+            <table class="def">
                 <thead><tr><th>RDF Property:</th><th><a href="http://xmlns.com/foaf/0.1/primaryTopic">foaf:primaryTopic</a></th></tr></thead>
                 <tbody>
                 <tr><td class="prop">Definition:</td><td>The  <a href="#Class:Resource"><code>dcat:Resource</code></a> (dataset or service) described in the record.</td></tr>
@@ -2187,7 +2189,7 @@
               </p>
             </aside>
 
-            <table class="definition">
+            <table class="def">
                 <thead><tr><th>RDF Property:</th><th><a href="http://purl.org/dc/terms/conformsTo">dcterms:conformsTo</a></th></tr></thead>
                 <tbody>
                 <tr><td class="prop">Definition:</td><td>An established standard to which the described resource conforms.</td></tr>
@@ -2284,7 +2286,7 @@
             The need to be able to provide usage notes for a dataset or distribution has been identified as a requirement to be satisfied in the revision of DCAT.
         </p-->
 
-        <table class="definition">
+        <table class="def">
             <thead><tr><th>RDF Class:</th><th><a href="http://www.w3.org/ns/dcat#Dataset">dcat:Dataset</a></th></tr></thead>
             <tbody>
             <tr><td class="prop">Definition:</td><td>A collection of data, published or curated by a single agent, and available for access or download in one or more representations.</td></tr>
@@ -2298,7 +2300,7 @@
         <section id="Property:dataset_distribution">
             <h4>Property: dataset distribution</h4>
 
-            <table class="definition">
+            <table class="def">
                 <thead><tr><th>RDF Property:</th><th><a href="http://www.w3.org/ns/dcat#distribution">dcat:distribution</a></th></tr></thead>
                 <tbody>
                 <tr><td class="prop">Definition:</td><td>An available distribution of the dataset.</td></tr>
@@ -2311,7 +2313,7 @@
 
         <section id="Property:dataset_frequency">
             <h4>Property: frequency</h4>
-            <table class="definition">
+            <table class="def">
                 <thead><tr><th>RDF Property:</th><th><a href="http://purl.org/dc/terms/accrualPeriodicity">dcterms:accrualPeriodicity</a></th></tr></thead>
                 <tbody>
                 <tr><td class="prop">Definition:</td><td>The frequency at which dataset is published.</td></tr>
@@ -2333,7 +2335,7 @@
     <aside class="note">
         <p>Property added in DCAT 3.</p>
     </aside>
-        <table class="definition">
+        <table class="def">
                 <thead><tr><th>RDF Property:</th><th><a href="http://www.w3.org/ns/dcat#inSeries">dcat:inSeries</a></th></tr></thead>
                 <tbody>
                 <tr><td class="prop">Definition:</td><td>A dataset series of which the dataset is part.</td></tr>
@@ -2363,7 +2365,7 @@
                 The need to be able to describe the spatial coverage of a dataset as a geometry has been identified as a requirement to be satisfied in the revision of DCAT.
             </p-->
 
-            <table class="definition">
+            <table class="def">
                 <thead><tr><th>RDF Property:</th><th><a href="http://purl.org/dc/terms/spatial">dcterms:spatial</a></th></tr></thead>
                 <tbody>
                 <tr><td class="prop">Definition:</td><td>The geographical area covered by the dataset.</td></tr>
@@ -2386,7 +2388,7 @@
               </p>
             </aside>
 
-            <table class="definition">
+            <table class="def">
                 <thead><tr><th>RDF Property:</th><th><a href="http://www.w3.org/ns/dcat#spatialResolutionInMeters">dcat:spatialResolutionInMeters</a></th></tr></thead>
                 <tbody>
                 <tr><td class="prop">Definition:</td><td>Minimum spatial separation resolvable in a dataset, measured in meters.</td></tr>
@@ -2404,7 +2406,7 @@
         <section id="Property:dataset_temporal">
             <h4>Property: temporal coverage</h4>
 
-            <table class="definition">
+            <table class="def">
                 <thead><tr><th>RDF Property:</th><th><a href="http://purl.org/dc/terms/temporal">dcterms:temporal</a></th></tr></thead>
                 <tbody>
                 <tr><td class="prop">Definition:</td><td>The temporal period that the dataset covers.</td></tr>
@@ -2428,7 +2430,7 @@
               </p>
             </aside>
 
-            <table class="definition">
+            <table class="def">
                 <thead><tr><th>RDF Property:</th><th><a href="http://www.w3.org/ns/dcat#temporalResolution">dcat:temporalResolution</a></th></tr></thead>
                 <tbody>
                 <tr><td class="prop">Definition:</td><td>Minimum time period resolvable in the dataset.</td></tr>
@@ -2455,7 +2457,7 @@
               </p>
             </aside>
 
-            <table class="definition">
+            <table class="def">
                 <thead><tr><th>RDF Property:</th><th><a data-cite="PROV-O#wasGeneratedBy">prov:wasGeneratedBy</a></th></tr></thead>
                 <tbody>
                 <tr><td class="prop">Definition:</td><td>An activity that generated, or provides the business context for, the creation of the dataset.</td></tr>
@@ -2531,7 +2533,7 @@
         </p>
         <div class="issue" title="Any other properties to mention in this class ?" data-number="1308"></div>
     
-        <table class="definition">
+        <table class="def">
             <thead><tr><th>RDF Class:</th><th><a href="http://www.w3.org/ns/dcat#DatasetSeries">dcat:DatasetSeries</a></th></tr></thead>
             <tbody>
             <tr><td class="prop">Definition:</td><td>A collection of datasets that are published separately, but share some common characteristics that groups them. <!--, and could also be made available as a single dataset.--></td></tr>
@@ -2547,7 +2549,7 @@
            <aside class="note">
                <p>Property added in DCAT 3.</p>
            </aside>
-            <table class="definition">
+            <table class="def">
                 <thead><tr><th>RDF Property:</th><th><a href="http://www.w3.org/ns/dcat#seriesMember">dcat:seriesMember</a></th></tr></thead>
                 <tbody>
                 <tr><td class="prop">Definition:</td><td>A child dataset that is part of the dataset series.</td></tr>
@@ -2593,7 +2595,7 @@
             <a href="#Property:distribution_update_date">update/modification date</a>.
         </p>
 
-        <table class="definition">
+        <table class="def">
             <thead><tr><th>RDF class:</th><th><a href="http://www.w3.org/ns/dcat#Distribution">dcat:Distribution</a></th></tr></thead>
             <tbody>
             <tr><td class="prop">Definition:</td><td>A specific representation of a dataset. A dataset might be available in multiple serializations that may differ in various ways, including natural language, media-type or format, schematic organization, temporal and spatial resolution, level of detail or profiles (which might specify any or all of the above). </td></tr>
@@ -2626,7 +2628,7 @@
 
         <section id="Property:distribution_title">
             <h4>Property: title</h4>
-            <table class="definition">
+            <table class="def">
                 <thead><tr><th>RDF Property:</th><th><a href="http://purl.org/dc/terms/title">dcterms:title</a></th></tr></thead>
                 <tbody>
                 <tr><td class="prop">Definition:</td><td>A name given to the distribution.</td></tr>
@@ -2637,7 +2639,7 @@
 
         <section id="Property:distribution_description">
             <h4>Property: description</h4>
-            <table class="definition">
+            <table class="def">
                 <thead><tr><th>RDF Property:</th><th><a href="http://purl.org/dc/terms/description">dcterms:description</a></th></tr></thead>
                 <tbody>
                 <tr><td class="prop">Definition:</td><td>A free-text account of the distribution.</td></tr>
@@ -2648,7 +2650,7 @@
 
         <section id="Property:distribution_release_date">
             <h4>Property: release date</h4>
-            <table class="definition">
+            <table class="def">
                 <thead><tr><th>RDF Property:</th><th><a href="http://purl.org/dc/terms/issued">dcterms:issued</a></th></tr></thead>
                 <tbody>
                 <tr><td class="prop">Definition:</td><td>Date of formal issuance (e.g., publication) of the distribution.</td></tr>
@@ -2663,7 +2665,7 @@
 
         <section id="Property:distribution_update_date">
             <h4>Property: update/modification date</h4>
-            <table class="definition">
+            <table class="def">
                 <thead><tr><th>RDF Property:</th><th><a href="http://purl.org/dc/terms/modified">dcterms:modified</a></th></tr></thead>
                 <tbody>
                 <tr><td class="prop">Definition:</td><td>Most recent date on which the distribution was changed, updated or modified.</td></tr>
@@ -2677,7 +2679,7 @@
         <section id="Property:distribution_license">
             <h4>Property: license</h4>
 
-            <table class="definition">
+            <table class="def">
                 <thead><tr><th>RDF Property:</th><th><a href="http://purl.org/dc/terms/license">dcterms:license</a></th></tr></thead>
                 <tbody>
                 <tr><td class="prop">Definition:</td><td>A legal document under which the distribution is made available.</td></tr>
@@ -2693,7 +2695,7 @@
         <section id="Property:distribution_access_rights">
             <h4>Property: access rights</h4>
 
-            <table class="definition">
+            <table class="def">
                 <thead><tr><th>RDF Property:</th><th><a href="http://purl.org/dc/terms/accessRights">dcterms:accessRights</a></th></tr></thead>
                 <tbody>
                 <tr><td class="prop">Definition:</td><td>A rights statement that concerns how the distribution is accessed.</td></tr>
@@ -2707,7 +2709,7 @@
         <section id="Property:distribution_rights">
             <h4>Property: rights</h4>
 
-            <table class="definition">
+            <table class="def">
                 <thead><tr><th>RDF Property:</th><th><a href="http://purl.org/dc/terms/rights">dcterms:rights</a></th></tr></thead>
                 <tbody>
                 <tr><td class="prop">Definition:</td><td>Information about rights held in and over the distribution.</td></tr>
@@ -2731,7 +2733,7 @@
               </p>
             </aside>
         
-            <table class="definition">
+            <table class="def">
                 <thead><tr><th>RDF Property:</th><th><a href="https://www.w3.org/TR/odrl-vocab/#term-hasPolicy">odrl:hasPolicy</a></th></tr></thead>
                 <tbody>
                 <tr><td class="prop">Definition:</td><td>An ODRL conformant policy expressing the rights associated with the distribution.</td></tr>
@@ -2750,7 +2752,7 @@
                 The granularity of <code>dcat:accessURL</code> is being re-considered to provide different usages for list and item endpoints as well as supporting the declaration of different profiles (for list results and data payload).
             </p-->
 
-            <table class="definition">
+            <table class="def">
                 <thead><tr><th>RDF Property:</th><th><a href="http://www.w3.org/ns/dcat#accessURL">dcat:accessURL</a></th></tr></thead>
                 <tbody>
                 <tr><td class="prop">Definition:</td><td>A URL of the resource that gives access to a distribution of the dataset. E.g. landing page, feed, SPARQL endpoint.</td></tr>
@@ -2779,7 +2781,7 @@
               </p>
             </aside>
 
-            <table class="definition">
+            <table class="def">
                 <thead><tr><th>RDF Property:</th><th><a href="http://www.w3.org/ns/dcat#accessService">dcat:accessService</a></th></tr></thead>
                 <tbody>
                 <tr><td class="prop">Definition:</td><td>A data service that gives access to the distribution of the dataset</td></tr>
@@ -2793,7 +2795,7 @@
         <section id="Property:distribution_download_url">
             <h4>Property: download URL</h4>
 
-            <table class="definition">
+            <table class="def">
                 <thead><tr><th>RDF Property:</th><th><a href="http://www.w3.org/ns/dcat#downloadURL">dcat:downloadURL</a></th></tr></thead>
                 <tbody>
                 <tr><td class="prop">Definition:</td><td>The URL of the downloadable file in a given format. E.g. CSV file or RDF file. The format is indicated by the distribution's <code>dcterms:format</code> and/or <code>dcat:mediaType</code></td></tr>
@@ -2812,7 +2814,7 @@
                 The axiomatization of <code>dcat:byteSize</code> is being re-evaluated as part of the revision of DCAT.
             </p-->
 
-            <table class="definition">
+            <table class="def">
                 <thead><tr><th>RDF Property:</th><th><a href="http://www.w3.org/ns/dcat#size">dcat:byteSize</a></th></tr></thead>
                 <tbody>
                 <tr><td class="prop">Definition:</td><td>The size of a distribution in bytes.</td></tr>
@@ -2832,7 +2834,7 @@
               </p>
             </aside>
 
-            <table class="definition">
+            <table class="def">
                 <thead><tr><th>RDF Property:</th><th><a href="http://www.w3.org/ns/dcat#spatialResolutionInMeters">dcat:spatialResolutionInMeters</a></th></tr></thead>
                 <tbody>
                   <tr><td class="prop">Definition:</td><td>The minimum spatial separation resolvable in a dataset distribution, measured in meters.</td></tr>
@@ -2858,7 +2860,7 @@
             </aside>
 
 
-            <table class="definition">
+            <table class="def">
                 <thead><tr><th>RDF Property:</th><th><a href="http://www.w3.org/ns/dcat#temporalResolution">dcat:temporalResolution</a></th></tr></thead>
                 <tbody>
                 <tr><td class="prop">Definition:</td><td>Minimum time period resolvable in the dataset distribution.</td></tr>
@@ -2882,7 +2884,7 @@
               </p>
             </aside>
 
-            <table class="definition">
+            <table class="def">
                 <thead><tr><th>RDF Property:</th><th><a href="http://purl.org/dc/terms/conformsTo">dcterms:conformsTo</a></th></tr></thead>
                 <tbody>
                 <tr><td class="prop">Definition:</td><td>An established standard to which the distribution conforms.</td></tr>
@@ -2908,7 +2910,7 @@
               </p>
             </aside>
 
-            <table class="definition">
+            <table class="def">
                 <thead><tr><th>RDF Property:</th><th><a href="http://www.w3.org/ns/dcat#mediaType">dcat:mediaType</a></th></tr></thead>
                 <tbody>
                 <tr><td class="prop">Definition:</td><td>The media type of the distribution as defined by IANA [[!IANA-MEDIA-TYPES]].</td></tr>
@@ -2924,7 +2926,7 @@
         <section id="Property:distribution_format">
             <h4>Property: format</h4>
 
-            <table class="definition">
+            <table class="def">
                 <thead><tr><th>RDF Property:</th><th><a href="http://purl.org/dc/terms/format">dcterms:format</a></th></tr></thead>
                 <tbody>
                 <tr><td class="prop">Definition:</td><td>The file format of the distribution.</td></tr>
@@ -2944,7 +2946,7 @@
               </p>
             </aside>
 
-            <table class="definition">
+            <table class="def">
                 <thead><tr><th>RDF Property:</th><th><a href="http://www.w3.org/ns/dcat#compressFormat">dcat:compressFormat</a></th></tr></thead>
                 <tbody>
                 <tr><td class="prop">Definition:</td><td>The compression format of the distribution in which the data is contained in a compressed form, e.g. to reduce the size of the downloadable file.</td></tr>
@@ -2967,7 +2969,7 @@
               </p>
             </aside>
 
-            <table class="definition">
+            <table class="def">
                 <thead><tr><th>RDF Property:</th><th><a href="http://www.w3.org/ns/dcat#packageFormat">dcat:packageFormat</a></th></tr></thead>
                 <tbody>
                 <tr><td class="prop">Definition:</td><td>The package format of the distribution in which one or more data files are grouped together, e.g. to enable a set of related files to be downloaded together.</td></tr>
@@ -2990,7 +2992,7 @@
 <p>Property added in DCAT 3.</p>
 </aside>
 
-<table class="definition">
+<table class="def">
 <thead>
 <tr>
 <th>RDF Property:</th>
@@ -3068,7 +3070,7 @@
         </p>
 
 
-        <table class="definition">
+        <table class="def">
             <thead><tr><th>RDF Class:</th><th><a href="http://www.w3.org/ns/dcat#DataService">dcat:DataService</a></th></tr></thead>
             <tbody>
             <tr><td class="prop">Definition:</td><td>A collection of operations that provides access to one or more datasets or data processing functions.</td></tr>
@@ -3083,7 +3085,7 @@
 
         <section id="Property:data_service_endpoint_url">
             <h4>Property: endpoint URL</h4>
-            <table class="definition">
+            <table class="def">
                 <thead><tr><th>RDF Property:</th><th><a href="http://www.w3.org/ns/dcat#endpointURL"><code>dcat:endpointURL</code></a></th></tr></thead>
                 <tbody>
                 <tr><td class="prop">Definition:</td><td>The root location or primary endpoint of the service (a Web-resolvable IRI).</td></tr>
@@ -3095,7 +3097,7 @@
 
         <section id="Property:data_service_endpoint_description">
             <h4>Property: endpoint description</h4>
-            <table class="definition">
+            <table class="def">
                 <thead><tr><th>RDF Property:</th><th><a href="http://www.w3.org/ns/dcat#endpointDescription">dcat:endpointDescription</a></th></tr></thead>
                 <tbody>
                 <tr><td class="prop">Definition:</td><td>A description of the services available via the end-points, including their operations, parameters etc.</td></tr>
@@ -3109,7 +3111,7 @@
 <!--
         <section id="Property:data_service_license">
             <h4>Property: license</h4>
-            <table class="definition">
+            <table class="def">
                 <thead><tr><th>RDF Property:</th><th><a href="http://purl.org/dc/terms/license">dcterms:license</a></th></tr></thead>
                 <tbody>
                 <tr><td class="prop">Definition:</td><td>A legal document under which the service is made available.</td></tr>
@@ -3121,7 +3123,7 @@
 
         <section id="Property:data_service_access_rights">
             <h4>Property: access rights</h4>
-            <table class="definition">
+            <table class="def">
                 <thead><tr><th>RDF Property:</th><th><a href="http://purl.org/dc/terms/accessRights">dcterms:accessRights</a></th></tr></thead>
                 <tbody>
                 <tr><td class="prop">Definition:</td><td>Information about who can access the resource or an indication of its security status.</td></tr>
@@ -3133,7 +3135,7 @@
 -->
         <section id="Property:data_service_serves_dataset">
             <h4>Property: serves dataset</h4>
-            <table class="definition">
+            <table class="def">
                 <thead><tr><th>RDF Property:</th><th><a href="http://www.w3.org/ns/dcat#servesdataset">dcat:servesDataset</a></th></tr></thead>
                 <tbody>
                 <tr><td class="prop">Definition:</td><td>A collection of data that this data service can distribute.</td></tr>
@@ -3146,7 +3148,7 @@
 
     <section id="Class:Concept_Scheme">
         <h3>Class: Concept Scheme</h3>
-        <table class="definition">
+        <table class="def">
             <thead><tr><th>RDF Class:</th><th><a href="http://www.w3.org/2004/02/skos/core#ConceptScheme">skos:ConceptScheme</a></th></tr></thead>
             <tbody>
             <tr><td class="prop">Definition:</td><td>A knowledge organization system (KOS) used to represent themes/categories of datasets in the catalog.</td></tr>
@@ -3157,7 +3159,7 @@
 
     <section id="Class:Concept">
         <h3>Class: Concept</h3>
-        <table class="definition">
+        <table class="def">
             <thead><tr><th>RDF Class:</th><th><a href="http://www.w3.org/2004/02/skos/core#Concept">skos:Concept</a></th></tr></thead>
             <tbody>
             <tr><td class="prop">Definition:</td><td>A category or a theme used to describe datasets in the catalog.</td></tr>
@@ -3171,7 +3173,7 @@
     <section id="Class:Organization_Person">
         <h3>Class: Organization/Person</h3>
 
-        <table class="definition">
+        <table class="def">
             <thead><tr><th>RDF Classes:</th><th><a href="http://xmlns.com/foaf/0.1/Person"><code>foaf:Person</code></a> for people and <a href="http://xmlns.com/foaf/0.1/Organization"><code>foaf:Organization</code></a> for government agencies or other entities.</th></tr></thead>
             <tbody>
             <tr><td class="prop">Usage note:</td><td>[[!FOAF]] provides several properties to describe these entities.</td></tr>
@@ -3195,7 +3197,7 @@
 
 <p>Examples illustrating use of this class and its properties are given in <a href="#qualified-forms"></a>.</p>
 
-        <table class="definition">
+        <table class="def">
           <thead><tr><th>RDF Class:</th><th><a href="http://www.w3.org/ns/dcat#Relationship">dcat:Relationship</a></th></tr></thead>
           <tbody>
             <tr><td class="prop">Definition:</td><td>An association class for attaching additional information to a relationship between DCAT Resources</td></tr>
@@ -3230,7 +3232,7 @@
 
         <section id="Property:relationship_relation">
             <h4>Property: relation</h4>
-            <table class="definition">
+            <table class="def">
                 <thead><tr><th>RDF Property:</th><th><a href="http://purl.org/dc/terms/relation">dcterms:relation</a></th></tr></thead>
                 <tbody>
                 <tr><td class="prop">Definition:</td><td>The resource related to the source resource.</td></tr>
@@ -3249,7 +3251,7 @@
               </p>
             </aside>
 
-            <table class="definition">
+            <table class="def">
               <thead><tr><th>RDF Property:</th><th><a href="http://www.w3.org/ns/dcat#hadRole">dcat:hadRole</a></th></tr></thead>
               <tbody>
               <tr><td class="prop">Definition:</td><td>The function of an entity or agent with respect to another entity or resource.</td></tr>
@@ -3279,7 +3281,7 @@
 
 <p>Examples illustrating use of this class are given in <a href="#qualified-forms"></a>.</p>
 
-        <table class="definition">
+        <table class="def">
             <thead><tr><th>RDF Class:</th><th><a href="http://www.w3.org/ns/dcat#Role">dcat:Role</a></th></tr></thead>
             <tbody>
             <tr><td class="prop">Definition:</td><td>A role is the function of a resource or agent with respect to another resource, in the context of resource attribution or resource relationships.</td></tr>
@@ -3323,7 +3325,7 @@
           Examples illustrating use of these options for the temporal coverage of a dataset are given in <a href="#temporal-properties"></a>.
         </p>
 
-        <table class="definition">
+        <table class="def">
           <thead><tr><th>RDF Class:</th><th><a href="https://www.dublincore.org/specifications/dublin-core/dcmi-terms/#http://purl.org/dc/terms/PeriodOfTime" title="http://purl.org/dc/terms/PeriodOfTime">dcterms:PeriodOfTime</a></th></tr></thead>
           <tbody>
             <tr>
@@ -3351,7 +3353,7 @@
               </p>
             </aside>
 
-            <table class="definition">
+            <table class="def">
               <thead><tr><th>RDF Property:</th><th><a href="http://www.w3.org/ns/dcat#startDate" title="http://www.w3.org/ns/dcat#startDate">dcat:startDate</a></th></tr></thead>
               <tbody>
               <tr><td class="prop">Definition:</td><td>The start of the period.</td></tr>
@@ -3371,7 +3373,7 @@
               </p>
             </aside>
 
-            <table class="definition">
+            <table class="def">
               <thead><tr><th>RDF Property:</th><th><a href="http://www.w3.org/ns/dcat#endDate" title="http://www.w3.org/ns/dcat#endDate">dcat:endDate</a></th></tr></thead>
               <tbody>
               <tr><td class="prop">Definition:</td><td>The end of the period.</td></tr>
@@ -3391,7 +3393,7 @@
               </p>
             </aside>
 
-            <table class="definition">
+            <table class="def">
               <thead><tr><th>RDF Property:</th><th><a title="http://www.w3.org/2006/time#hasBeginning" data-cite="OWL-TIME#time:hasBeginning">time:hasBeginning</a></th></tr></thead>
               <tbody>
               <tr><td class="prop">Definition:</td><td>Beginning of a period or interval.</td></tr>
@@ -3420,7 +3422,7 @@
               </p>
             </aside>
 
-            <table class="definition">
+            <table class="def">
               <thead><tr><th>RDF Property:</th><th><a title="http://www.w3.org/2006/time#hasEnd" data-cite="OWL-TIME#time:hasEnd">time:hasEnd</a></th></tr></thead>
               <tbody>
               <tr><td class="prop">Definition:</td><td>End of a period or interval.</td></tr>
@@ -3461,7 +3463,7 @@
           Examples illustrating use of these options for the spatial coverage of a dataset are given in <a href="#spatial-properties"></a>.
         </p>
 
-        <table class="definition">
+        <table class="def">
           <thead><tr><th>RDF Class:</th><th><a href="https://www.dublincore.org/specifications/dublin-core/dcmi-terms/#http://purl.org/dc/terms/Location" title="http://purl.org/dc/terms/Location">dcterms:Location</a></th></tr></thead>
           <tbody>
             <tr>
@@ -3489,7 +3491,7 @@
               </p>
             </aside>
 
-            <table class="definition">
+            <table class="def">
               <thead><tr><th>RDF Property:</th><th><a data-cite="LOCN#locn:geometry" title="http://www.w3.org/ns/locn#geometry">locn:geometry</a></th></tr></thead>
               <tbody>
               <tr><td class="prop">Definition:</td><td>Associates any resource with the corresponding geometry. [[LOCN]]</td></tr>
@@ -3515,7 +3517,7 @@
               </p>
             </aside>
 
-            <table class="definition">
+            <table class="def">
               <thead><tr><th>RDF Property:</th><th><a href="http://www.w3.org/ns/dcat#bbox" title="http://www.w3.org/ns/dcat#centroid">dcat:bbox</a></th></tr></thead>
               <tbody>
               <tr><td class="prop">Definition:</td><td>The geographic bounding box of a resource.</td></tr>
@@ -3541,7 +3543,7 @@
               </p>
             </aside>
 
-            <table class="definition">
+            <table class="def">
               <thead><tr><th>RDF Property:</th><th><a href="http://www.w3.org/ns/dcat#centroid" title="http://www.w3.org/ns/dcat#centroid">dcat:centroid</a></th></tr></thead>
               <tbody>
               <tr><td class="prop">Definition:</td><td>The geographic center (centroid) of a resource.</td></tr>
@@ -3577,7 +3579,7 @@
 <a href="#Property:checksum_checksum_value">checksum value</a>.
 </p>
 
-<table class="definition">
+<table class="def">
 <thead>
 <tr>
 <th>RDF Class:</th>
@@ -3604,7 +3606,7 @@
 <p>Property added in DCAT 3.</p>
 </aside>
 
-<table class="definition">
+<table class="def">
 <thead>
 <tr>
 <th>RDF Property:</th>
@@ -3658,7 +3660,7 @@
 <p>Property added in DCAT 3.</p>
 </aside>
 
-<table class="definition">
+<table class="def">
 <thead>
 <tr>
 <th>RDF Property:</th>

--- a/dcat/index.html
+++ b/dcat/index.html
@@ -3901,6 +3901,8 @@ ex:InternationalDOIFundation a foaf:Organization ;
 
   <p>Finally, in the particular case when rights are expressed via <a data-cite="ODRL-VOCAB#term-Policy">ODRL policies</a>, it is recommended to use the <a data-cite="ODRL-VOCAB#term-hasPolicy"><code>odrl:hasPolicy</code></a> property as the link from the description of the cataloged resource or distribution to the ODRL policy, in addition to the corresponding [[DCTERMS]] property that matches the same ODRL policy type.</p>
   
+<div class="issue" data-number="1342"></div>
+  
 <aside class="note">
 <p>The Open Digital Rights Language (ODRL) is a policy expression language that provides a flexible and interoperable information model [[ODRL-MODEL]], vocabulary [[ODRL-VOCAB]], and encoding mechanisms for representing statements about usage (i.e. permissions, prohibitions, and obligations) of content and services.</p>
 </aside>

--- a/dcat/index.html
+++ b/dcat/index.html
@@ -9,7 +9,10 @@
 <!--	
     <link rel="stylesheet" type="text/css" href="style.css">
     <link rel="stylesheet" type="text/css" href="small.css" media="only all and (max-width: 649px)">
--->	
+-->
+<style>
+table.simple {width:100%;}
+</style>	
 </head>
 <body>
 


### PR DESCRIPTION
Relevant issues: https://github.com/w3c/dxwg/issues/676 , https://github.com/w3c/dxwg/issues/1333

Summary of changes:
- Added example on the use of `dcterms:license`, `dcterms:accessRights`, and `dcterms:rights`
- Added example on the use of `odrl:hasPolicy`, based on the one contributed by @riannella in https://github.com/w3c/dxwg/issues/1333
- Use relevant ReSpec classes for tables
- Editorial fixes.

Preview: https://raw.githack.com/w3c/dxwg/dcat-issue-676/dcat/index.html#license-rights

Diff: https://services.w3.org/htmldiff?doc1=https%3A%2F%2Fw3c.github.io%2Fdxwg%2Fdcat%2F&doc2=https%3A%2F%2Fraw.githack.com%2Fw3c%2Fdxwg%2Fdcat-issue-676%2Fdcat%2Findex.html#license-rights

