### PR TITLE
Issue #1308

### DIFF
--- a/dcat/config.js
+++ b/dcat/config.js
@@ -122,8 +122,8 @@ var respecConfig = {
             title:"DBPedia ontology"
         },
         "DCAT-AP-SE": {
-            title: "DCAT-AP-SE: Swedish recommendation for DCAT-AP1.1",
-            href: "https://lankadedata.se/spec/DCAT-AP-SE",
+            title: "DCAT-AP-SE: Clarifications, translations and explanations of DCAT-AP for Sweden",
+            href: "https://docs.dataportal.se/dcat/en/",
             authors: ["Matthias Palmér"],
             etAl: false
         },

--- a/dcat/index.html
+++ b/dcat/index.html
@@ -203,6 +203,7 @@
             <tr><td><code>pav</code></td><td><code>http://purl.org/pav/</code></td><td>[[?PAV]]</td></tr>
             <tr><td><code>sdmx-attribute</code></td><td><code>http://purl.org/linked-data/sdmx/2009/attribute#</code></td><td>[[?VOCAB-DATA-CUBE]]</td></tr>
             <tr><td><code>sdo</code></td><td><code>https://schema.org/</code></td><td>[[?SCHEMA-ORG]]</td></tr>
+            <tr><td><code>xhv</code></td><td><code>http://www.w3.org/1999/xhtml/vocab#</code></td><td>[[XHTML-VOCAB]]</td></tr>
             <tr><td><code>w3cgeo</code></td><td><code>http://www.w3.org/2003/01/geo/wgs84_pos#</code></td><td>[[?W3C-BASIC-GEO]]</td></tr>
             </tbody>
         </table>
@@ -796,7 +797,25 @@
             <a href="#Property:resource_title">title</a>,
             <a href="#Property:resource_type">type/genre</a>,
             <a href="#Property:resource_update_date">update/modification date</a>,
-            <a href="#Property:resource_qualified_attribution">qualified attribution</a>.
+            <a href="#Property:resource_qualified_attribution">qualified attribution</a>,
+
+            <a href="#Property:resource_has_current_version">has current version</a>,
+<!--			
+            <a href="#Property:resource_has_last_version">has last version</a>,
+-->			
+            <a href="#Property:resource_has_version">has version</a>,
+            <a href="#Property:resource_is_replaced_by">is replaced by</a>,
+            <a href="#Property:resource_is_version_of">is version of</a>,
+            <a href="#Property:resource_previous_version">previous version</a>,
+            <a href="#Property:resource_replaces">replaces</a>,
+            <a href="#Property:resource_status">status</a>,
+            <a href="#Property:resource_version">version</a>,
+            <a href="#Property:resource_version_notes">version notes</a>,
+
+<a href="#Property:resource_last">last</a>,
+<a href="#Property:resource_next">next</a>.
+<a href="#Property:resource_previous">previous</a>.
+
         </p>
 
         <table class="definition">
@@ -965,7 +984,7 @@
             <a href="#Property:resource_type">type/genre</a>,
             <a href="#Property:resource_update_date">update/modification date</a>,
             <a href="#Property:resource_qualified_attribution">qualified attribution</a>,
-			
+<!-- Versioning properties -->			
             <a href="#Property:resource_has_current_version">has current version</a>,
 <!--			
             <a href="#Property:resource_has_last_version">has last version</a>,
@@ -977,7 +996,11 @@
             <a href="#Property:resource_replaces">replaces</a>,
             <a href="#Property:resource_status">status</a>,
             <a href="#Property:resource_version">version</a>,
-            <a href="#Property:resource_version_notes">version notes</a>.
+            <a href="#Property:resource_version_notes">version notes</a>,
+<!-- Series properties -->			
+            <a href="#Property:resource_last">last</a>,
+            <a href="#Property:resource_next">next</a>,
+            <a href="#Property:resource_previous">previous</a>.
 			
         </p>
 
@@ -2071,6 +2094,159 @@
 
 </section>
 
+<!-- Series properties -->
+
+<section id="Property:resource_last">
+
+<h4>Property: last</h4>
+
+<aside class="note">
+<p>Property added in DCAT 3.</p>
+</aside>
+
+<table class="definition">
+<thead>
+<tr>
+<th>RDF Property:</th>
+<th><a href="http://www.w3.org/ns/adms#last">adms:last</a></th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="prop">Definition:</td>
+<td>The last resource in an ordered collection or series of resources, to which the current resource belongs.</td>
+</tr>
+<!--
+<tr>
+<td class="prop">Equivalent property:</td>
+<td><a data-cite="?XHTML-VOCAB#last"><code title="http://www.w3.org/1999/xhtml/vocab#last">xhv:last</code></a></td>
+</tr>
+-->
+<tr>
+<td class="prop">Sub-property of:</td>
+<td><a data-cite="?XHTML-VOCAB#next"><code title="http://www.w3.org/1999/xhtml/vocab#last">xhv:last</code></a></td>
+</tr>
+<tr>
+<td class="prop">Usage note:</td>
+<td>
+<p>In DCAT this property is used for resources belonging to a <a href="#Class:Dataset_Series"><code>dcat:DatasetSeries</code></a>.</p>
+</td>
+</tr>
+<tr>
+<td class="prop">See also:</td>
+<td>
+<a href="#Property:resource_next"></a>,
+<a href="#Property:resource_previous"></a>.
+</td>
+</tr>
+</tbody>
+</table>
+
+<p>For guidance on the use of this property, see <a href="#dataset-series"></a>.</p>
+
+</section>
+
+<section id="Property:resource_next">
+
+<h4>Property: next</h4>
+
+<aside class="note">
+<p>Property added in DCAT 3.</p>
+</aside>
+
+<table class="definition">
+<thead>
+<tr>
+<th>RDF Property:</th>
+<th><a href="http://www.w3.org/ns/adms#next">adms:next</a></th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="prop">Definition:</td>
+<td>The next resource (after the current one) in an ordered collection or series of resources.</td>
+</tr>
+<!--
+<tr>
+<td class="prop">Equivalent property:</td>
+<td><a data-cite="?XHTML-VOCAB#prev"><code title="http://www.w3.org/1999/xhtml/vocab#prev">xhv:prev</code></a></td>
+</tr>
+-->
+<tr>
+<td class="prop">Sub-property of:</td>
+<td><a data-cite="?XHTML-VOCAB#next"><code title="http://www.w3.org/1999/xhtml/vocab#next">xhv:next</code></a></td>
+</tr>
+<tr>
+<td class="prop">Usage note:</td>
+<td>
+<p>In DCAT this property is used for resources belonging to a <a href="#Class:Dataset_Series"><code>dcat:DatasetSeries</code></a>.</p>
+</td>
+</tr>
+<tr>
+<td class="prop">See also:</td>
+<td>
+<a href="#Property:resource_last"></a>,
+<a href="#Property:resource_previous"></a>.
+</td>
+</tr>
+</tbody>
+</table>
+
+<p>For guidance on the use of this property, see <a href="#dataset-series"></a>.</p>
+
+</section>
+
+<section id="Property:resource_previous">
+
+<h4>Property: previous</h4>
+
+<aside class="note">
+<p>Property added in DCAT 3.</p>
+</aside>
+
+<table class="definition">
+<thead>
+<tr>
+<th>RDF Property:</th>
+<th><a href="http://www.w3.org/ns/adms#prev">adms:prev</a></th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="prop">Definition:</td>
+<td>The previous resource (before the current one) in an ordered collection or series of resources.</td>
+</tr>
+<!--
+<tr>
+<td class="prop">Equivalent property:</td>
+<td><a data-cite="?XHTML-VOCAB#prev"><code title="http://www.w3.org/1999/xhtml/vocab#prev">xhv:prev</code></a></td>
+</tr>
+-->
+<tr>
+<td class="prop">Sub-property of:</td>
+<td><a data-cite="?XHTML-VOCAB#prev"><code title="http://www.w3.org/1999/xhtml/vocab#prev">xhv:prev</code></a></td>
+</tr>
+<tr>
+<td class="prop">Usage note:</td>
+<td>
+<p>In DCAT this property is used for resources belonging to a <a href="#Class:Dataset_Series"><code>dcat:DatasetSeries</code></a>.</p>
+<p>It is important to note that this property is different from <a href="#Property:resource_previous_version">dcat:previousVersion</a>, as it does not denote a previous version of the same resource, but a distinct resource immediately preceding the current one in an ordered collection of resources.</p>
+</td>
+</tr>
+<tr>
+<td class="prop">See also:</td>
+<td>
+<a href="#Property:resource_last"></a>,
+<a href="#Property:resource_next"></a>.
+</td>
+</tr>
+</tbody>
+</table>
+
+<p>For guidance on the use of this property, see <a href="#dataset-series"></a>.</p>
+
+</section>
+
     </section> <!-- end class Resource -->
 
     <section id="Class:Catalog_Record">
@@ -2254,7 +2430,24 @@
             <a href="#Property:resource_title">title</a>,
             <a href="#Property:resource_type">type/genre</a>,
             <a href="#Property:resource_update_date">update/modification date</a>,
-            <a href="#Property:resource_qualified_attribution">qualified attribution</a>.
+            <a href="#Property:resource_qualified_attribution">qualified attribution</a>,
+
+            <a href="#Property:resource_has_current_version">has current version</a>,
+<!--			
+            <a href="#Property:resource_has_last_version">has last version</a>,
+-->			
+            <a href="#Property:resource_has_version">has version</a>,
+            <a href="#Property:resource_is_replaced_by">is replaced by</a>,
+            <a href="#Property:resource_is_version_of">is version of</a>,
+            <a href="#Property:resource_previous_version">previous version</a>,
+            <a href="#Property:resource_replaces">replaces</a>,
+            <a href="#Property:resource_status">status</a>,
+            <a href="#Property:resource_version">version</a>,
+            <a href="#Property:resource_version_notes">version notes</a>,
+
+<a href="#Property:resource_last">last</a>,
+<a href="#Property:resource_next">next</a>.
+<a href="#Property:resource_previous">previous</a>.
 
         </p>
 
@@ -2527,9 +2720,31 @@
             <a href="#Property:dataset_spatial_resolution">spatial resolution</a>,
             <a href="#Property:dataset_temporal">temporal coverage</a>,
             <a href="#Property:dataset_temporal_resolution">temporal resolution</a>,
-            <a href="#Property:dataset_was_generated_by">was generated by</a>.
+            <a href="#Property:dataset_was_generated_by">was generated by</a>,
+
+            <a href="#Property:resource_has_current_version">has current version</a>,
+<!--			
+            <a href="#Property:resource_has_last_version">has last version</a>,
+-->			
+            <a href="#Property:resource_has_version">has version</a>,
+            <a href="#Property:resource_is_replaced_by">is replaced by</a>,
+            <a href="#Property:resource_is_version_of">is version of</a>,
+            <a href="#Property:resource_previous_version">previous version</a>,
+            <a href="#Property:resource_replaces">replaces</a>,
+            <a href="#Property:resource_status">status</a>,
+            <a href="#Property:resource_version">version</a>,
+            <a href="#Property:resource_version_notes">version notes</a>,
+
+<a href="#Property:resource_last">last</a>,
+<a href="#Property:resource_next">next</a>.
+<a href="#Property:resource_previous">previous</a>.
+
         </p>
         <div class="issue" title="Any other properties to mention in this class ?" data-number="1308"></div>
+
+<aside class="note">
+<p>Some of the inherited properties may have a particular semantics when used with <code>dcat:DatasetSeries</code>. For more details, see <a href="#dataset-series"></a>.</p>
+</aside>
     
         <table class="definition">
             <thead><tr><th>RDF Class:</th><th><a href="http://www.w3.org/ns/dcat#DatasetSeries">dcat:DatasetSeries</a></th></tr></thead>
@@ -3064,7 +3279,25 @@
             <a href="#Property:resource_title">title</a>,
             <a href="#Property:resource_type">type/genre</a>,
             <a href="#Property:resource_update_date">update/modification date</a>,
-            <a href="#Property:resource_qualified_attribution">qualified attribution</a>.
+            <a href="#Property:resource_qualified_attribution">qualified attribution</a>,
+
+            <a href="#Property:resource_has_current_version">has current version</a>,
+<!--			
+            <a href="#Property:resource_has_last_version">has last version</a>,
+-->			
+            <a href="#Property:resource_has_version">has version</a>,
+            <a href="#Property:resource_is_replaced_by">is replaced by</a>,
+            <a href="#Property:resource_is_version_of">is version of</a>,
+            <a href="#Property:resource_previous_version">previous version</a>,
+            <a href="#Property:resource_replaces">replaces</a>,
+            <a href="#Property:resource_status">status</a>,
+            <a href="#Property:resource_version">version</a>,
+            <a href="#Property:resource_version_notes">version notes</a>,
+
+<a href="#Property:resource_last">last</a>,
+<a href="#Property:resource_next">next</a>.
+<a href="#Property:resource_previous">previous</a>.
+
         </p>
 
 
@@ -4647,7 +4880,7 @@ ex:budget-2020 a dcat:Dataset ;
 </aside>
 
 
-<p>Dataset series may evolve over time, by acquiring new datasets. E.g., a dataset series about yearly budget data will acquire a new child dataset every year. In such cases, it might be important to link the yearly releases with relationships specifying the previous, next, and latest ones. In such scenario, DCAT makes use of the [[VOCAB-ADMS]] properties <a href="#Property:resource_prev"><code>adms:prev</code></a>, <a href="#Property:resource_next"><code>adms:next</code></a>, and <a href="#Property:resource_last"><code>adms:last</code></a>, respectively.</p>
+<p>Dataset series may evolve over time, by acquiring new datasets. E.g., a dataset series about yearly budget data will acquire a new child dataset every year. In such cases, it might be important to link the yearly releases with relationships specifying the previous, next, and latest ones. In such scenario, DCAT makes use of the [[VOCAB-ADMS]] properties <a href="#Property:resource_previous"><code>adms:prev</code></a>, <a href="#Property:resource_next"><code>adms:next</code></a>, and <a href="#Property:resource_last"><code>adms:last</code></a>, respectively.</p>
 
 <aside class="example" id="ex-dataset-series-releases" title="Linking datasets in a series">
 <p>The following example extends <a href="#ex-dataset-series-containment"></a> by specifying the publication date (<code>dcterms:issued</code>) of each child dataset, and the previous (<code>adms:prev</code>) and next release (<code>adms:next</code>).</p>

--- a/dcat/index.html
+++ b/dcat/index.html
@@ -812,6 +812,7 @@
             <a href="#Property:resource_version">version</a>,
             <a href="#Property:resource_version_notes">version notes</a>,
 
+<a href="#Property:resource_first">first</a>,
 <a href="#Property:resource_last">last</a>,
 <a href="#Property:resource_next">next</a>.
 <a href="#Property:resource_previous">previous</a>.
@@ -998,6 +999,7 @@
             <a href="#Property:resource_version">version</a>,
             <a href="#Property:resource_version_notes">version notes</a>,
 <!-- Series properties -->			
+            <a href="#Property:resource_first">first</a>,
             <a href="#Property:resource_last">last</a>,
             <a href="#Property:resource_next">next</a>,
             <a href="#Property:resource_previous">previous</a>.
@@ -2096,6 +2098,57 @@
 
 <!-- Series properties -->
 
+<section id="Property:resource_first">
+
+<h4>Property: first</h4>
+
+<aside class="note">
+<p>Property added in DCAT 3.</p>
+</aside>
+
+<table class="definition">
+<thead>
+<tr>
+<th>RDF Property:</th>
+<th><a href="http://www.w3.org/ns/dcat#first">dcat:first</a></th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="prop">Definition:</td>
+<td>The first resource in an ordered collection or series of resources, to which the current resource belongs.</td>
+</tr>
+<!--
+<tr>
+<td class="prop">Equivalent property:</td>
+<td><a data-cite="?XHTML-VOCAB#last"><code title="http://www.w3.org/1999/xhtml/vocab#last">xhv:last</code></a></td>
+</tr>
+-->
+<tr>
+<td class="prop">Sub-property of:</td>
+<td><a data-cite="?XHTML-VOCAB#first"><code title="http://www.w3.org/1999/xhtml/vocab#first">xhv:first</code></a></td>
+</tr>
+<tr>
+<td class="prop">Usage note:</td>
+<td>
+<p>In DCAT this property is used for resources belonging to a <a href="#Class:Dataset_Series"><code>dcat:DatasetSeries</code></a>.</p>
+</td>
+</tr>
+<tr>
+<td class="prop">See also:</td>
+<td>
+<a href="#Property:resource_last"></a>,
+<a href="#Property:resource_next"></a>,
+<a href="#Property:resource_previous"></a>.
+</td>
+</tr>
+</tbody>
+</table>
+
+<p>For guidance on the use of this property, see <a href="#dataset-series"></a>.</p>
+
+</section>
+
 <section id="Property:resource_last">
 
 <h4>Property: last</h4>
@@ -2108,7 +2161,7 @@
 <thead>
 <tr>
 <th>RDF Property:</th>
-<th><a href="http://www.w3.org/ns/adms#last">adms:last</a></th>
+<th><a href="http://www.w3.org/ns/dcat#last">dcat:last</a></th>
 </tr>
 </thead>
 <tbody>
@@ -2124,7 +2177,7 @@
 -->
 <tr>
 <td class="prop">Sub-property of:</td>
-<td><a data-cite="?XHTML-VOCAB#next"><code title="http://www.w3.org/1999/xhtml/vocab#last">xhv:last</code></a></td>
+<td><a data-cite="?XHTML-VOCAB#last"><code title="http://www.w3.org/1999/xhtml/vocab#last">xhv:last</code></a></td>
 </tr>
 <tr>
 <td class="prop">Usage note:</td>
@@ -2135,6 +2188,7 @@
 <tr>
 <td class="prop">See also:</td>
 <td>
+<a href="#Property:resource_first"></a>,
 <a href="#Property:resource_next"></a>,
 <a href="#Property:resource_previous"></a>.
 </td>
@@ -2158,7 +2212,7 @@
 <thead>
 <tr>
 <th>RDF Property:</th>
-<th><a href="http://www.w3.org/ns/adms#next">adms:next</a></th>
+<th><a href="http://www.w3.org/ns/dcat#next">dcat:next</a></th>
 </tr>
 </thead>
 <tbody>
@@ -2185,6 +2239,7 @@
 <tr>
 <td class="prop">See also:</td>
 <td>
+<a href="#Property:resource_first"></a>,
 <a href="#Property:resource_last"></a>,
 <a href="#Property:resource_previous"></a>.
 </td>
@@ -2208,7 +2263,7 @@
 <thead>
 <tr>
 <th>RDF Property:</th>
-<th><a href="http://www.w3.org/ns/adms#prev">adms:prev</a></th>
+<th><a href="http://www.w3.org/ns/dcat#prev">dcat:prev</a></th>
 </tr>
 </thead>
 <tbody>
@@ -2230,12 +2285,13 @@
 <td class="prop">Usage note:</td>
 <td>
 <p>In DCAT this property is used for resources belonging to a <a href="#Class:Dataset_Series"><code>dcat:DatasetSeries</code></a>.</p>
-<p>It is important to note that this property is different from <a href="#Property:resource_previous_version">dcat:previousVersion</a>, as it does not denote a previous version of the same resource, but a distinct resource immediately preceding the current one in an ordered collection of resources.</p>
+<p>It is important to note that this property is different from <a href="#Property:resource_previous_version"><code>dcat:previousVersion</code></a>, as it does not denote a previous version of the same resource, but a distinct resource immediately preceding the current one in an ordered collection of resources.</p>
 </td>
 </tr>
 <tr>
 <td class="prop">See also:</td>
 <td>
+<a href="#Property:resource_first"></a>,
 <a href="#Property:resource_last"></a>,
 <a href="#Property:resource_next"></a>.
 </td>
@@ -2445,6 +2501,7 @@
             <a href="#Property:resource_version">version</a>,
             <a href="#Property:resource_version_notes">version notes</a>,
 
+<a href="#Property:resource_first">first</a>,
 <a href="#Property:resource_last">last</a>,
 <a href="#Property:resource_next">next</a>.
 <a href="#Property:resource_previous">previous</a>.
@@ -2735,6 +2792,7 @@
             <a href="#Property:resource_version">version</a>,
             <a href="#Property:resource_version_notes">version notes</a>,
 
+<a href="#Property:resource_first">first</a>,
 <a href="#Property:resource_last">last</a>,
 <a href="#Property:resource_next">next</a>.
 <a href="#Property:resource_previous">previous</a>.
@@ -2751,7 +2809,7 @@
             <tbody>
             <tr><td class="prop">Definition:</td><td>A collection of datasets that are published separately, but share some common characteristics that groups them. <!--, and could also be made available as a single dataset.--></td></tr>
             <tr><td class="prop">Sub-class of:</td><td><a href="#Class:Dataset"><code>dcat:Dataset</code></a></td></tr>
-            <tr><td class="prop">Usage note:</td><td> Dataset series can be also soft-typed via property <code>dcterms:type</code> as in the approach used in [[GeoDCAT-AP]], and adopted in [[DCAT-AP-IT]] and [[GeoDCAT-AP-IT]]).</td></tr>
+            <tr><td class="prop">Usage note:</td><td> Dataset series can be also soft-typed via property <code>dcterms:type</code> as in the approach used in [[?GeoDCAT-AP]], and adopted in [[?DCAT-AP-IT]] and [[?GeoDCAT-AP-IT]]).</td></tr>
             <tr><td class="prop">Usage note:</td><td>Common scenarios for dataset series include: time series composed of periodically released subsets; map-series composed of items of the same type or theme but with differing spatial footprints.</td></tr>
             </tbody>
         </table>
@@ -3294,6 +3352,7 @@
             <a href="#Property:resource_version">version</a>,
             <a href="#Property:resource_version_notes">version notes</a>,
 
+<a href="#Property:resource_first">first</a>,
 <a href="#Property:resource_last">last</a>,
 <a href="#Property:resource_next">next</a>.
 <a href="#Property:resource_previous">previous</a>.
@@ -4504,7 +4563,7 @@ For example:
 <li><a data-cite="VOCAB-ADMS#adms-last"><code>adms:last</code></a> is defined as <q>A link to the current or latest version of the Asset</q>, whereas in [[PAV]] the current and latest versions of a resource may be different, and link to by using different properties.</li>
 </ul>
 <p>Moreover, although the definitions of the [[VOCAB-ADMS]] properties states explicitly that they are meant to be used for "versions", they are subproperties of the corresponding terms in [[XHTML-VOCAB]], where they are used to link resources in a collection (e.g., the set of pages of a Web site). E.g., the definition of <a data-cite="XHTML-VOCAB#last"><code>xhv:last</code></a> reads as follows: <q>last refers to the last resource in a collection of resources.</q>.</p>
-<p>Based on that, in this draft, [[PAV]]-equivalent properties are used for versions, whereas the [[VOCAB-ADMS]] ones are used for dataset series (<a href="#dataset-series"></a>). Properties <code>dcterms:hasVersion</code> / <code>dcterms:isVersionOf</code> are not used.</p>
+<p>Based on that, in this draft, [[PAV]]-equivalent properties are used for versions, whereas the [[VOCAB-ADMS]] properties, and properties <code>dcterms:hasVersion</code> / <code>dcterms:isVersionOf</code> are not used.</p>
 </aside>
 
 <p>Property <code>dcat:previousVersion</code> is used to build a version chain, that can be navigated backward from a given version to the first one. This reflects the most typical use case - i.e., linking different versions published as distinct resources in a catalog.</p>
@@ -4823,10 +4882,11 @@ mycity-bus:stops-2015-01-01
 <section class="informative" id="dataset-series">
 
 <h2>Dataset series</h2>
+
 <aside class="ednote">
 <p>This is a new draft for discussion on dataset series support in DCAT. Compared with the first draft in [[VOCAB-DCAT-3-20201217]], this section has been revised.</p>
 <p>A new class <code>dcat:DatasetSeries</code> is defined as suggested in <a href="https://github.com/w3c/dxwg/issues/1272">Issue #1272</a>. </p>
-<p>Only one property  <code>dcat:inSeries</code> linking the child datasets to dataset series is defined. The new property <code>dcat:inSeries</code> replaces the use of <code>dcterms:isPartOf</code> helping to distinguish between the composition in dataset series and  <a href="https://www.w3.org/TR/vocab-dcat-3/#examples-bag-of-files">Loosely structured catalog</a> (see <a href="https://github.com/w3c/dxwg/issues/1307">Issue #1307</a>). </p>
+<p>Only one property  <code>dcat:inSeries</code> linking the child datasets to dataset series is defined. The new property <code>dcat:inSeries</code> replaces the use of <code>dcterms:isPartOf</code> helping to distinguish between the composition in dataset series and  <a href="https://www.w3.org/TR/vocab-dcat-3/#examples-bag-of-files">Loosely structured catalog</a> (see <a href="https://github.com/w3c/dxwg/issues/1307">Issue #1307</a>). Finally, properties <code>adms:prev</code>, <code>adms:next</code>, and <code>adms:last</code> have been replaced by newly defined properties - <code>dcat:prev</code>, <code>dcat:next</code>, and <code>dcat:last</code> (see <a href="https://github.com/w3c/dxwg/issues/1308">Issue #1308</a>)).</p>
 </aside>
 
 <p>With "dataset series" we refer to data, somehow interrelated, that are published separately. An example is budget data split by year and/or country, instead of being made available in a single dataset.</p>
@@ -4880,10 +4940,10 @@ ex:budget-2020 a dcat:Dataset ;
 </aside>
 
 
-<p>Dataset series may evolve over time, by acquiring new datasets. E.g., a dataset series about yearly budget data will acquire a new child dataset every year. In such cases, it might be important to link the yearly releases with relationships specifying the previous, next, and latest ones. In such scenario, DCAT makes use of the [[VOCAB-ADMS]] properties <a href="#Property:resource_previous"><code>adms:prev</code></a>, <a href="#Property:resource_next"><code>adms:next</code></a>, and <a href="#Property:resource_last"><code>adms:last</code></a>, respectively.</p>
+<p>Dataset series may evolve over time, by acquiring new datasets. E.g., a dataset series about yearly budget data will acquire a new child dataset every year. In such cases, it might be important to link the yearly releases with relationships specifying the first, previous, next, and latest ones. In such scenario, DCAT makes use of properties <a href="#Property:resource_first"><code>dcat:first</code></a>, <a href="#Property:resource_previous"><code>dcat:prev</code></a>, <a href="#Property:resource_next"><code>dcat:next</code></a>, and <a href="#Property:resource_last"><code>dcat:last</code></a>, respectively.</p>
 
 <aside class="example" id="ex-dataset-series-releases" title="Linking datasets in a series">
-<p>The following example extends <a href="#ex-dataset-series-containment"></a> by specifying the publication date (<code>dcterms:issued</code>) of each child dataset, and the previous (<code>adms:prev</code>) and next release (<code>adms:next</code>).</p>
+<p>The following example extends <a href="#ex-dataset-series-containment"></a> by specifying the publication date (<code>dcterms:issued</code>) of each child dataset, and the previous (<code>dcat:prev</code>) and next release (<code>dcat:next</code>).</p>
 <pre>
 
 ex:budget a dcat:DatasetSeries ;
@@ -4895,22 +4955,22 @@ ex:budget-2018 a dcat:Dataset ;
   dcterms:title "Budget data for year 2018"@en ;
   dcat:inSeries ex:budget ;
   dcterms:issued "2019-01-01"^^xsd:date ;
-  adms:next ex:budget-2019 ;
+  dcat:next ex:budget-2019 ;
   .
   
 ex:budget-2019 a dcat:Dataset ;
   dcterms:title "Budget data for year 2019"@en ;
   dcat:inSeries ex:budget ;
   dcterms:issued "2020-01-01"^^xsd:date ;
-  adms:prev ex:budget-2018 ;
-  adms:next ex:budget-2020 ;
+  dcat:prev ex:budget-2018 ;
+  dcat:next ex:budget-2020 ;
   .
   
 ex:budget-2020 a dcat:Dataset ;
   dcterms:title "Budget data for year 2020"@en ;
   dcat:inSeries ex:budget ;
   dcterms:issued "2021-01-01"^^xsd:date ;
-  adms:prev ex:budget-2019 ;
+  dcat:prev ex:budget-2019 ;
   .
 </pre>
 </aside>
@@ -4935,7 +4995,7 @@ ex:budget-2020 a dcat:Dataset ;
 
 <p>Properties about dataset series can be classified into two groups.</p>
 
-<p>The first group is about properties describing the dataset series itself. For instance, this is the case of property <a href="#Property:dataset_series_update_frequency"><code>dcterms:accrualPeriodicity</code></a>, whose value should correspond to the frequency upon which a new child dataset is added.</p>
+<p>The first group is about properties describing the dataset series itself. For instance, this is the case of property <a href="#Property:dataset_frequency"><code>dcterms:accrualPeriodicity</code></a>, whose value should correspond to the frequency upon which a new child dataset is added.</p>
 
 <p>The second group is about properties reflecting the dimensions described in child dataset metadata, via upstream inheritance - i.e., property values of child datasets are inherited by their parent (the dataset series).</p>
 
@@ -4950,8 +5010,8 @@ ex:budget-2020 a dcat:Dataset ;
 <p>Finally, some annotation properties of child datasets may need to be taken into account as well at the level of dataset series. In particular, properties concerning the creation / publication / update dates of child datasets may affect the corresponding ones in the series. For these properties, DCAT recommends the following approach:</p>
 <ul>
 <li>The creation date (<code>dcterms:created</code>) of the dataset series should correspond to the earliest creation date of the child datasets.</li>
-<li>The publication date (<a href="#Property:dataset_series_release_date"><code>dcterms:issued</code></a>) of the dataset series should correspond to the earliest publication date of the child datasets.</li>
-<li>The update date (<a href="#Property:dataset_series_update_date"><code>dcterms:modified</code></a>) of the dataset series should correspond to the latest publication or update date of the child datasets.</li>
+<li>The publication date (<a href="#Property:resource_release_date"><code>dcterms:issued</code></a>) of the dataset series should correspond to the earliest publication date of the child datasets.</li>
+<li>The update date (<a href="#Property:resource_update_date"><code>dcterms:modified</code></a>) of the dataset series should correspond to the latest publication or update date of the child datasets.</li>
 </ul>
 
 <aside class="note">
@@ -4983,7 +5043,7 @@ ex:budget-2018-be a dcat:Dataset ;
   dcterms:title "Belgium budget data for year 2018"@en ;
   dcat:inSeries ex:budget ;
   dcterms:issued "2019-01-01"^^xsd:date ;
-  adms:next ex:budget-2019-be ;
+  dcat:next ex:budget-2019-be ;
   dcterms:accrualPeriodicity &lt;http://purl.org/cld/freq/annual&gt; ;
   dcat:temporalResolution "P1Y"^^xsd:duration ;
   dcterms:temporal [ a dcterms:PeriodOfTime ;
@@ -4999,7 +5059,7 @@ ex:budget-2018-fr a dcat:Dataset ;
   dcterms:title "France budget data for year 2018"@en ;
   dcat:inSeries ex:budget ;
   dcterms:issued "2019-01-01"^^xsd:date ;
-  adms:next ex:budget-2019-fr ;
+  dcat:next ex:budget-2019-fr ;
   dcterms:accrualPeriodicity &lt;http://purl.org/cld/freq/annual&gt; ;
   dcat:temporalResolution "P1Y"^^xsd:duration ;
   dcterms:temporal [ a dcterms:PeriodOfTime ;
@@ -5015,7 +5075,7 @@ ex:budget-2018-it a dcat:Dataset ;
   dcterms:title "Italy budget data for year 2018"@en ;
   dcat:inSeries ex:budget ;
   dcterms:issued "2019-01-01"^^xsd:date ;
-  adms:next ex:budget-2019-it ;
+  dcat:next ex:budget-2019-it ;
   dcterms:accrualPeriodicity &lt;http://purl.org/cld/freq/annual&gt; ;
   dcat:temporalResolution "P1Y"^^xsd:duration ;
   dcterms:temporal [ a dcterms:PeriodOfTime ;
@@ -5046,7 +5106,7 @@ ex:budget-2018-it a dcat:Dataset ;
 <li>Both the dataset series and its child datasets are typed as a <code>dcat:Dataset</code>'s, and the two are usually linked by using the [[DCTERMS]] properties <code>dcterms:hasPart</code> / <code>dcterms:isPartOf</code>.</li>
 </ol>
 
-<p>In both cases, the dataset series is sometimes soft-typed by using the [[DCTERMS]] property <code>dcterms:type</code> (e.g., this is the approach used in [[GeoDCAT-AP]], and adopted in [[DCAT-AP-IT]] and [[GeoDCAT-AP-IT]]).</p>
+<p>In both cases, the dataset series is sometimes soft-typed by using the [[DCTERMS]] property <code>dcterms:type</code> (e.g., this is the approach used in [[?GeoDCAT-AP]], and adopted in [[?DCAT-AP-IT]] and [[?GeoDCAT-AP-IT]]).</p>
 
 <p>These options are not formally incompatible with DCAT, so they can cohexist with <code>dcat:DatasetSeries</code> during the upgrade to DCAT 3.</p>
 
@@ -5209,7 +5269,7 @@ ex:budget-2018-it a dcat:Dataset ;
     <section id="quality-conformance">
         <h2>Documenting conformance to standards</h2>
 
-  <p> This section shows different modelling patterns combining [[?VOCAB-DQV]] with [[?PROV-O]] and EARL [[?EARL10-Schema]] to represent the conformance degree to a stated quality standard and the details about the conformance tests.
+  <p> This section shows different modeling patterns combining [[?VOCAB-DQV]] with [[?PROV-O]] and EARL [[?EARL10-Schema]] to represent the conformance degree to a stated quality standard and the details about the conformance tests.
         </p>
 
         <section id="quality-conformance-statement">
@@ -6437,7 +6497,12 @@ ga-courts:jc-wms
 <p>The other sections include only editorial changes.</p>
 </li>
 <li><a href="#Class:Resource"></a> has been updated to include the definition of the properties illustrated in <a href="#dataset-versions"></a>.</li>
-<li><p><a href="#dataset-series"></a> has been revised making dataset series first class citizens of data catalogs and introducing new properties for linking dataset series and datasets (see Issues <a href="https://github.com/w3c/dxwg/issues/1272">#1272</a> and <a href="https://github.com/w3c/dxwg/issues/1307">#1307</a>). In particular, the class <code>dcat:DatasetSeries</code> has been minted (see <a href="#Class:Dataset_Series"></a>), the property <code>dcat:inSeries</code> has been added to <a href="#Class:Dataset"></a>.</p>
+<li><p><a href="#dataset-series"></a> has been revised making dataset series first class citizens of data catalogs and introducing new properties for linking dataset series and datasets. In particular:</p>
+<ul>
+<li>A new class <code>dcat:DatasetSeries</code> has been defined (see <a href="#Class:Dataset_Series"></a>) - see Issue <a href="https://github.com/w3c/dxwg/issues/1272">#1272</a>.</li>
+<li>Property <code>dcat:inSeries</code> has been added to <a href="#Class:Dataset"></a> - see Issue <a href="https://github.com/w3c/dxwg/issues/1307">#1307</a>.</li>
+<li>Properties <code>dcat:prev</code>, <code>dcat:next</code>, and <code>dcat:last</code> have been added to <a href="#Class:Resource"></a> - see Issue <a href="https://github.com/w3c/dxwg/issues/1308">#1308</a>.</li>
+</ul>
 </li>
 <li>Added property <a href="#Property:distribution_checksum"><code>spdx:checksum</code></a> to <code>dcat:Distribution</code>, class <a href="#Class:Checksum"><code>spdx:Checksum</code></a>, and properties <a href="#Property:checksum_algorithm"><code>spdx:algorithm</code></a> and <a href="#Property:checksum_checksum_value"><code>spdx:checksumValue</code></a> - see Issue <a href="https://github.com/w3c/dxwg/issues/1287">#1287</a>.</li>
 </ul>


### PR DESCRIPTION
Relevant issue: https://github.com/w3c/dxwg/issues/1308

Summary of changes:
- Add `dcat:first`, `dcat:last`, `dcat:next`, `dcat:prev` to `dcat:Resource`
- Update list of inherited properties for subclasses of `dcat:Resource`
- Add `xhv` to the table with informative namespaces
- Add NOTE after the list of inherited properties of `dcat:DatasetSeries`, to say that some of the inherited properties may have particular semantics when used in this context
- Editorial fixes

Preview: https://raw.githack.com/w3c/dxwg/dcat-issue-1308/dcat/index.html

Diff: https://services.w3.org/htmldiff?doc1=https%3A%2F%2Fw3c.github.io%2Fdxwg%2Fdcat%2F&doc2=https%3A%2F%2Fraw.githack.com%2Fw3c%2Fdxwg%2Fdcat-issue-1308%2Fdcat%2Findex.html