### PR TITLE
Fix two broken links in public draft candidate

### DIFF
--- a/dcat/index.html
+++ b/dcat/index.html
@@ -3084,7 +3084,7 @@ table.simple {width:100%;}
                 <tr><th>RDF Property:</th><td><a href="http://www.w3.org/ns/dcat#packageFormat"><code>dcat:packageFormat</code></a></td></tr>
                 <tr><th class="prop">Definition:</th><td>The package format of the distribution in which one or more data files are grouped together, e.g. to enable a set of related files to be downloaded together.</td></tr>
                 <tr><th class="prop">Range:</th><td><a href="http://purl.org/dc/terms/MediaType"><code>dcterms:MediaType</code></a></td></tr>
-                <tr><th class="prop">Usage note:</th><td>This property to be used when the files in the distribution are packaged, e.g. in a <a href="https://en.wikipedia.org/wiki/Tar_(computing)">TAR file</a>, a <a href="http://frictionlessdata.io/data-packages/">Frictionless Data Package</a> or a <a href="https://tools.ietf.org/html/draft-kunze-bagit-14">Bagit</a> file. The format SHOULD be expressed using a media type as defined by IANA [[!IANA-MEDIA-TYPES]], if available.</td></tr>
+                <tr><th class="prop">Usage note:</th><td>This property to be used when the files in the distribution are packaged, e.g. in a <a href="https://en.wikipedia.org/wiki/Tar_(computing)">TAR file</a>, a <a href="http://frictionlessdata.io/data-package/">Frictionless Data Package</a> or a <a href="https://tools.ietf.org/html/draft-kunze-bagit-14">Bagit</a> file. The format SHOULD be expressed using a media type as defined by IANA [[!IANA-MEDIA-TYPES]], if available.</td></tr>
                 <tr><th class="prop">See also:</th><td><a href="#Property:distribution_compression_format"></a>.</td></tr>
                 </table>
               
@@ -6489,7 +6489,7 @@ ga-courts:jc-wms
         <p>The document has undergone the following changes since the DCAT 2 W3C Recommendation of 4 February 2020 [[?VOCAB-DCAT-2-20200204]]:</p>
         <ul>
         <li> 
-          Examples about <a href="examples-bag-of-files">loosely structured catalog</a> were updated replacing <code>dcterms:relation</code> with more specific subrelations and emphatizing the use of <code>dcterms:hasPart</code>.
+          Examples about <a href="#examples-bag-of-files">loosely structured catalog</a> were updated replacing <code>dcterms:relation</code> with more specific subrelations and emphatizing the use of <code>dcterms:hasPart</code>.
         </li> 
         <li>
         Section <a href="#dataset-versions"></a> was extended with draft guidelines to deal with version delta (Issue <a href="https://github.com/w3c/dxwg/issues/#89">#89</a>), version release date (Issue <a href="https://github.com/w3c/dxwg/issues/#91">#91</a>),  version identifier (Issue <a href="https://github.com/w3c/dxwg/issues/#92">#92</a>),  version compatibility (Issue <a href="https://github.com/w3c/dxwg/issues/#1258">#1258</a>) and resource status (Issue <a href="https://github.com/w3c/dxwg/issues/#1238">#1238</a>). 


### PR DESCRIPTION
Rendered at https://raw.githack.com/w3c/dxwg/dcat-broken-links/dcat/index.html

Broken links at line 3087 (frictionlessdata) and 6492 (internal link to example) 