### PR TITLE
Revise usage notes of dcat:bbox and dct:centroid

### DIFF
--- a/dcat/index.html
+++ b/dcat/index.html
@@ -6454,7 +6454,7 @@ ga-courts:jc-wms
 
 <ul>
 <li>The usage note of property <a href="#Property:location_geometry"><code title="http://www.w3.org/ns/locn#geometry">locn:geometry</code></a> has been revised to make it clearer that it can be used with either geometry literals or classes.</li>
-<li>The usage notes of properties <a href="#Property:location_bbox"><code title="http://www.w3.org/ns/dcat#bbox">dcat:bbox</code></a> and <a href="#Property:location_centroid"><code title="http://www.w3.org/ns/dcat#centroid">dcat:centroid</code></a> has been revised to make it clearer that they are supposed to be used only with with either geometry literals.</li>
+<li>The usage notes of properties <a href="#Property:location_bbox"><code title="http://www.w3.org/ns/dcat#bbox">dcat:bbox</code></a> and <a href="#Property:location_centroid"><code title="http://www.w3.org/ns/dcat#centroid">dcat:centroid</code></a> has been revised to make it clearer that they are supposed to be used only with geometry literals.</li>
 </ul>
 
 </section>

--- a/dcat/index.html
+++ b/dcat/index.html
@@ -3633,7 +3633,7 @@ The interval can also be open - i.e., it can have just a start or just an end.</
 </tr>
 <tr><th class="prop">Definition:</th><td>Associates any resource with the corresponding geometry. [[LOCN]]</td></tr>
 <tr><th class="prop">Range:</th><td><a data-cite="LOCN#locn:Geometry"><code title="https://www.w3.org/ns/locn#Geometry">locn:Geometry</code></a></td></tr>
-<tr><th class="prop">Usage note:</th><td>The range of this property (<code title="https://www.w3.org/ns/locn#Geometry">locn:Geometry</code>) allows for any type of geometry specification. E.g., the geometry could be encoded by a literal, as <abbr title="Well-known Text">WKT</abbr> (<a href="http://www.opengis.net/ont/geosparql#wktLiteral"><code title="http://www.opengis.net/ont/geosparql#wktLiteral">geosparql:wktLiteral</code></a> [[GeoSPARQL]]), or represented by a class, as <code>geosparql:Geometry</code> (or any of its subclasses) [[GeoSPARQL]].</td></tr>
+<tr><th class="prop">Usage note:</th><td>The range of this property (<code title="https://www.w3.org/ns/locn#Geometry">locn:Geometry</code>) allows for any type of geometry specification. E.g., the geometry could be encoded by a literal, as <abbr title="Well-known Text">WKT</abbr> (<a href="http://www.opengis.net/ont/geosparql#wktLiteral"><code title="http://www.opengis.net/ont/geosparql#wktLiteral">geosparql:wktLiteral</code></a> [[GeoSPARQL]]), or represented by a class, as <a href="http://www.opengis.net/ont/geosparql#Geometry"><code title="http://www.opengis.net/ont/geosparql#Geometry">geosparql:Geometry</code></a> (or any of its subclasses) [[GeoSPARQL]].</td></tr>
 </table>
 <!--
             <aside class="note">
@@ -3659,7 +3659,7 @@ The interval can also be open - i.e., it can have just a start or just an end.</
 </tr>
 <tr><th class="prop">Definition:</th><td>The geographic bounding box of a resource.</td></tr>
 <tr><th class="prop">Range:</th><td><a data-cite="RDF-SCHEMA#ch_literal"><code title="http://www.w3.org/2000/01/rdf-schema#Literal">rdfs:Literal</code></a></td></tr>
-<tr><th class="prop">Usage note:</th><td>The range of this property is intentionally generic, with the purpose of allowing different geometry encodings. E.g., the geometry could be encoded as <abbr title="Well-known Text">WKT</abbr> (<a href="http://www.opengis.net/ont/geosparql#wktLiteral"><code title="http://www.opengis.net/ont/geosparql#wktLiteral">geosparql:wktLiteral</code></a> [[GeoSPARQL]]).</td></tr>
+<tr><th class="prop">Usage note:</th><td>The range of this property (<code>rdfs:Literal</code>) is intentionally generic, with the purpose of allowing different geometry literal encodings. E.g., the geometry could be encoded as a <abbr title="Well-known Text">WKT</abbr> literal (<a href="http://www.opengis.net/ont/geosparql#wktLiteral"><code title="http://www.opengis.net/ont/geosparql#wktLiteral">geosparql:wktLiteral</code></a> [[GeoSPARQL]]).</td></tr>
 </table>
 
             <aside class="note">
@@ -3686,7 +3686,7 @@ The interval can also be open - i.e., it can have just a start or just an end.</
 </tr>
 <tr><th class="prop">Definition:</th><td>The geographic center (centroid) of a resource.</td></tr>
 <tr><th class="prop">Range:</th><td><a data-cite="RDF-SCHEMA#ch_literal"><code title="http://www.w3.org/2000/01/rdf-schema#Literal">rdfs:Literal</code></a></td></tr>
-<tr><th class="prop">Usage note:</th><td>The range of this property is intentionally generic, with the purpose of allowing different geometry encodings. E.g., the geometry could be encoded as <abbr title="Well-known Text">WKT</abbr> (<a href="http://www.opengis.net/ont/geosparql#wktLiteral"><code title="http://www.opengis.net/ont/geosparql#wktLiteral">geosparql:wktLiteral</code></a> [[GeoSPARQL]]).</td></tr>
+<tr><th class="prop">Usage note:</th><td>The range of this property (<code>rdfs:Literal</code>) is intentionally generic, with the purpose of allowing different geometry literal encodings. E.g., the geometry could be encoded as a <abbr title="Well-known Text">WKT</abbr> literal (<a href="http://www.opengis.net/ont/geosparql#wktLiteral"><code title="http://www.opengis.net/ont/geosparql#wktLiteral">geosparql:wktLiteral</code></a> [[GeoSPARQL]]).</td></tr>
 </table>
 
             <aside class="note">

--- a/dcat/index.html
+++ b/dcat/index.html
@@ -6453,8 +6453,8 @@ ga-courts:jc-wms
 <p>The document has undergone the following changes since the DCAT 3 second public working draft of 4 May 2021 [[?VOCAB-DCAT-3-20210504]]:</p>
 
 <ul>
-<li>The usage note of property <a href="#Property:location_geometry"><code title="http://www.w3.org/ns/locn#geometry">locn:geometry</code></a> has been revised to make it clearer that it can be used with either geometry literals or classes.</li>
-<li>The usage notes of properties <a href="#Property:location_bbox"><code title="http://www.w3.org/ns/dcat#bbox">dcat:bbox</code></a> and <a href="#Property:location_centroid"><code title="http://www.w3.org/ns/dcat#centroid">dcat:centroid</code></a> has been revised to make it clearer that they are supposed to be used only with geometry literals.</li>
+<li>The usage note of property <a href="#Property:location_geometry"><code title="http://www.w3.org/ns/locn#geometry">locn:geometry</code></a> has been revised to make it clearer that it can be used with either geometry literals or classes - see Issue <a href="https://github.com/w3c/dxwg/issues/1359">#1359</a>.</li>
+<li>The usage notes of properties <a href="#Property:location_bbox"><code title="http://www.w3.org/ns/dcat#bbox">dcat:bbox</code></a> and <a href="#Property:location_centroid"><code title="http://www.w3.org/ns/dcat#centroid">dcat:centroid</code></a> have been revised to make it clearer that they are supposed to be used only with geometry literals - see Issue <a href="https://github.com/w3c/dxwg/issues/1359">#1359</a>.</li>
 </ul>
 
 </section>

--- a/dcat/index.html
+++ b/dcat/index.html
@@ -6440,8 +6440,10 @@ ga-courts:jc-wms
 
 
 <section id="changes" class="appendix">
-    <h2>Change history</h2>
-    <p>A full change-log is available on <a href="https://github.com/w3c/dxwg/commits/gh-pages/dcat">GitHub</a></p>
+
+<h2>Change history</h2>
+
+<p>A full change-log is available on <a href="https://github.com/w3c/dxwg/commits/gh-pages/dcat">GitHub</a></p>
 	
 
 <section id="changes-since-20210504">
@@ -6451,8 +6453,8 @@ ga-courts:jc-wms
 <p>The document has undergone the following changes since the DCAT 3 second public working draft of 4 May 2021 [[?VOCAB-DCAT-3-20210504]]:</p>
 
 <ul>
-<li>The usage note of property <a href="#Class:Location_geometry"><code title="http://www.w3.org/ns/locn#geometry">locn:geometry</code></a> has been revised to make it clearer that it can be used with either geometry literals or classes.</li>
-<li>The usage notes of properties <a href="#Class:Location_bbox"><code title="http://www.w3.org/ns/dcat#bbox">dcat:bbox</code></a> and <a href="#Class:Location_centroid"><code title="http://www.w3.org/ns/dcat#centroid">dcat:centroid</code></a> has been revised to make it clearer that they are supposed to be used only with with either geometry literals.</li>
+<li>The usage note of property <a href="#Property:location_geometry"><code title="http://www.w3.org/ns/locn#geometry">locn:geometry</code></a> has been revised to make it clearer that it can be used with either geometry literals or classes.</li>
+<li>The usage notes of properties <a href="#Property:location_bbox"><code title="http://www.w3.org/ns/dcat#bbox">dcat:bbox</code></a> and <a href="#Property:location_centroid"><code title="http://www.w3.org/ns/dcat#centroid">dcat:centroid</code></a> has been revised to make it clearer that they are supposed to be used only with with either geometry literals.</li>
 </ul>
 
 </section>

--- a/dcat/index.html
+++ b/dcat/index.html
@@ -6453,7 +6453,6 @@ ga-courts:jc-wms
 <p>The document has undergone the following changes since the DCAT 3 second public working draft of 4 May 2021 [[?VOCAB-DCAT-3-20210504]]:</p>
 
 <ul>
-<li>The usage note of property <a href="#Property:location_geometry"><code title="http://www.w3.org/ns/locn#geometry">locn:geometry</code></a> has been revised to make it clearer that it can be used with either geometry literals or classes - see Issue <a href="https://github.com/w3c/dxwg/issues/1359">#1359</a>.</li>
 <li>The usage notes of properties <a href="#Property:location_bbox"><code title="http://www.w3.org/ns/dcat#bbox">dcat:bbox</code></a> and <a href="#Property:location_centroid"><code title="http://www.w3.org/ns/dcat#centroid">dcat:centroid</code></a> have been revised to make it clearer that they are supposed to be used only with geometry literals - see Issue <a href="https://github.com/w3c/dxwg/issues/1359">#1359</a>.</li>
 </ul>
 
@@ -6490,6 +6489,7 @@ ga-courts:jc-wms
 </ul>
 </li>
 <li>Added property <a href="#Property:distribution_checksum"><code>spdx:checksum</code></a> to <a href="#Class:Distribution"></a>; added class <code>spdx:Checksum</code> (see <a href="#Class:Checksum"></a>), and its properties <a href="#Property:checksum_algorithm"><code>spdx:algorithm</code></a> and <a href="#Property:checksum_checksum_value"><code>spdx:checksumValue</code></a> - see Issue <a href="https://github.com/w3c/dxwg/issues/1287">#1287</a>.</li>
+<li>Revised range of property <a href="#Property:location_geometry"><code title="http://www.w3.org/ns/locn#geometry">locn:geometry</code></a>, to align it with its definition in [[LOCN]]. The usage note of this property has been also revised to make it clear that it can be used with either geometry literals or classes - see Issue <a href="https://github.com/w3c/dxwg/issues/1293">#1293</a>.</li>
 <li>Added examples to <a href="#license-rights"></a> - see Issues <a href="https://github.com/w3c/dxwg/issues/676">#676</a> and <a href="https://github.com/w3c/dxwg/issues/1333">#1333</a>.</li>
 <li>Replaced [[?DCTERMS]] namespace prefix <code>dct:</code> with <code>dcterms:</code> throughout the document - see Issue <a href="https://github.com/w3c/dxwg/issues/1314">#1314</a>.</li>
 <li>Fixed inconsistent use of "URI" and "IRI" throughout the document - see Issue <a href="https://github.com/w3c/dxwg/issues/1341">#1341</a>.</li>

--- a/dcat/index.html
+++ b/dcat/index.html
@@ -6443,6 +6443,19 @@ ga-courts:jc-wms
     <h2>Change history</h2>
     <p>A full change-log is available on <a href="https://github.com/w3c/dxwg/commits/gh-pages/dcat">GitHub</a></p>
 	
+
+<section id="changes-since-20210504">
+
+<h2>Changes since the second public working draft of 4 May 2021</h2>
+
+<p>The document has undergone the following changes since the DCAT 3 second public working draft of 4 May 2021 [[?VOCAB-DCAT-3-20210504]]:</p>
+
+<ul>
+<li>The usage note of property <a href="#Class:Location_geometry"><code title="http://www.w3.org/ns/locn#geometry">locn:geometry</code></a> has been revised to make it clearer that it can be used with either geometry literals or classes.</li>
+<li>The usage notes of properties <a href="#Class:Location_bbox"><code title="http://www.w3.org/ns/dcat#bbox">dcat:bbox</code></a> and <a href="#Class:Location_centroid"><code title="http://www.w3.org/ns/dcat#centroid">dcat:centroid</code></a> has been revised to make it clearer that they are supposed to be used only with with either geometry literals.</li>
+</ul>
+
+</section>
 	
 <section id="changes-since-20201217">
 

--- a/dcat/rdf/dcat3.jsonld
+++ b/dcat/rdf/dcat3.jsonld
@@ -1,105 +1,111 @@
 {
   "@graph" : [ {
     "@id" : "_:b0",
+    "@type" : "owl:Restriction",
+    "maxCardinality" : "1",
+    "onProperty" : "dcat:endpointURL"
+  }, {
+    "@id" : "_:b1",
+    "seeAlso" : "https://orcid.org/0000-0001-5648-2713",
+    "homepage" : [ "https://w3id.org/people/ralbertoni/", "http://www.imati.cnr.it/index.php/people/8-curricula/178-riccardo-albertoni" ],
+    "foaf:name" : "Riccardo Albertoni"
+  }, {
+    "@id" : "_:b10",
+    "seeAlso" : "https://orcid.org/0000-0001-9300-2694",
+    "homepage" : "http://www.andrea-perego.name/foaf/#me",
+    "foaf:name" : "Andrea Perego"
+  }, {
+    "@id" : "_:b11",
+    "seeAlso" : "https://jakub.klímek.com/#me",
+    "homepage" : "https://jakub.klímek.com/",
+    "foaf:name" : "Jakub Klímek"
+  }, {
+    "@id" : "_:b12",
+    "affiliation" : "_:b4",
+    "seeAlso" : "https://orcid.org/0000-0003-3499-8262",
+    "homepage" : "https://agbeltran.github.io",
+    "foaf:name" : "Alejandra Gonzalez-Beltran"
+  }, {
+    "@id" : "_:b13",
+    "homepage" : "http://www.asahi-net.or.jp/~ax2s-kmtn/",
+    "foaf:name" : "Shuji Kamitsuna"
+  }, {
+    "@id" : "_:b14",
+    "foaf:name" : "Marios Meimaris"
+  }, {
+    "@id" : "_:b15",
+    "homepage" : "http://www.w3.org/2011/gld/",
+    "foaf:name" : "Government Linked Data WG"
+  }, {
+    "@id" : "_:b16",
+    "@type" : "owl:Restriction",
+    "allValuesFrom" : "dcat:Resource",
+    "onProperty" : "dcterms:hasPart"
+  }, {
+    "@id" : "_:b17",
+    "homepage" : "https://csiro.au",
+    "foaf:name" : "Commonwealth Scientific and Industrial Research Organisation"
+  }, {
+    "@id" : "_:b2",
+    "homepage" : "http://okfn.org",
+    "foaf:name" : "Open Knowledge Foundation"
+  }, {
+    "@id" : "_:b20",
+    "affiliation" : "_:b2",
+    "foaf:name" : "Rufus Pollock"
+  }, {
+    "@id" : "_:b21",
+    "@type" : "owl:Restriction",
+    "minCardinality" : "1",
+    "onProperty" : "dcterms:relation"
+  }, {
+    "@id" : "_:b22",
+    "foaf:name" : "Boris Villazón-Terrazas"
+  }, {
+    "@id" : "_:b23",
+    "seeAlso" : "http://www.eurecom.fr/~atemezin/gatemezing-foaf.rdf",
+    "foaf:name" : "Ghislain Auguste Atemezing"
+  }, {
+    "@id" : "_:b24",
     "affiliation" : "http://www.w3.org/data#W3C",
     "seeAlso" : "http://philarcher.org/foaf.rdf#me",
     "homepage" : "http://www.w3.org/People/all#phila",
     "foaf:name" : "Phil Archer"
   }, {
-    "@id" : "_:b10",
-    "homepage" : "http://stfc.ac.uk",
-    "foaf:name" : "Science and Technology Facilities Council, UK"
-  }, {
-    "@id" : "_:b11",
-    "@type" : "owl:Class",
-    "unionOf" : {
-      "@list" : [ "prov:Attribution", "dcat:Relationship" ]
-    }
-  }, {
-    "@id" : "_:b12",
-    "foaf:name" : "Richard Cyganiak"
-  }, {
-    "@id" : "_:b13",
-    "homepage" : "http://www.w3.org/2011/gld/",
-    "foaf:name" : "Government Linked Data WG"
-  }, {
-    "@id" : "_:b15",
-    "homepage" : "https://csiro.au",
-    "foaf:name" : "Commonwealth Scientific and Industrial Research Organisation"
-  }, {
-    "@id" : "_:b16",
-    "@type" : "owl:Restriction",
-    "maxCardinality" : "1",
-    "onProperty" : "dcat:endpointURL"
-  }, {
-    "@id" : "_:b17",
+    "@id" : "_:b25",
     "seeAlso" : "http://makxdekkers.com/makxdekkers.rdf#me",
     "homepage" : "http://makxdekkers.com/",
     "foaf:name" : "Makx Dekkers"
   }, {
-    "@id" : "_:b18",
-    "@type" : "owl:Restriction",
-    "allValuesFrom" : "dcat:Resource",
-    "onProperty" : "dcterms:hasPart"
-  }, {
-    "@id" : "_:b19",
+    "@id" : "_:b26",
     "foaf:name" : "John Erickson"
   }, {
-    "@id" : "_:b2",
-    "homepage" : "http://ec.europa.eu/dgs/informatics/",
-    "foaf:name" : "European Commission, DG DIGIT"
-  }, {
-    "@id" : "_:b20",
-    "homepage" : "http://www.asahi-net.or.jp/~ax2s-kmtn/",
-    "foaf:name" : "Shuji Kamitsuna"
-  }, {
-    "@id" : "_:b23",
-    "@type" : "owl:Restriction",
-    "cardinality" : "1",
-    "onProperty" : "foaf:primaryTopic"
-  }, {
-    "@id" : "_:b24",
-    "seeAlso" : "http://fadmaa.me/foaf.ttl",
-    "foaf:name" : "Fadi Maali"
-  }, {
-    "@id" : "_:b25",
-    "affiliation" : "_:b2",
-    "foaf:name" : "Vassilios Peristeras"
-  }, {
-    "@id" : "_:b26",
-    "seeAlso" : "http://www.eurecom.fr/~atemezin/gatemezing-foaf.rdf",
-    "foaf:name" : "Ghislain Auguste Atemezing"
-  }, {
     "@id" : "_:b27",
-    "seeAlso" : "https://jakub.klímek.com/#me",
-    "homepage" : "https://jakub.klímek.com/",
-    "foaf:name" : "Jakub Klímek"
-  }, {
-    "@id" : "_:b28",
     "@type" : "foaf:Person",
-    "affiliation" : "_:b15",
+    "affiliation" : "_:b17",
     "seeAlso" : "https://orcid.org/0000-0002-3884-3420",
     "foaf:name" : "Simon J D Cox",
     "workInfoHomepage" : "http://people.csiro.au/Simon-Cox"
   }, {
+    "@id" : "_:b28",
+    "affiliation" : "_:b32",
+    "foaf:name" : "David Browning"
+  }, {
     "@id" : "_:b29",
     "foaf:name" : "Martin Alvarez-Espinar"
   }, {
-    "@id" : "_:b3",
-    "foaf:name" : "Boris Villazón-Terrazas"
-  }, {
     "@id" : "_:b30",
-    "seeAlso" : "https://orcid.org/0000-0001-9300-2694",
-    "homepage" : "http://www.andrea-perego.name/foaf/#me",
-    "foaf:name" : "Andrea Perego"
+    "seeAlso" : "http://fadmaa.me/foaf.ttl",
+    "foaf:name" : "Fadi Maali"
   }, {
     "@id" : "_:b31",
-    "foaf:name" : "Marios Meimaris"
+    "@type" : "owl:Restriction",
+    "cardinality" : "1",
+    "onProperty" : "foaf:primaryTopic"
   }, {
     "@id" : "_:b32",
-    "@type" : "owl:Restriction",
-    "minCardinality" : "1",
-    "onProperty" : "dcterms:relation"
+    "homepage" : "http://www.refinitiv.com",
+    "foaf:name" : "Refinitiv"
   }, {
     "@id" : "_:b33",
     "@type" : "owl:Restriction",
@@ -107,36 +113,30 @@
     "onProperty" : "foaf:primaryTopic"
   }, {
     "@id" : "_:b4",
-    "affiliation" : "_:b5",
-    "foaf:name" : "David Browning"
+    "homepage" : "http://stfc.ac.uk",
+    "foaf:name" : "Science and Technology Facilities Council, UK"
   }, {
     "@id" : "_:b5",
-    "homepage" : "http://www.refinitiv.com",
-    "foaf:name" : "Refinitiv"
-  }, {
-    "@id" : "_:b6",
-    "seeAlso" : "https://orcid.org/0000-0001-5648-2713",
-    "homepage" : [ "https://w3id.org/people/ralbertoni/", "http://www.imati.cnr.it/index.php/people/8-curricula/178-riccardo-albertoni" ],
-    "foaf:name" : "Riccardo Albertoni"
+    "@type" : "owl:Class",
+    "unionOf" : {
+      "@list" : [ "prov:Attribution", "dcat:Relationship" ]
+    }
   }, {
     "@id" : "_:b7",
     "affiliation" : "_:b8",
-    "foaf:name" : "Rufus Pollock"
+    "foaf:name" : "Vassilios Peristeras"
   }, {
     "@id" : "_:b8",
-    "homepage" : "http://okfn.org",
-    "foaf:name" : "Open Knowledge Foundation"
+    "homepage" : "http://ec.europa.eu/dgs/informatics/",
+    "foaf:name" : "European Commission, DG DIGIT"
   }, {
     "@id" : "_:b9",
-    "affiliation" : "_:b10",
-    "seeAlso" : "https://orcid.org/0000-0003-3499-8262",
-    "homepage" : "https://agbeltran.github.io",
-    "foaf:name" : "Alejandra Gonzalez-Beltran"
+    "foaf:name" : "Richard Cyganiak"
   }, {
     "@id" : "http://www.w3.org/ns/dcat",
     "@type" : "owl:Ontology",
-    "contributor" : [ "_:b26", "_:b3", "_:b17", "_:b12", "_:b27", "_:b28", "_:b29", "_:b30", "_:b25", "_:b31", "_:b7", "_:b6", "_:b9", "_:b4", "_:b0", "_:b20" ],
-    "creator" : [ "_:b24", "_:b19" ],
+    "contributor" : [ "_:b14", "_:b23", "_:b10", "_:b7", "_:b20", "_:b11", "_:b24", "_:b9", "_:b1", "_:b13", "_:b22", "_:b25", "_:b12", "_:b27", "_:b28", "_:b29" ],
+    "creator" : [ "_:b26", "_:b30" ],
     "license" : "https://creativecommons.org/licenses/by/4.0/",
     "modified" : [ "2021-04-08", "2020-11-30", "2012-04-24", "2017-12-19", "2013-09-20", "2021-03-09", "2013-11-28" ],
     "dcterms:modified" : "2019",
@@ -217,7 +217,7 @@
       "@language" : "en",
       "@value" : "English language definitions updated in this revision in line with ED. Multilingual text unevenly updated."
     },
-    "maker" : "_:b13"
+    "maker" : "_:b15"
   }, {
     "@id" : "dcat:Catalog",
     "@type" : [ "owl:Class", "rdfs:Class" ],
@@ -278,7 +278,7 @@
       "@language" : "fr",
       "@value" : "Catalogue"
     } ],
-    "subClassOf" : [ "dcat:Dataset", "_:b18" ],
+    "subClassOf" : [ "dcat:Dataset", "_:b16" ],
     "skos:definition" : [ {
       "@language" : "da",
       "@value" : "En samling af metadata om ressourcer."
@@ -393,7 +393,7 @@
       "@language" : "fr",
       "@value" : "Registre du catalogue"
     } ],
-    "subClassOf" : [ "_:b23", "_:b33" ],
+    "subClassOf" : [ "_:b33", "_:b31" ],
     "skos:definition" : [ {
       "@language" : "it",
       "@value" : "Un record in un catalogo di dati che descrive un singolo dataset o servizio di dati."
@@ -424,6 +424,9 @@
       "@value" : "English definition updated in this revision. Multilingual text not yet updated except the Spanish one and the Czech one and Italian one."
     },
     "skos:scopeNote" : [ {
+      "@language" : "ja",
+      "@value" : "このクラスはオプションで、すべてのカタログがそれを用いるとは限りません。これは、データセットに関するメタデータとカタログ内のデータセットのエントリーに関するメタデータとで区別が行われるカタログのために存在しています。例えば、データセットの公開日プロパティーは、公開機関が情報を最初に利用可能とした日付を示しますが、カタログ・レコードの公開日は、データセットがカタログに追加された日付です。両方の日付が異っていたり、後者だけが分かっている場合は、カタログ・レコードに対してのみ公開日を指定すべきです。W3CのPROVオントロジー[prov-o]を用いれば、データセットに対する特定の変更に関連するプロセスやエージェントの詳細などの、さらに詳しい来歴情報の記述が可能となることに注意してください。"
+    }, {
       "@language" : "it",
       "@value" : "Questa classe è opzionale e non tutti i cataloghi la utilizzeranno. Esiste per cataloghi in cui si opera una distinzione tra i metadati relativi al dataset ed i metadati relativi alla gestione del dataset nel catalogo. Ad esempio, la  proprietà per indicare la data di pubblicazione del dataset rifletterà la data in cui l'informazione è stata originariamente messa a disposizione dalla casa editrice, mentre la data di pubblicazione per il record nel catalogo rifletterà la data in cui il dataset è stato aggiunto al catalogo. Nei casi dove solo quest'ultima sia nota, si utilizzerà esclusivamente la data di  pubblicazione relativa al record del catalogo. Si noti che l'Ontologia W3C PROV permette di descrivere ulteriori informazioni sulla provenienza, quali i dettagli del processo, la procedura e l'agente coinvolto in una particolare modifica di un dataset."
     }, {
@@ -441,9 +444,6 @@
     }, {
       "@language" : "da",
       "@value" : "Denne klasse er valgfri og ikke alle kataloger vil anvende denne klasse. Den kan anvendes i de kataloger hvor der skelnes mellem metadata om datasættet eller datatjenesten og metadata om selve posten til registreringen af datasættet eller datatjenesten i kataloget. Udgivelsesdatoen for datasættet afspejler for eksempel den dato hvor informationerne oprindeligt blev gjort tilgængelige af udgiveren, hvorimod udgivelsesdatoen for katalogposten er den dato hvor datasættet blev føjet til kataloget. I de tilfælde hvor de to datoer er forskellige eller hvor blot sidstnævnte er kendt, bør udgivelsesdatoen kun angives for katalogposten. Bemærk at W3Cs PROV ontologi gør til muligt at tilføje yderligere proveniensoplysninger eksempelvis om processen eller aktøren involveret i en given ændring af datasættet."
-    }, {
-      "@language" : "ja",
-      "@value" : "このクラスはオプションで、すべてのカタログがそれを用いるとは限りません。これは、データセットに関するメタデータとカタログ内のデータセットのエントリーに関するメタデータとで区別が行われるカタログのために存在しています。例えば、データセットの公開日プロパティーは、公開機関が情報を最初に利用可能とした日付を示しますが、カタログ・レコードの公開日は、データセットがカタログに追加された日付です。両方の日付が異っていたり、後者だけが分かっている場合は、カタログ・レコードに対してのみ公開日を指定すべきです。W3CのPROVオントロジー[prov-o]を用いれば、データセットに対する特定の変更に関連するプロセスやエージェントの詳細などの、さらに詳しい来歴情報の記述が可能となることに注意してください。"
     }, {
       "@language" : "fr",
       "@value" : "C'est une classe facultative et tous les catalogues ne l'utiliseront pas. Cette classe existe pour les catalogues\tayant une distinction entre les métadonnées sur le jeu de données et les métadonnées sur une entrée du jeu de données dans le catalogue."
@@ -480,7 +480,7 @@
       "@language" : "da",
       "@value" : "Datatjeneste"
     } ],
-    "subClassOf" : [ "_:b16", "dctype:Service", "dcat:Resource" ],
+    "subClassOf" : [ "dctype:Service", "_:b0", "dcat:Resource" ],
     "skos:altLabel" : {
       "@language" : "da",
       "@value" : "Dataservice"
@@ -859,7 +859,7 @@
       "@language" : "en",
       "@value" : "Relationship"
     } ],
-    "subClassOf" : "_:b32",
+    "subClassOf" : "_:b21",
     "skos:changeNote" : [ {
       "@language" : "it",
       "@value" : "Nuova classe aggiunta in DCAT 2.0."
@@ -1372,18 +1372,22 @@
       "@language" : "en",
       "@value" : "The geographic bounding box of a resource."
     } ],
+    "skos:editorialNote" : {
+      "@language" : "en",
+      "@value" : "English language definitions and comments updated in this revision in line with ED. Multilingual text unevenly updated."
+    },
     "skos:scopeNote" : [ {
       "@language" : "es",
       "@value" : "El rango de esta propiedad es intencionalmente genérico con el propósito de permitir distintas codificaciones geométricas. Por ejemplo, la geometría puede ser codificada como WKT (geosparql:wktLiteral [GeoSPARQL]) o [GML] (geosparql:asGML [GeoSPARQL])."
     }, {
       "@language" : "en",
-      "@value" : "The range of this property is intentionally generic, with the purpose of allowing different geometry encodings. E.g., the geometry could be encoded with as WKT (geosparql:wktLiteral [GeoSPARQL]) or [GML] (geosparql:asGML [GeoSPARQL])."
-    }, {
-      "@language" : "it",
-      "@value" : "Il range di questa proprietà è volutamente generica, con lo scopo di consentire diverse codifiche geometriche. Ad esempio, la geometria potrebbe essere codificata con WKT (geosparql:wktLiteral [GeoSPARQL]) o [GML] (geosparql:asGML [GeoSPARQL])."
+      "@value" : "The range of this property (rdfs:Literal) is intentionally generic, with the purpose of allowing different geometry literal encodings. E.g., the geometry could be encoded as a WKT literal (geosparql:wktLiteral [GeoSPARQL])."
     }, {
       "@language" : "cs",
       "@value" : "Obor hodnot této vlastnosti je úmyslně obecný, aby umožnil různé kódování geometrií. Geometrie by kupříkladu mohla být kódována jako WKT (geosparql:wktLiteral [GeoSPARQL]) či [GML] (geosparql:asGML [GeoSPARQL])."
+    }, {
+      "@language" : "it",
+      "@value" : "Il range di questa proprietà (rdfs:Literal) è volutamente generica, con lo scopo di consentire diverse codifiche geometriche letterali. Ad esempio, la geometria potrebbe essere codificata con un letterale WKT (geosparql:wktLiteral [GeoSPARQL]) o [GML] (geosparql:asGML [GeoSPARQL])."
     }, {
       "@language" : "da",
       "@value" : "Rækkevidden for denne egenskab er bevidst generisk defineret med det formål at tillade forskellige kodninger af geometrier. Geometrien kan eksempelvis repræsenteres som WKT (geosparql:asWKT [GeoSPARQL]) eller [GML] (geosparql:asGML [GeoSPARQL])."
@@ -1637,12 +1641,13 @@
       "@language" : "en",
       "@value" : "The geographic center (centroid) of a resource."
     } ],
+    "skos:editorialNote" : {
+      "@language" : "en",
+      "@value" : "English language definitions and comments updated in this revision in line with ED. Multilingual text unevenly updated."
+    },
     "skos:scopeNote" : [ {
       "@language" : "da",
       "@value" : "Rækkevidden for denne egenskab er bevidst generisk definere med det formål at tillade forskellige geokodninger. Geometrien kan eksempelvis repræsenteres som WKT (geosparql:asWKT [GeoSPARQL]) eller [GML] (geosparql:asGML [GeoSPARQL])."
-    }, {
-      "@language" : "en",
-      "@value" : "The range of this property is intentionally generic, with the purpose of allowing different geometry encodings. E.g., the geometry could be encoded with as WKT (geosparql:wktLiteral [GeoSPARQL]) or [GML] (geosparql:asGML [GeoSPARQL])."
     }, {
       "@language" : "cs",
       "@value" : "Obor hodnot této vlastnosti je úmyslně obecný, aby umožnil různé kódování geometrií. Geometrie by kupříkladu mohla být kódována jako WKT (geosparql:wktLiteral [GeoSPARQL]) či [GML] (geosparql:asGML [GeoSPARQL])."
@@ -1650,8 +1655,11 @@
       "@language" : "es",
       "@value" : "El rango de esta propiedad es intencionalmente genérico con el objetivo de permitir distintas codificaciones geométricas. Por ejemplo, la geometría puede codificarse como WKT (geosparql:wktLiteral [GeoSPARQL]) o [GML] (geosparql:asGML [GeoSPARQL])."
     }, {
+      "@language" : "en",
+      "@value" : "The range of this property (rdfs:Literal) is intentionally generic, with the purpose of allowing different geometry literal encodings. E.g., the geometry could be encoded as a WKT literal (geosparql:wktLiteral [GeoSPARQL])."
+    }, {
       "@language" : "it",
-      "@value" : "Il range di questa proprietà è volutamente generica, con lo scopo di consentire diverse codifiche geometriche. Ad esempio, la geometria potrebbe essere codificata con WKT (geosparql:wktLiteral [GeoSPARQL]) o [GML] (geosparql:asGML [GeoSPARQL])."
+      "@value" : "Il range di questa proprietà (rdfs:Literal) è volutamente generica, con lo scopo di consentire diverse codifiche geometriche letterali. Ad esempio, la geometria potrebbe essere codificata con un letterale WKT (geosparql:wktLiteral [GeoSPARQL]) o [GML] (geosparql:asGML [GeoSPARQL])."
     } ]
   }, {
     "@id" : "dcat:compressFormat",
@@ -2416,7 +2424,7 @@
       "@language" : "en",
       "@value" : "The function of an entity or agent with respect to another entity or resource."
     } ],
-    "domain" : "_:b11",
+    "domain" : "_:b5",
     "rdfs:label" : [ {
       "@language" : "it",
       "@value" : "tiene rol"
@@ -3846,6 +3854,14 @@
       "@id" : "http://www.w3.org/2000/01/rdf-schema#range",
       "@type" : "@id"
     },
+    "onProperty" : {
+      "@id" : "http://www.w3.org/2002/07/owl#onProperty",
+      "@type" : "@id"
+    },
+    "maxCardinality" : {
+      "@id" : "http://www.w3.org/2002/07/owl#maxCardinality",
+      "@type" : "http://www.w3.org/2001/XMLSchema#nonNegativeInteger"
+    },
     "name" : {
       "@id" : "http://xmlns.com/foaf/0.1/name",
       "@type" : "http://www.w3.org/2001/XMLSchema#string"
@@ -3858,9 +3874,9 @@
       "@id" : "http://www.w3.org/2000/01/rdf-schema#seeAlso",
       "@type" : "@id"
     },
-    "affiliation" : {
-      "@id" : "http://schema.org/affiliation",
-      "@type" : "@id"
+    "editorialNote" : {
+      "@id" : "http://www.w3.org/2004/02/skos/core#editorialNote",
+      "@type" : "http://www.w3.org/1999/02/22-rdf-syntax-ns#langString"
     },
     "rest" : {
       "@id" : "http://www.w3.org/1999/02/22-rdf-syntax-ns#rest",
@@ -3874,32 +3890,24 @@
       "@id" : "http://www.w3.org/2004/02/skos/core#altLabel",
       "@type" : "http://www.w3.org/1999/02/22-rdf-syntax-ns#langString"
     },
-    "editorialNote" : {
-      "@id" : "http://www.w3.org/2004/02/skos/core#editorialNote",
-      "@type" : "http://www.w3.org/1999/02/22-rdf-syntax-ns#langString"
-    },
     "unionOf" : {
       "@id" : "http://www.w3.org/2002/07/owl#unionOf",
       "@type" : "@id"
     },
-    "onProperty" : {
-      "@id" : "http://www.w3.org/2002/07/owl#onProperty",
-      "@type" : "@id"
-    },
-    "maxCardinality" : {
-      "@id" : "http://www.w3.org/2002/07/owl#maxCardinality",
-      "@type" : "http://www.w3.org/2001/XMLSchema#nonNegativeInteger"
-    },
-    "allValuesFrom" : {
-      "@id" : "http://www.w3.org/2002/07/owl#allValuesFrom",
+    "affiliation" : {
+      "@id" : "http://schema.org/affiliation",
       "@type" : "@id"
     },
     "rangeIncludes" : {
       "@id" : "http://schema.org/rangeIncludes",
       "@type" : "@id"
     },
-    "cardinality" : {
-      "@id" : "http://www.w3.org/2002/07/owl#cardinality",
+    "allValuesFrom" : {
+      "@id" : "http://www.w3.org/2002/07/owl#allValuesFrom",
+      "@type" : "@id"
+    },
+    "minCardinality" : {
+      "@id" : "http://www.w3.org/2002/07/owl#minCardinality",
       "@type" : "http://www.w3.org/2001/XMLSchema#nonNegativeInteger"
     },
     "versionInfo" : {
@@ -3914,10 +3922,6 @@
       "@id" : "http://purl.org/dc/terms/modified",
       "@type" : "http://www.w3.org/2001/XMLSchema#date"
     },
-    "maker" : {
-      "@id" : "http://xmlns.com/foaf/0.1/maker",
-      "@type" : "@id"
-    },
     "imports" : {
       "@id" : "http://www.w3.org/2002/07/owl#imports",
       "@type" : "@id"
@@ -3930,6 +3934,10 @@
       "@id" : "http://purl.org/dc/terms/creator",
       "@type" : "@id"
     },
+    "maker" : {
+      "@id" : "http://xmlns.com/foaf/0.1/maker",
+      "@type" : "@id"
+    },
     "subClassOf" : {
       "@id" : "http://www.w3.org/2000/01/rdf-schema#subClassOf",
       "@type" : "@id"
@@ -3938,13 +3946,13 @@
       "@id" : "http://www.w3.org/2002/07/owl#propertyChainAxiom",
       "@type" : "@id"
     },
+    "cardinality" : {
+      "@id" : "http://www.w3.org/2002/07/owl#cardinality",
+      "@type" : "http://www.w3.org/2001/XMLSchema#nonNegativeInteger"
+    },
     "workInfoHomepage" : {
       "@id" : "http://xmlns.com/foaf/0.1/workInfoHomepage",
       "@type" : "@id"
-    },
-    "minCardinality" : {
-      "@id" : "http://www.w3.org/2002/07/owl#minCardinality",
-      "@type" : "http://www.w3.org/2001/XMLSchema#nonNegativeInteger"
     },
     "owl" : "http://www.w3.org/2002/07/owl#",
     "rdf" : "http://www.w3.org/1999/02/22-rdf-syntax-ns#",

--- a/dcat/rdf/dcat3.rdf
+++ b/dcat/rdf/dcat3.rdf
@@ -17,122 +17,24 @@
     <owl:versionInfo xml:lang="en">Questa è una copia aggiornata del vocabolario DCAT v2.0 disponibile in https://www.w3.org/ns/dcat.ttl</owl:versionInfo>
     <rdfs:comment xml:lang="da">DCAT er et RDF-vokabular som har til formål at understøtte interoperabilitet mellem datakataloger udgivet på nettet. Ved at anvende DCAT til at beskrive datasæt i datakataloger, kan udgivere øge findbarhed og gøre det gøre det lettere for applikationer at anvende metadata fra forskellige kataloger. Derudover understøttes decentraliseret udstilling af kataloger og fødererede datasætsøgninger på tværs af websider. Aggregerede DCAT-metadata kan fungere som fortegnelsesfiler der kan understøtte digital bevaring. DCAT er defineret på http://www.w3.org/TR/vocab-dcat/. Enhver forskel mellem det normative dokument og dette schema er en fejl i dette schema.</rdfs:comment>
     <dcterms:contributor rdf:parseType="Resource">
-      <foaf:name>Vassilios Peristeras</foaf:name>
-      <sdo:affiliation rdf:parseType="Resource">
-        <foaf:name>European Commission, DG DIGIT</foaf:name>
-        <foaf:homepage rdf:resource="http://ec.europa.eu/dgs/informatics/"/>
-      </sdo:affiliation>
+      <foaf:name>Richard Cyganiak</foaf:name>
     </dcterms:contributor>
     <owl:versionInfo xml:lang="en">This is an updated copy of v2.0 of the DCAT vocabulary, taken from https://www.w3.org/ns/dcat.ttl</owl:versionInfo>
     <rdfs:label xml:lang="fr">Le vocabulaire des jeux de données</rdfs:label>
     <dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#date"
     >2021-04-08</dcterms:modified>
     <dcterms:contributor rdf:parseType="Resource">
-      <foaf:name>Richard Cyganiak</foaf:name>
+      <foaf:name>Phil Archer</foaf:name>
+      <foaf:homepage rdf:resource="http://www.w3.org/People/all#phila"/>
+      <rdfs:seeAlso rdf:resource="http://philarcher.org/foaf.rdf#me"/>
+      <sdo:affiliation rdf:resource="http://www.w3.org/data#W3C"/>
     </dcterms:contributor>
     <dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#date"
     >2020-11-30</dcterms:modified>
     <rdfs:comment xml:lang="fr">DCAT est un vocabulaire développé pour faciliter l'interopérabilité entre les jeux de données publiées sur le Web. En utilisant DCAT pour décrire les jeux de données dans les catalogues de données, les fournisseurs de données augmentent leur découverte et permettent que les applications facilement les métadonnées de plusieurs catalogues. Il permet en plus la publication décentralisée des catalogues et facilitent la recherche fédérée des données entre plusieurs sites. Les métadonnées DCAT aggrégées peuvent servir comme un manifeste pour faciliter la préservation digitale des ressources. DCAT est définie à l'adresse http://www.w3.org/TR/vocab-dcat/. Une quelconque version de ce document normatif et ce vocabulaire est une erreur dans ce vocabulaire.</rdfs:comment>
     <rdfs:label xml:lang="es">El vocabulario de catálogo de datos</rdfs:label>
     <owl:imports rdf:resource="http://www.w3.org/2004/02/skos/core"/>
-    <dcterms:contributor rdf:parseType="Resource">
-      <foaf:name>Rufus Pollock</foaf:name>
-      <sdo:affiliation rdf:parseType="Resource">
-        <foaf:name>Open Knowledge Foundation</foaf:name>
-        <foaf:homepage rdf:resource="http://okfn.org"/>
-      </sdo:affiliation>
-    </dcterms:contributor>
-    <dcterms:contributor rdf:parseType="Resource">
-      <foaf:name>Phil Archer</foaf:name>
-      <foaf:homepage rdf:resource="http://www.w3.org/People/all#phila"/>
-      <rdfs:seeAlso rdf:resource="http://philarcher.org/foaf.rdf#me"/>
-      <sdo:affiliation rdf:resource="http://www.w3.org/data#W3C"/>
-    </dcterms:contributor>
     <rdfs:comment xml:lang="cs">DCAT je RDF slovník navržený pro zprostředkování interoperability mezi datovými katalogy publikovanými na Webu. Poskytovatelé dat používáním slovníku DCAT pro popis datových sad v datových katalozích zvyšují jejich dohledatelnost a umožňují aplikacím konzumovat metadata z více katalogů. Dále je umožňena decentralizovaná publikace katalogů a federované dotazování na datové sady napříč katalogy. Agregovaná DCAT metadata mohou také sloužit jako průvodka umožňující digitální uchování informace. DCAT je definován na http://www.w3.org/TR/vocab-dcat/. Jakýkoliv nesoulad mezi odkazovaným dokumentem a tímto schématem je chybou v tomto schématu.</rdfs:comment>
-    <owl:versionInfo xml:lang="es">Esta es una copia del vocabulario DCAT v2.0 disponible en https://www.w3.org/ns/dcat.ttl</owl:versionInfo>
-    <dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#date"
-    >2012-04-24</dcterms:modified>
-    <rdfs:comment xml:lang="ar">هي أنطولوجية تسهل تبادل البيانات بين مختلف الفهارس على الوب. استخدام هذه الأنطولوجية يساعد على اكتشاف قوائم  البيانات المنشورة على الوب و يمكن التطبيقات المختلفة من الاستفادة أتوماتيكيا من البيانات المتاحة من مختلف الفهارس.</rdfs:comment>
-    <skos:editorialNote xml:lang="en">English language definitions updated in this revision in line with ED. Multilingual text unevenly updated.</skos:editorialNote>
-    <dcterms:contributor rdf:parseType="Resource">
-      <foaf:name>Riccardo Albertoni</foaf:name>
-      <foaf:homepage rdf:resource="https://w3id.org/people/ralbertoni/"/>
-      <foaf:homepage rdf:resource="http://www.imati.cnr.it/index.php/people/8-curricula/178-riccardo-albertoni"/>
-      <rdfs:seeAlso rdf:resource="https://orcid.org/0000-0001-5648-2713"/>
-    </dcterms:contributor>
-    <rdfs:label xml:lang="da">Datakatalogvokabular</rdfs:label>
-    <foaf:maker rdf:parseType="Resource">
-      <foaf:name>Government Linked Data WG</foaf:name>
-      <foaf:homepage rdf:resource="http://www.w3.org/2011/gld/"/>
-    </foaf:maker>
-    <dcterms:creator rdf:parseType="Resource">
-      <foaf:name>John Erickson</foaf:name>
-    </dcterms:creator>
-    <dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#date"
-    >2017-12-19</dcterms:modified>
-    <dcterms:creator rdf:parseType="Resource">
-      <foaf:name>Fadi Maali</foaf:name>
-      <rdfs:seeAlso rdf:resource="http://fadmaa.me/foaf.ttl"/>
-    </dcterms:creator>
-    <dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#date"
-    >2013-09-20</dcterms:modified>
-    <owl:imports rdf:resource="http://www.w3.org/ns/prov-o#"/>
-    <rdfs:comment xml:lang="ja">DCATは、ウェブ上で公開されたデータ・カタログ間の相互運用性の促進を目的とするRDFの語彙です。このドキュメントでは、その利用のために、スキーマを定義し、例を提供します。データ・カタログ内のデータセットを記述するためにDCATを用いると、公開者が、発見可能性を増加させ、アプリケーションが複数のカタログのメタデータを容易に利用できるようになります。さらに、カタログの分散公開を可能にし、複数のサイトにまたがるデータセットの統合検索を促進します。集約されたDCATメタデータは、ディジタル保存を促進するためのマニフェスト・ファイルとして使用できます。</rdfs:comment>
-    <owl:versionInfo xml:lang="da">Dette er en opdateret kopi af DCAT v. 2.0 som er tilgænglig på https://www.w3.org/ns/dcat.ttl</owl:versionInfo>
-    <rdfs:comment xml:lang="en">DCAT is an RDF vocabulary designed to facilitate interoperability between data catalogs published on the Web. By using DCAT to describe datasets in data catalogs, publishers increase discoverability and enable applications easily to consume metadata from multiple catalogs. It further enables decentralized publishing of catalogs and facilitates federated dataset search across sites. Aggregated DCAT metadata can serve as a manifest file to facilitate digital preservation. DCAT is defined at http://www.w3.org/TR/vocab-dcat/. Any variance between that normative document and this schema is an error in this schema.</rdfs:comment>
-    <dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#date"
-    >2021-03-09</dcterms:modified>
-    <dcterms:contributor rdf:parseType="Resource">
-      <foaf:name>Andrea Perego</foaf:name>
-      <foaf:homepage rdf:resource="http://www.andrea-perego.name/foaf/#me"/>
-      <rdfs:seeAlso rdf:resource="https://orcid.org/0000-0001-9300-2694"/>
-    </dcterms:contributor>
-    <dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#date"
-    >2013-11-28</dcterms:modified>
-    <dcterms:contributor rdf:parseType="Resource">
-      <foaf:name>Ghislain Auguste Atemezing</foaf:name>
-      <rdfs:seeAlso rdf:resource="http://www.eurecom.fr/~atemezin/gatemezing-foaf.rdf"/>
-    </dcterms:contributor>
-    <dcterms:modified>2019</dcterms:modified>
-    <dcterms:license rdf:resource="https://creativecommons.org/licenses/by/4.0/"/>
-    <dcterms:contributor rdf:parseType="Resource">
-      <foaf:name>Marios Meimaris</foaf:name>
-    </dcterms:contributor>
-    <dcterms:contributor rdf:parseType="Resource">
-      <foaf:name>Jakub Klímek</foaf:name>
-      <foaf:homepage rdf:resource="https://jakub.klímek.com/"/>
-      <rdfs:seeAlso rdf:resource="https://jakub.klímek.com/#me"/>
-    </dcterms:contributor>
-    <owl:imports rdf:resource="http://purl.org/dc/terms/"/>
-    <dcterms:contributor rdf:parseType="Resource">
-      <foaf:name>David Browning</foaf:name>
-      <sdo:affiliation rdf:parseType="Resource">
-        <foaf:name>Refinitiv</foaf:name>
-        <foaf:homepage rdf:resource="http://www.refinitiv.com"/>
-      </sdo:affiliation>
-    </dcterms:contributor>
-    <rdfs:comment xml:lang="es">DCAT es un vocabulario RDF diseñado para facilitar la interoperabilidad entre catálogos de datos publicados en la Web. Utilizando DCAT para describir datos disponibles en catálogos se aumenta la posibilidad de que sean descubiertos y se permite que las aplicaciones consuman fácilmente los metadatos de varios catálogos.</rdfs:comment>
-    <rdfs:label xml:lang="ar">أنطولوجية فهارس قوائم البيانات</rdfs:label>
-    <dcterms:contributor rdf:parseType="Resource">
-      <foaf:name>Alejandra Gonzalez-Beltran</foaf:name>
-      <foaf:homepage rdf:resource="https://agbeltran.github.io"/>
-      <rdfs:seeAlso rdf:resource="https://orcid.org/0000-0003-3499-8262"/>
-      <sdo:affiliation rdf:parseType="Resource">
-        <foaf:name>Science and Technology Facilities Council, UK</foaf:name>
-        <foaf:homepage rdf:resource="http://stfc.ac.uk"/>
-      </sdo:affiliation>
-    </dcterms:contributor>
-    <rdfs:label xml:lang="el">Το λεξιλόγιο των καταλόγων δεδομένων</rdfs:label>
-    <owl:versionInfo xml:lang="cs">Toto je aktualizovaná kopie slovníku DCAT verze 2.0, převzatá z https://www.w3.org/ns/dcat.ttl</owl:versionInfo>
-    <rdfs:comment xml:lang="el">Το DCAT είναι ένα RDF λεξιλόγιο που σχεδιάσθηκε για να κάνει εφικτή τη διαλειτουργικότητα μεταξύ καταλόγων δεδομένων στον Παγκόσμιο Ιστό. Χρησιμοποιώντας το DCAT για την περιγραφή συνόλων δεδομένων, οι εκδότες αυτών αυξάνουν την ανακαλυψιμότητα και επιτρέπουν στις εφαρμογές την εύκολη κατανάλωση μεταδεδομένων από πολλαπλούς καταλόγους. Επιπλέον, δίνει τη δυνατότητα για αποκεντρωμένη έκδοση και διάθεση καταλόγων και επιτρέπει δυνατότητες ενοποιημένης αναζήτησης μεταξύ διαφορετικών πηγών. Συγκεντρωτικά μεταδεδομένα που έχουν περιγραφεί με το DCAT μπορούν να χρησιμοποιηθούν σαν ένα δηλωτικό αρχείο (manifest file) ώστε να διευκολύνουν την ψηφιακή συντήρηση.</rdfs:comment>
-    <rdfs:label xml:lang="ja">データ・カタログ語彙（DCAT）</rdfs:label>
-    <dcterms:contributor rdf:parseType="Resource">
-      <foaf:name>Shuji Kamitsuna</foaf:name>
-      <foaf:homepage rdf:resource="http://www.asahi-net.or.jp/~ax2s-kmtn/"/>
-    </dcterms:contributor>
-    <dcterms:contributor rdf:parseType="Resource">
-      <foaf:name>Boris Villazón-Terrazas</foaf:name>
-    </dcterms:contributor>
     <dcterms:contributor rdf:parseType="Resource">
       <foaf:name>Makx Dekkers</foaf:name>
       <foaf:homepage rdf:resource="http://makxdekkers.com/"/>
@@ -141,7 +43,32 @@
     <dcterms:contributor rdf:parseType="Resource">
       <foaf:name>Martin Alvarez-Espinar</foaf:name>
     </dcterms:contributor>
-    <rdfs:comment xml:lang="it">DCAT è un vocabolario RDF progettato per facilitare l'interoperabilità tra i cataloghi di dati pubblicati nel Web. Utilizzando DCAT per descrivere i dataset nei cataloghi di dati, i fornitori migliorano la capacità di individuazione dei dati e abilitano le  applicazioni al consumo di dati provenienti da cataloghi differenti. DCAT permette di decentralizzare la pubblicazione di cataloghi e facilita la ricerca federata dei dataset. L'aggregazione dei metadati federati può fungere da file manifesto per facilitare la conservazione digitale. DCAT è definito all'indirizzo http://www.w3.org/TR/vocab-dcat/. Qualsiasi scostamento tra tale definizione normativa e questo schema è da considerarsi un errore di questo schema.</rdfs:comment>
+    <owl:versionInfo xml:lang="es">Esta es una copia del vocabulario DCAT v2.0 disponible en https://www.w3.org/ns/dcat.ttl</owl:versionInfo>
+    <dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#date"
+    >2012-04-24</dcterms:modified>
+    <rdfs:comment xml:lang="ar">هي أنطولوجية تسهل تبادل البيانات بين مختلف الفهارس على الوب. استخدام هذه الأنطولوجية يساعد على اكتشاف قوائم  البيانات المنشورة على الوب و يمكن التطبيقات المختلفة من الاستفادة أتوماتيكيا من البيانات المتاحة من مختلف الفهارس.</rdfs:comment>
+    <skos:editorialNote xml:lang="en">English language definitions updated in this revision in line with ED. Multilingual text unevenly updated.</skos:editorialNote>
+    <dcterms:contributor rdf:parseType="Resource">
+      <foaf:name>Marios Meimaris</foaf:name>
+    </dcterms:contributor>
+    <rdfs:label xml:lang="da">Datakatalogvokabular</rdfs:label>
+    <dcterms:contributor rdf:parseType="Resource">
+      <foaf:name>David Browning</foaf:name>
+      <sdo:affiliation rdf:parseType="Resource">
+        <foaf:name>Refinitiv</foaf:name>
+        <foaf:homepage rdf:resource="http://www.refinitiv.com"/>
+      </sdo:affiliation>
+    </dcterms:contributor>
+    <foaf:maker rdf:parseType="Resource">
+      <foaf:name>Government Linked Data WG</foaf:name>
+      <foaf:homepage rdf:resource="http://www.w3.org/2011/gld/"/>
+    </foaf:maker>
+    <dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#date"
+    >2017-12-19</dcterms:modified>
+    <dcterms:contributor rdf:parseType="Resource">
+      <foaf:name>Ghislain Auguste Atemezing</foaf:name>
+      <rdfs:seeAlso rdf:resource="http://www.eurecom.fr/~atemezin/gatemezing-foaf.rdf"/>
+    </dcterms:contributor>
     <dcterms:contributor>
       <foaf:Person>
         <foaf:workInfoHomepage rdf:resource="http://people.csiro.au/Simon-Cox"/>
@@ -153,6 +80,79 @@
         </sdo:affiliation>
       </foaf:Person>
     </dcterms:contributor>
+    <dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#date"
+    >2013-09-20</dcterms:modified>
+    <dcterms:contributor rdf:parseType="Resource">
+      <foaf:name>Jakub Klímek</foaf:name>
+      <foaf:homepage rdf:resource="https://jakub.klímek.com/"/>
+      <rdfs:seeAlso rdf:resource="https://jakub.klímek.com/#me"/>
+    </dcterms:contributor>
+    <dcterms:contributor rdf:parseType="Resource">
+      <foaf:name>Shuji Kamitsuna</foaf:name>
+      <foaf:homepage rdf:resource="http://www.asahi-net.or.jp/~ax2s-kmtn/"/>
+    </dcterms:contributor>
+    <owl:imports rdf:resource="http://www.w3.org/ns/prov-o#"/>
+    <rdfs:comment xml:lang="ja">DCATは、ウェブ上で公開されたデータ・カタログ間の相互運用性の促進を目的とするRDFの語彙です。このドキュメントでは、その利用のために、スキーマを定義し、例を提供します。データ・カタログ内のデータセットを記述するためにDCATを用いると、公開者が、発見可能性を増加させ、アプリケーションが複数のカタログのメタデータを容易に利用できるようになります。さらに、カタログの分散公開を可能にし、複数のサイトにまたがるデータセットの統合検索を促進します。集約されたDCATメタデータは、ディジタル保存を促進するためのマニフェスト・ファイルとして使用できます。</rdfs:comment>
+    <owl:versionInfo xml:lang="da">Dette er en opdateret kopi af DCAT v. 2.0 som er tilgænglig på https://www.w3.org/ns/dcat.ttl</owl:versionInfo>
+    <rdfs:comment xml:lang="en">DCAT is an RDF vocabulary designed to facilitate interoperability between data catalogs published on the Web. By using DCAT to describe datasets in data catalogs, publishers increase discoverability and enable applications easily to consume metadata from multiple catalogs. It further enables decentralized publishing of catalogs and facilitates federated dataset search across sites. Aggregated DCAT metadata can serve as a manifest file to facilitate digital preservation. DCAT is defined at http://www.w3.org/TR/vocab-dcat/. Any variance between that normative document and this schema is an error in this schema.</rdfs:comment>
+    <dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#date"
+    >2021-03-09</dcterms:modified>
+    <dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#date"
+    >2013-11-28</dcterms:modified>
+    <dcterms:modified>2019</dcterms:modified>
+    <dcterms:license rdf:resource="https://creativecommons.org/licenses/by/4.0/"/>
+    <dcterms:contributor rdf:parseType="Resource">
+      <foaf:name>Boris Villazón-Terrazas</foaf:name>
+    </dcterms:contributor>
+    <dcterms:contributor rdf:parseType="Resource">
+      <foaf:name>Rufus Pollock</foaf:name>
+      <sdo:affiliation rdf:parseType="Resource">
+        <foaf:name>Open Knowledge Foundation</foaf:name>
+        <foaf:homepage rdf:resource="http://okfn.org"/>
+      </sdo:affiliation>
+    </dcterms:contributor>
+    <owl:imports rdf:resource="http://purl.org/dc/terms/"/>
+    <dcterms:contributor rdf:parseType="Resource">
+      <foaf:name>Vassilios Peristeras</foaf:name>
+      <sdo:affiliation rdf:parseType="Resource">
+        <foaf:name>European Commission, DG DIGIT</foaf:name>
+        <foaf:homepage rdf:resource="http://ec.europa.eu/dgs/informatics/"/>
+      </sdo:affiliation>
+    </dcterms:contributor>
+    <rdfs:comment xml:lang="es">DCAT es un vocabulario RDF diseñado para facilitar la interoperabilidad entre catálogos de datos publicados en la Web. Utilizando DCAT para describir datos disponibles en catálogos se aumenta la posibilidad de que sean descubiertos y se permite que las aplicaciones consuman fácilmente los metadatos de varios catálogos.</rdfs:comment>
+    <rdfs:label xml:lang="ar">أنطولوجية فهارس قوائم البيانات</rdfs:label>
+    <rdfs:label xml:lang="el">Το λεξιλόγιο των καταλόγων δεδομένων</rdfs:label>
+    <dcterms:contributor rdf:parseType="Resource">
+      <foaf:name>Riccardo Albertoni</foaf:name>
+      <foaf:homepage rdf:resource="https://w3id.org/people/ralbertoni/"/>
+      <foaf:homepage rdf:resource="http://www.imati.cnr.it/index.php/people/8-curricula/178-riccardo-albertoni"/>
+      <rdfs:seeAlso rdf:resource="https://orcid.org/0000-0001-5648-2713"/>
+    </dcterms:contributor>
+    <dcterms:contributor rdf:parseType="Resource">
+      <foaf:name>Andrea Perego</foaf:name>
+      <foaf:homepage rdf:resource="http://www.andrea-perego.name/foaf/#me"/>
+      <rdfs:seeAlso rdf:resource="https://orcid.org/0000-0001-9300-2694"/>
+    </dcterms:contributor>
+    <owl:versionInfo xml:lang="cs">Toto je aktualizovaná kopie slovníku DCAT verze 2.0, převzatá z https://www.w3.org/ns/dcat.ttl</owl:versionInfo>
+    <dcterms:creator rdf:parseType="Resource">
+      <foaf:name>John Erickson</foaf:name>
+    </dcterms:creator>
+    <dcterms:contributor rdf:parseType="Resource">
+      <foaf:name>Alejandra Gonzalez-Beltran</foaf:name>
+      <foaf:homepage rdf:resource="https://agbeltran.github.io"/>
+      <rdfs:seeAlso rdf:resource="https://orcid.org/0000-0003-3499-8262"/>
+      <sdo:affiliation rdf:parseType="Resource">
+        <foaf:name>Science and Technology Facilities Council, UK</foaf:name>
+        <foaf:homepage rdf:resource="http://stfc.ac.uk"/>
+      </sdo:affiliation>
+    </dcterms:contributor>
+    <rdfs:comment xml:lang="el">Το DCAT είναι ένα RDF λεξιλόγιο που σχεδιάσθηκε για να κάνει εφικτή τη διαλειτουργικότητα μεταξύ καταλόγων δεδομένων στον Παγκόσμιο Ιστό. Χρησιμοποιώντας το DCAT για την περιγραφή συνόλων δεδομένων, οι εκδότες αυτών αυξάνουν την ανακαλυψιμότητα και επιτρέπουν στις εφαρμογές την εύκολη κατανάλωση μεταδεδομένων από πολλαπλούς καταλόγους. Επιπλέον, δίνει τη δυνατότητα για αποκεντρωμένη έκδοση και διάθεση καταλόγων και επιτρέπει δυνατότητες ενοποιημένης αναζήτησης μεταξύ διαφορετικών πηγών. Συγκεντρωτικά μεταδεδομένα που έχουν περιγραφεί με το DCAT μπορούν να χρησιμοποιηθούν σαν ένα δηλωτικό αρχείο (manifest file) ώστε να διευκολύνουν την ψηφιακή συντήρηση.</rdfs:comment>
+    <rdfs:label xml:lang="ja">データ・カタログ語彙（DCAT）</rdfs:label>
+    <rdfs:comment xml:lang="it">DCAT è un vocabolario RDF progettato per facilitare l'interoperabilità tra i cataloghi di dati pubblicati nel Web. Utilizzando DCAT per descrivere i dataset nei cataloghi di dati, i fornitori migliorano la capacità di individuazione dei dati e abilitano le  applicazioni al consumo di dati provenienti da cataloghi differenti. DCAT permette di decentralizzare la pubblicazione di cataloghi e facilita la ricerca federata dei dataset. L'aggregazione dei metadati federati può fungere da file manifesto per facilitare la conservazione digitale. DCAT è definito all'indirizzo http://www.w3.org/TR/vocab-dcat/. Qualsiasi scostamento tra tale definizione normativa e questo schema è da considerarsi un errore di questo schema.</rdfs:comment>
+    <dcterms:creator rdf:parseType="Resource">
+      <foaf:name>Fadi Maali</foaf:name>
+      <rdfs:seeAlso rdf:resource="http://fadmaa.me/foaf.ttl"/>
+    </dcterms:creator>
     <rdfs:label xml:lang="en">The data catalog vocabulary</rdfs:label>
   </owl:Ontology>
   <rdfs:Class rdf:about="http://www.w3.org/ns/dcat#Dataset">
@@ -220,6 +220,11 @@
     <rdfs:label xml:lang="it">Servizio di dati</rdfs:label>
     <skos:scopeNote xml:lang="en">The kind of service can be indicated using the dcterms:type property. Its value may be taken from a controlled vocabulary such as the INSPIRE spatial data service type vocabulary.</skos:scopeNote>
     <rdfs:subClassOf rdf:resource="http://purl.org/dc/dcmitype/Service"/>
+    <skos:altLabel xml:lang="da">Dataservice</skos:altLabel>
+    <skos:definition xml:lang="en">A site or end-point providing operations related to the discovery of, access to, or processing functions on, data or related resources.</skos:definition>
+    <skos:scopeNote xml:lang="cs">Druh služby může být indikován vlastností dcterms:type. Její hodnota může být z řízeného slovníku, kterým je například slovník typů prostorových datových služeb INSPIRE.</skos:scopeNote>
+    <skos:definition xml:lang="da">Et site eller endpoint der udstiller operationer relateret til opdagelse af, adgang til eller behandlende funktioner på data eller relaterede ressourcer.</skos:definition>
+    <rdfs:label xml:lang="en">Data service</rdfs:label>
     <rdfs:subClassOf>
       <owl:Restriction>
         <owl:onProperty>
@@ -229,11 +234,6 @@
         >1</owl:maxCardinality>
       </owl:Restriction>
     </rdfs:subClassOf>
-    <skos:altLabel xml:lang="da">Dataservice</skos:altLabel>
-    <skos:definition xml:lang="en">A site or end-point providing operations related to the discovery of, access to, or processing functions on, data or related resources.</skos:definition>
-    <skos:scopeNote xml:lang="cs">Druh služby může být indikován vlastností dcterms:type. Její hodnota může být z řízeného slovníku, kterým je například slovník typů prostorových datových služeb INSPIRE.</skos:scopeNote>
-    <skos:definition xml:lang="da">Et site eller endpoint der udstiller operationer relateret til opdagelse af, adgang til eller behandlende funktioner på data eller relaterede ressourcer.</skos:definition>
-    <rdfs:label xml:lang="en">Data service</rdfs:label>
     <rdfs:comment xml:lang="da">Et websted eller endpoint der udstiller operationer relateret til opdagelse af, adgang til eller behandlende funktioner på data eller relaterede ressourcer.</rdfs:comment>
     <skos:scopeNote xml:lang="es">El tipo de servicio puede indicarse usando la propiedad dcterms:type. Su valor puede provenir de un vocabulario controlado, como por ejemplo el vocabulario de servicios de datos espaciales de INSPIRE.</skos:scopeNote>
     <skos:scopeNote xml:lang="da">Datatjenestetypen kan indikeres ved hjælp af egenskaben dcterms:type. Værdien kan tages fra kontrollerede udfaldsrum såsom INSPIRE spatial data service vocabulary.</skos:scopeNote>
@@ -264,6 +264,12 @@
     <skos:definition xml:lang="cs">Záznam v datovém katalogu popisující jednu datovou sadu či datovou službu.</skos:definition>
     <rdfs:label xml:lang="es">Registro del catálogo</rdfs:label>
     <rdfs:label xml:lang="it">Record di catalogo</rdfs:label>
+    <skos:scopeNote xml:lang="it">Questa classe è opzionale e non tutti i cataloghi la utilizzeranno. Esiste per cataloghi in cui si opera una distinzione tra i metadati relativi al dataset ed i metadati relativi alla gestione del dataset nel catalogo. Ad esempio, la  proprietà per indicare la data di pubblicazione del dataset rifletterà la data in cui l'informazione è stata originariamente messa a disposizione dalla casa editrice, mentre la data di pubblicazione per il record nel catalogo rifletterà la data in cui il dataset è stato aggiunto al catalogo. Nei casi dove solo quest'ultima sia nota, si utilizzerà esclusivamente la data di  pubblicazione relativa al record del catalogo. Si noti che l'Ontologia W3C PROV permette di descrivere ulteriori informazioni sulla provenienza, quali i dettagli del processo, la procedura e l'agente coinvolto in una particolare modifica di un dataset.</skos:scopeNote>
+    <skos:scopeNote xml:lang="cs">Tato třída je volitelná a ne všechny katalogy ji využijí. Existuje pro katalogy, ve kterých se rozlišují metadata datové sady či datové služby a metadata o záznamu o datové sadě či datové službě v katalogu. Například datum publikace datové sady odráží datum, kdy byla datová sada původně zveřejněna poskytovatelem dat, zatímco datum publikace katalogizačního záznamu je datum zanesení datové sady do katalogu. V případech kdy se obě data liší, nebo je známo jen to druhé, by mělo být specifikováno jen datum publikace katalogizačního záznamu. Všimněte si, že ontologie W3C PROV umožňuje popsat další informace o původu jako například podrobnosti o procesu konkrétní změny datové sady a jeho účastnících.</skos:scopeNote>
+    <skos:definition xml:lang="es">Un registro en un catálogo de datos que describe un solo conjunto de datos o un servicio de datos.</skos:definition>
+    <rdfs:comment xml:lang="da">En post i et datakatalog der beskriver registreringen af et enkelt datasæt eller en datatjeneste.</rdfs:comment>
+    <skos:definition xml:lang="da">En post i et datakatalog der beskriver registreringen af et enkelt datasæt eller en datatjeneste.</skos:definition>
+    <rdfs:comment xml:lang="cs">Záznam v datovém katalogu popisující jednu datovou sadu či datovou službu.</rdfs:comment>
     <rdfs:subClassOf>
       <owl:Restriction>
         <owl:onProperty>
@@ -274,12 +280,6 @@
         </owl:allValuesFrom>
       </owl:Restriction>
     </rdfs:subClassOf>
-    <skos:scopeNote xml:lang="it">Questa classe è opzionale e non tutti i cataloghi la utilizzeranno. Esiste per cataloghi in cui si opera una distinzione tra i metadati relativi al dataset ed i metadati relativi alla gestione del dataset nel catalogo. Ad esempio, la  proprietà per indicare la data di pubblicazione del dataset rifletterà la data in cui l'informazione è stata originariamente messa a disposizione dalla casa editrice, mentre la data di pubblicazione per il record nel catalogo rifletterà la data in cui il dataset è stato aggiunto al catalogo. Nei casi dove solo quest'ultima sia nota, si utilizzerà esclusivamente la data di  pubblicazione relativa al record del catalogo. Si noti che l'Ontologia W3C PROV permette di descrivere ulteriori informazioni sulla provenienza, quali i dettagli del processo, la procedura e l'agente coinvolto in una particolare modifica di un dataset.</skos:scopeNote>
-    <skos:scopeNote xml:lang="cs">Tato třída je volitelná a ne všechny katalogy ji využijí. Existuje pro katalogy, ve kterých se rozlišují metadata datové sady či datové služby a metadata o záznamu o datové sadě či datové službě v katalogu. Například datum publikace datové sady odráží datum, kdy byla datová sada původně zveřejněna poskytovatelem dat, zatímco datum publikace katalogizačního záznamu je datum zanesení datové sady do katalogu. V případech kdy se obě data liší, nebo je známo jen to druhé, by mělo být specifikováno jen datum publikace katalogizačního záznamu. Všimněte si, že ontologie W3C PROV umožňuje popsat další informace o původu jako například podrobnosti o procesu konkrétní změny datové sady a jeho účastnících.</skos:scopeNote>
-    <skos:definition xml:lang="es">Un registro en un catálogo de datos que describe un solo conjunto de datos o un servicio de datos.</skos:definition>
-    <rdfs:comment xml:lang="da">En post i et datakatalog der beskriver registreringen af et enkelt datasæt eller en datatjeneste.</rdfs:comment>
-    <skos:definition xml:lang="da">En post i et datakatalog der beskriver registreringen af et enkelt datasæt eller en datatjeneste.</skos:definition>
-    <rdfs:comment xml:lang="cs">Záznam v datovém katalogu popisující jednu datovou sadu či datovou službu.</rdfs:comment>
     <rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Class"/>
     <rdfs:comment xml:lang="fr">Un registre du catalogue ou une entrée du catalogue, décrivant un seul jeu de données.</rdfs:comment>
     <skos:definition xml:lang="ja">1つのデータセットを記述したデータ・カタログ内のレコード。</skos:definition>
@@ -357,13 +357,6 @@
     <rdfs:comment xml:lang="es">Una clase de asociación para adjuntar información adicional a una relación entre recursos DCAT.</rdfs:comment>
     <skos:changeNote xml:lang="es">Nueva clase añadida en DCAT 2.0.</skos:changeNote>
     <skos:definition xml:lang="it">Una classe di associazione per il collegamento di informazioni aggiuntive a una relazione tra le risorse DCAT.</skos:definition>
-    <rdfs:subClassOf>
-      <owl:Restriction>
-        <owl:onProperty rdf:resource="http://purl.org/dc/terms/relation"/>
-        <owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger"
-        >1</owl:minCardinality>
-      </owl:Restriction>
-    </rdfs:subClassOf>
     <rdfs:label xml:lang="it">Relazione</rdfs:label>
     <skos:definition xml:lang="da">En associationsklasse til brug for tilknytning af yderligere information til en relation mellem DCAT-ressourcer.</skos:definition>
     <skos:scopeNote xml:lang="da">Anvendes til at karakterisere en relation mellem datasæt, og potentielt andre ressourcer, hvor relationen er kendt men ikke tilstrækkeligt beskrevet af de standardiserede egenskaber i Dublin Core (dcterms:hasPart, dcterms:isPartOf, dcterms:conformsTo, dcterms:isFormatOf, dcterms:hasFormat, dcterms:isVersionOf, dcterms:hasVersion, dcterms:replaces, dcterms:isReplacedBy, dcterms:references, dcterms:isReferencedBy, dcterms:requires, dcterms:isRequiredBy) eller PROV-O-egenskaber (prov:wasDerivedFrom, prov:wasInfluencedBy, prov:wasQuotedFrom, prov:wasRevisionOf, prov:hadPrimarySource, prov:alternateOf, prov:specializationOf).</skos:scopeNote>
@@ -381,6 +374,13 @@
     <skos:scopeNote xml:lang="en">Use to characterize a relationship between datasets, and potentially other resources, where the nature of the relationship is known but is not adequately characterized by the standard Dublin Core properties (dcterms:hasPart, dcterms:isPartOf, dcterms:conformsTo, dcterms:isFormatOf, dcterms:hasFormat, dcterms:isVersionOf, dcterms:hasVersion, dcterms:replaces, dcterms:isReplacedBy, dcterms:references, dcterms:isReferencedBy, dcterms:requires, dcterms:isRequiredBy) or PROV-O properties (prov:wasDerivedFrom, prov:wasInfluencedBy, prov:wasQuotedFrom, prov:wasRevisionOf, prov:hadPrimarySource, prov:alternateOf, prov:specializationOf).</skos:scopeNote>
     <rdfs:comment xml:lang="da">En associationsklasse til brug for tilknytning af yderligere information til en relation mellem DCAT-ressourcer.</rdfs:comment>
     <skos:scopeNote xml:lang="es">Se usa para caracterizar la relación entre conjuntos de datos, y potencialmente otros recursos, donde la naturaleza de la relación se conoce pero no está caracterizada adecuadamente con propiedades del estándar 'Dublin Core' (dcterms:hasPart, dcterms:isPartOf, dcterms:conformsTo, dcterms:isFormatOf, dcterms:hasFormat, dcterms:isVersionOf, dcterms:hasVersion, dcterms:replaces, dcterms:isReplacedBy, dcterms:references, dcterms:isReferencedBy, dcterms:requires, dcterms:isRequiredBy) or PROV-O properties (prov:wasDerivedFrom, prov:wasInfluencedBy, prov:wasQuotedFrom, prov:wasRevisionOf, prov:hadPrimarySource, prov:alternateOf, prov:specializationOf).</skos:scopeNote>
+    <rdfs:subClassOf>
+      <owl:Restriction>
+        <owl:onProperty rdf:resource="http://purl.org/dc/terms/relation"/>
+        <owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger"
+        >1</owl:minCardinality>
+      </owl:Restriction>
+    </rdfs:subClassOf>
     <rdfs:label xml:lang="es">Relación</rdfs:label>
     <rdfs:comment xml:lang="it">Una classe di associazione per il collegamento di informazioni aggiuntive a una relazione tra le risorse DCAT.</rdfs:comment>
     <rdfs:label xml:lang="en">Relationship</rdfs:label>
@@ -420,6 +420,12 @@
   <owl:Class rdf:about="http://www.w3.org/ns/dcat#Catalog">
     <rdfs:isDefinedBy rdf:resource="http://www.w3.org/TR/vocab-dcat/"/>
     <skos:definition xml:lang="da">En samling af metadata om ressourcer.</skos:definition>
+    <rdfs:subClassOf>
+      <owl:Restriction>
+        <owl:onProperty rdf:resource="http://purl.org/dc/terms/hasPart"/>
+        <owl:allValuesFrom rdf:resource="http://www.w3.org/ns/dcat#Resource"/>
+      </owl:Restriction>
+    </rdfs:subClassOf>
     <rdfs:subClassOf rdf:resource="http://www.w3.org/ns/dcat#Dataset"/>
     <rdfs:comment xml:lang="it">Una raccolta curata di metadati sulle risorse (ad es. sui dataset e relativi servizi nel contesto di cataloghi di dati).</rdfs:comment>
     <rdfs:label xml:lang="es">Catálogo</rdfs:label>
@@ -457,12 +463,6 @@
     <rdfs:comment xml:lang="en">A curated collection of metadata about resources (e.g., datasets and data services in the context of a data catalog).</rdfs:comment>
     <rdfs:comment xml:lang="ar">مجموعة من توصيفات قوائم البيانات</rdfs:comment>
     <rdfs:comment xml:lang="cs">Řízená kolekce metadat o datových sadách a datových službách</rdfs:comment>
-    <rdfs:subClassOf>
-      <owl:Restriction>
-        <owl:onProperty rdf:resource="http://purl.org/dc/terms/hasPart"/>
-        <owl:allValuesFrom rdf:resource="http://www.w3.org/ns/dcat#Resource"/>
-      </owl:Restriction>
-    </rdfs:subClassOf>
   </owl:Class>
   <owl:Class rdf:about="http://www.w3.org/ns/dcat#Distribution">
     <rdfs:label xml:lang="ar">التوزيع</rdfs:label>
@@ -894,16 +894,8 @@
     <skos:scopeNote xml:lang="it">Può essere utilizzata in una relazione qualificata per specificare il ruolo di un'entità rispetto a un'altra entità. Si raccomanda che il valore sia preso da un vocabolario controllato di ruoli di entità come ISO 19115 DS_AssociationTypeCode http://registry.it.csiro.au/def/isotc211/DS_AssociationTypeCode, IANA Registry of Link Relations https://www.iana.org/assignments/link-relation, DataCite metadata schema, o MARC relators https://id.loc.gov/vocabulary/relators.</skos:scopeNote>
     <skos:definition xml:lang="it">La funzione di un'entità o un agente rispetto ad un'altra entità o risorsa.</skos:definition>
     <skos:definition xml:lang="en">The function of an entity or agent with respect to another entity or resource.</skos:definition>
-    <skos:scopeNote xml:lang="cs">Může být použito v kvalifikovaném vztahu pro specifikaci role Entity ve vztahu k jiné Entitě. Je doporučeno použít hodnotu z řízeného slovníku rolí entit, jako například ISO 19115 DS_AssociationTypeCode http://registry.it.csiro.au/def/isotc211/DS_AssociationTypeCode, IANA Registry of Link Relations https://www.iana.org/assignments/link-relation, DataCite metadata schema, MARC relators https://id.loc.gov/vocabulary/relators.</skos:scopeNote>
     <rdfs:comment xml:lang="da">Den funktion en entitet eller aktør har i forhold til en anden ressource.</rdfs:comment>
-    <rdfs:domain>
-      <owl:Class>
-        <owl:unionOf rdf:parseType="Collection">
-          <rdf:Description rdf:about="http://www.w3.org/ns/prov#Attribution"/>
-          <owl:Class rdf:about="http://www.w3.org/ns/dcat#Relationship"/>
-        </owl:unionOf>
-      </owl:Class>
-    </rdfs:domain>
+    <skos:scopeNote xml:lang="cs">Může být použito v kvalifikovaném vztahu pro specifikaci role Entity ve vztahu k jiné Entitě. Je doporučeno použít hodnotu z řízeného slovníku rolí entit, jako například ISO 19115 DS_AssociationTypeCode http://registry.it.csiro.au/def/isotc211/DS_AssociationTypeCode, IANA Registry of Link Relations https://www.iana.org/assignments/link-relation, DataCite metadata schema, MARC relators https://id.loc.gov/vocabulary/relators.</skos:scopeNote>
     <skos:changeNote xml:lang="it">Nuova proprietà aggiunta in DCAT 2.0.</skos:changeNote>
     <skos:changeNote xml:lang="es">Nueva propiedad agregada en DCAT 2.0.</skos:changeNote>
     <rdfs:label xml:lang="en">hadRole</rdfs:label>
@@ -924,6 +916,14 @@
     <skos:scopeNote xml:lang="es">Puede usarse en una atribución cualificada para especificar el rol de un Agente con respecto a una Entidad. Se recomienda que el valor sea de un vocabulario controlado de roles de agentes, como por ejemplo http://registry.it.csiro.au/def/isotc211/CI_RoleCode.</skos:scopeNote>
     <skos:editorialNote xml:lang="es">Agregada en DCAT para complementar prov:hadRole (cuyo uso está limitado a roles en el contexto de una actividad, con dominio prov:Association.</skos:editorialNote>
     <skos:scopeNote xml:lang="da">Kan vendes ved kvalificerede krediteringer til at angive en aktørs rolle i forhold en entitet. Det anbefales at værdierne styres som et kontrolleret udfaldsrum med aktørroller, såsom http://registry.it.csiro.au/def/isotc211/CI_RoleCode.</skos:scopeNote>
+    <rdfs:domain>
+      <owl:Class>
+        <owl:unionOf rdf:parseType="Collection">
+          <rdf:Description rdf:about="http://www.w3.org/ns/prov#Attribution"/>
+          <owl:Class rdf:about="http://www.w3.org/ns/dcat#Relationship"/>
+        </owl:unionOf>
+      </owl:Class>
+    </rdfs:domain>
     <skos:scopeNote xml:lang="es">Puede usarse en una atribución cualificada para especificar el rol de una Entidad con respecto a otra Entidad. Se recomienda que su valor se tome de un vocabulario controlado de roles de entidades como por ejemplo: ISO 19115 DS_AssociationTypeCode http://registry.it.csiro.au/def/isotc211/DS_AssociationTypeCode; IANA Registry of Link Relations https://www.iana.org/assignments/link-relation; esquema de metadatos de DataCite; MARC relators https://id.loc.gov/vocabulary/relators.</skos:scopeNote>
   </owl:ObjectProperty>
   <owl:ObjectProperty rdf:about="http://www.w3.org/ns/dcat#qualifiedRelation">
@@ -1150,6 +1150,10 @@
   </rdf:Property>
   <rdf:Property rdf:about="http://www.w3.org/ns/dcat#accessURL">
     <skos:scopeNote xml:lang="it">Se le distribuzioni sono accessibili solo attraverso una pagina web (ad esempio, gli URL per il download diretto non sono noti), allora il link della pagina web deve essere duplicato come accessURL sulla distribuzione.</skos:scopeNote>
+    <owl:propertyChainAxiom rdf:parseType="Collection">
+      <owl:ObjectProperty rdf:about="http://www.w3.org/ns/dcat#accessService"/>
+      <owl:ObjectProperty rdf:about="http://www.w3.org/ns/dcat#endpointURL"/>
+    </owl:propertyChainAxiom>
     <skos:definition xml:lang="da">En URL for en ressource som giver adgang til en repræsentation af datsættet. Fx destinationsside, feed, SPARQL-endpoint. Anvendes i alle sammenhænge undtagen til angivelse af et simpelt download link hvor anvendelse af egenskaben downloadURL foretrækkes.</skos:definition>
     <rdfs:label xml:lang="cs">přístupová adresa</rdfs:label>
     <skos:definition xml:lang="ja">データセットの配信にアクセス権を与えるランディング・ページ、フィード、SPARQLエンドポイント、その他の種類の資源。</skos:definition>
@@ -1158,10 +1162,6 @@
     <skos:definition xml:lang="fr">Ceci peut être tout type d'URL qui donne accès à une distribution du jeu de données. Par exemple, un lien à une page HTML contenant un lien au jeu de données, un Flux RSS, un point d'accès SPARQL. Utilisez le lorsque votre catalogue ne contient pas d'information sur quoi il est ou quand ce n'est pas téléchargeable.</skos:definition>
     <skos:altLabel xml:lang="da">adgangsURL</skos:altLabel>
     <rdfs:domain rdf:resource="http://www.w3.org/ns/dcat#Distribution"/>
-    <owl:propertyChainAxiom rdf:parseType="Collection">
-      <owl:ObjectProperty rdf:about="http://www.w3.org/ns/dcat#accessService"/>
-      <owl:ObjectProperty rdf:about="http://www.w3.org/ns/dcat#endpointURL"/>
-    </owl:propertyChainAxiom>
     <skos:editorialNote xml:lang="en">rdfs:label, rdfs:comment and skos:scopeNote have been modified. Non-english versions except for Italian must be updated.</skos:editorialNote>
     <skos:scopeNote xml:lang="da">Hvis en eller flere distributioner kun er tilgængelige via en destinationsside (dvs. en URL til direkte download er ikke kendt), så bør destinationssidelinket gentages som adgangsadresse for distributionen.</skos:scopeNote>
     <rdfs:comment xml:lang="es">Puede ser cualquier tipo de URL que de acceso a una distribución del conjunto de datos, e.g., página de destino, descarga, URL feed, punto de acceso SPARQL. Esta propriedad se debe usar cuando su catálogo de datos no tiene información sobre donde está o cuando no se puede descargar.</rdfs:comment>
@@ -1304,7 +1304,7 @@
   </rdf:Property>
   <rdf:Property rdf:about="http://www.w3.org/ns/dcat#bbox">
     <skos:scopeNote xml:lang="es">El rango de esta propiedad es intencionalmente genérico con el propósito de permitir distintas codificaciones geométricas. Por ejemplo, la geometría puede ser codificada como WKT (geosparql:wktLiteral [GeoSPARQL]) o [GML] (geosparql:asGML [GeoSPARQL]).</skos:scopeNote>
-    <skos:scopeNote xml:lang="en">The range of this property is intentionally generic, with the purpose of allowing different geometry encodings. E.g., the geometry could be encoded with as WKT (geosparql:wktLiteral [GeoSPARQL]) or [GML] (geosparql:asGML [GeoSPARQL]).</skos:scopeNote>
+    <skos:scopeNote xml:lang="en">The range of this property (rdfs:Literal) is intentionally generic, with the purpose of allowing different geometry literal encodings. E.g., the geometry could be encoded as a WKT literal (geosparql:wktLiteral [GeoSPARQL]).</skos:scopeNote>
     <skos:definition xml:lang="da">Den geografiske omskrevne firkant af en ressource.</skos:definition>
     <skos:definition xml:lang="it">Il riquadro di delimitazione geografica di una risorsa.</skos:definition>
     <skos:changeNote xml:lang="da">Ny egenskab tilføjet i DCAT 2.0.</skos:changeNote>
@@ -1314,15 +1314,16 @@
     <rdfs:label xml:lang="en">bounding box</rdfs:label>
     <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#DatatypeProperty"/>
     <skos:changeNote xml:lang="es">Propiedad nueva agregada en DCAT 2.0.</skos:changeNote>
-    <skos:scopeNote xml:lang="it">Il range di questa proprietà è volutamente generica, con lo scopo di consentire diverse codifiche geometriche. Ad esempio, la geometria potrebbe essere codificata con WKT (geosparql:wktLiteral [GeoSPARQL]) o [GML] (geosparql:asGML [GeoSPARQL]).</skos:scopeNote>
     <rdfs:label xml:lang="es">cuadro delimitador</rdfs:label>
     <skos:changeNote xml:lang="en">New property added in DCAT 2.0.</skos:changeNote>
     <rdfs:range rdf:resource="http://www.w3.org/2000/01/rdf-schema#Literal"/>
     <rdfs:label xml:lang="cs">ohraničení oblasti</rdfs:label>
     <skos:definition xml:lang="cs">Ohraničení geografické oblasti zdroje.</skos:definition>
     <skos:scopeNote xml:lang="cs">Obor hodnot této vlastnosti je úmyslně obecný, aby umožnil různé kódování geometrií. Geometrie by kupříkladu mohla být kódována jako WKT (geosparql:wktLiteral [GeoSPARQL]) či [GML] (geosparql:asGML [GeoSPARQL]).</skos:scopeNote>
+    <skos:editorialNote xml:lang="en">English language definitions and comments updated in this revision in line with ED. Multilingual text unevenly updated.</skos:editorialNote>
     <skos:definition xml:lang="es">El cuadro delimitador geográfico para un recurso.</skos:definition>
     <skos:changeNote xml:lang="it">Nuova proprietà aggiunta in DCAT 2.0.</skos:changeNote>
+    <skos:scopeNote xml:lang="it">Il range di questa proprietà (rdfs:Literal) è volutamente generica, con lo scopo di consentire diverse codifiche geometriche letterali. Ad esempio, la geometria potrebbe essere codificata con un letterale WKT (geosparql:wktLiteral [GeoSPARQL]) o [GML] (geosparql:asGML [GeoSPARQL]).</skos:scopeNote>
     <skos:definition xml:lang="en">The geographic bounding box of a resource.</skos:definition>
     <rdfs:label xml:lang="it">quadro di delimitazione</rdfs:label>
     <skos:scopeNote xml:lang="da">Rækkevidden for denne egenskab er bevidst generisk defineret med det formål at tillade forskellige kodninger af geometrier. Geometrien kan eksempelvis repræsenteres som WKT (geosparql:asWKT [GeoSPARQL]) eller [GML] (geosparql:asGML [GeoSPARQL]).</skos:scopeNote>
@@ -1411,9 +1412,9 @@
   <owl:DatatypeProperty rdf:about="http://www.w3.org/ns/dcat#centroid">
     <skos:changeNote xml:lang="da">Ny egenskab tilføjet i DCAT 2.0.</skos:changeNote>
     <skos:changeNote xml:lang="cs">Nová vlastnost přidaná ve verzi DCAT 2.0.</skos:changeNote>
+    <skos:editorialNote xml:lang="en">English language definitions and comments updated in this revision in line with ED. Multilingual text unevenly updated.</skos:editorialNote>
     <skos:definition xml:lang="it">Il centro geografico (centroide) di una risorsa.</skos:definition>
     <skos:scopeNote xml:lang="da">Rækkevidden for denne egenskab er bevidst generisk definere med det formål at tillade forskellige geokodninger. Geometrien kan eksempelvis repræsenteres som WKT (geosparql:asWKT [GeoSPARQL]) eller [GML] (geosparql:asGML [GeoSPARQL]).</skos:scopeNote>
-    <skos:scopeNote xml:lang="en">The range of this property is intentionally generic, with the purpose of allowing different geometry encodings. E.g., the geometry could be encoded with as WKT (geosparql:wktLiteral [GeoSPARQL]) or [GML] (geosparql:asGML [GeoSPARQL]).</skos:scopeNote>
     <skos:changeNote xml:lang="es">Nueva propiedad agregada en DCAT 2.0.</skos:changeNote>
     <skos:changeNote xml:lang="it">Nuova proprietà aggiunta in DCAT 2.0.</skos:changeNote>
     <skos:changeNote xml:lang="en">New property added in DCAT 2.0.</skos:changeNote>
@@ -1426,8 +1427,9 @@
     <rdfs:label xml:lang="da">geometrisk tyngdepunkt</rdfs:label>
     <skos:scopeNote xml:lang="cs">Obor hodnot této vlastnosti je úmyslně obecný, aby umožnil různé kódování geometrií. Geometrie by kupříkladu mohla být kódována jako WKT (geosparql:wktLiteral [GeoSPARQL]) či [GML] (geosparql:asGML [GeoSPARQL]).</skos:scopeNote>
     <skos:scopeNote xml:lang="es">El rango de esta propiedad es intencionalmente genérico con el objetivo de permitir distintas codificaciones geométricas. Por ejemplo, la geometría puede codificarse como WKT (geosparql:wktLiteral [GeoSPARQL]) o [GML] (geosparql:asGML [GeoSPARQL]).</skos:scopeNote>
+    <skos:scopeNote xml:lang="en">The range of this property (rdfs:Literal) is intentionally generic, with the purpose of allowing different geometry literal encodings. E.g., the geometry could be encoded as a WKT literal (geosparql:wktLiteral [GeoSPARQL]).</skos:scopeNote>
+    <skos:scopeNote xml:lang="it">Il range di questa proprietà (rdfs:Literal) è volutamente generica, con lo scopo di consentire diverse codifiche geometriche letterali. Ad esempio, la geometria potrebbe essere codificata con un letterale WKT (geosparql:wktLiteral [GeoSPARQL]) o [GML] (geosparql:asGML [GeoSPARQL]).</skos:scopeNote>
     <skos:definition xml:lang="da">Det geometrisk tyngdepunkt (centroid) for en ressource.</skos:definition>
-    <skos:scopeNote xml:lang="it">Il range di questa proprietà è volutamente generica, con lo scopo di consentire diverse codifiche geometriche. Ad esempio, la geometria potrebbe essere codificata con WKT (geosparql:wktLiteral [GeoSPARQL]) o [GML] (geosparql:asGML [GeoSPARQL]).</skos:scopeNote>
     <skos:definition xml:lang="es">El centro geográfico (centroide) de un recurso.</skos:definition>
     <rdfs:range rdf:resource="http://www.w3.org/2000/01/rdf-schema#Literal"/>
     <rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Property"/>

--- a/dcat/rdf/dcat3.ttl
+++ b/dcat/rdf/dcat3.ttl
@@ -587,9 +587,10 @@ dcat:bbox
   skos:definition "Den geografiske omskrevne firkant af en ressource."@da ;
   skos:scopeNote "El rango de esta propiedad es intencionalmente genérico con el propósito de permitir distintas codificaciones geométricas. Por ejemplo, la geometría puede ser codificada como WKT (geosparql:wktLiteral [GeoSPARQL]) o [GML] (geosparql:asGML [GeoSPARQL])."@es ;
   skos:scopeNote "Obor hodnot této vlastnosti je úmyslně obecný, aby umožnil různé kódování geometrií. Geometrie by kupříkladu mohla být kódována jako WKT (geosparql:wktLiteral [GeoSPARQL]) či [GML] (geosparql:asGML [GeoSPARQL])."@cs ;
-  skos:scopeNote "The range of this property is intentionally generic, with the purpose of allowing different geometry encodings. E.g., the geometry could be encoded with as WKT (geosparql:wktLiteral [GeoSPARQL]) or [GML] (geosparql:asGML [GeoSPARQL])."@en ;
-  skos:scopeNote "Il range di questa proprietà è volutamente generica, con lo scopo di consentire diverse codifiche geometriche. Ad esempio, la geometria potrebbe essere codificata con WKT (geosparql:wktLiteral [GeoSPARQL]) o [GML] (geosparql:asGML [GeoSPARQL])."@it ;
+  skos:scopeNote "The range of this property (rdfs:Literal) is intentionally generic, with the purpose of allowing different geometry literal encodings. E.g., the geometry could be encoded as a WKT literal (geosparql:wktLiteral [GeoSPARQL])."@en ;
+  skos:scopeNote "Il range di questa proprietà (rdfs:Literal) è volutamente generica, con lo scopo di consentire diverse codifiche geometriche letterali. Ad esempio, la geometria potrebbe essere codificata con un letterale WKT (geosparql:wktLiteral [GeoSPARQL]) o [GML] (geosparql:asGML [GeoSPARQL])."@it ;
   skos:scopeNote "Rækkevidden for denne egenskab er bevidst generisk defineret med det formål at tillade forskellige kodninger af geometrier. Geometrien kan eksempelvis repræsenteres som WKT (geosparql:asWKT [GeoSPARQL]) eller [GML] (geosparql:asGML [GeoSPARQL])."@da ;
+  skos:editorialNote "English language definitions and comments updated in this revision in line with ED. Multilingual text unevenly updated."@en ;
 .
 dcat:byteSize
   a rdf:Property ;
@@ -685,9 +686,10 @@ dcat:centroid
   skos:definition "Det geometrisk tyngdepunkt (centroid) for en ressource."@da ;
   skos:scopeNote "El rango de esta propiedad es intencionalmente genérico con el objetivo de permitir distintas codificaciones geométricas. Por ejemplo, la geometría puede codificarse como WKT (geosparql:wktLiteral [GeoSPARQL]) o [GML] (geosparql:asGML [GeoSPARQL])."@es ;
   skos:scopeNote "Obor hodnot této vlastnosti je úmyslně obecný, aby umožnil různé kódování geometrií. Geometrie by kupříkladu mohla být kódována jako WKT (geosparql:wktLiteral [GeoSPARQL]) či [GML] (geosparql:asGML [GeoSPARQL])."@cs ;
-  skos:scopeNote "The range of this property is intentionally generic, with the purpose of allowing different geometry encodings. E.g., the geometry could be encoded with as WKT (geosparql:wktLiteral [GeoSPARQL]) or [GML] (geosparql:asGML [GeoSPARQL])."@en ;
-  skos:scopeNote "Il range di questa proprietà è volutamente generica, con lo scopo di consentire diverse codifiche geometriche. Ad esempio, la geometria potrebbe essere codificata con WKT (geosparql:wktLiteral [GeoSPARQL]) o [GML] (geosparql:asGML [GeoSPARQL])."@it ;
+  skos:scopeNote "The range of this property (rdfs:Literal) is intentionally generic, with the purpose of allowing different geometry literal encodings. E.g., the geometry could be encoded as a WKT literal (geosparql:wktLiteral [GeoSPARQL])."@en ;
+  skos:scopeNote "Il range di questa proprietà (rdfs:Literal) è volutamente generica, con lo scopo di consentire diverse codifiche geometriche letterali. Ad esempio, la geometria potrebbe essere codificata con un letterale WKT (geosparql:wktLiteral [GeoSPARQL]) o [GML] (geosparql:asGML [GeoSPARQL])."@it ;
   skos:scopeNote "Rækkevidden for denne egenskab er bevidst generisk definere med det formål at tillade forskellige geokodninger. Geometrien kan eksempelvis repræsenteres som WKT (geosparql:asWKT [GeoSPARQL]) eller [GML] (geosparql:asGML [GeoSPARQL])."@da ;
+  skos:editorialNote "English language definitions and comments updated in this revision in line with ED. Multilingual text unevenly updated."@en ;
 .
 dcat:compressFormat
   a rdf:Property ;


### PR DESCRIPTION
Usage notes of `dcat:bbox` and `dcat:centroid` has been revised as proposed in https://github.com/w3c/dxwg/issues/1359#issuecomment-831451188 to make it clear that these properties are supposed to be used only with literals.

Changelog & RDF updated accordingly.

Preview: https://raw.githack.com/w3c/dxwg/dcat-issue-1359/dcat/index.html

Diff: https://services.w3.org/htmldiff?doc1=https%3A%2F%2Fw3c.github.io%2Fdxwg%2Fdcat%2F&doc2=https%3A%2F%2Fraw.githack.com%2Fw3c%2Fdxwg%2Fdcat-issue-1359%2Fdcat%2Findex.html