### PR TITLE
Adjusting DCAT scope sections after the class diagram update

### DIFF
--- a/dcat/index.html
+++ b/dcat/index.html
@@ -263,7 +263,7 @@ table.simple {width:100%;}
     <h3>DCAT scope</h3>
 
     <p>DCAT is an RDF vocabulary for representing data catalogs.
-      DCAT is based around six main classes (<a href="#UML_DCAT_All_Attr"></a>):</p>
+      DCAT is based around seven main classes (<a href="#UML_DCAT_All_Attr"></a>):</p>
     <ul>
         <li>
           <a href="#Class:Catalog"><code>dcat:Catalog</code></a> represents a catalog, which is a dataset in which each individual item is a metadata record describing some resource; the scope of <code>dcat:Catalog</code> is collections of metadata about <b>datasets</b> or <b>data services</b>.
@@ -286,12 +286,15 @@ table.simple {width:100%;}
           A data service is a collection of operations accessible through an interface (<abbr title="Application Programming Interface">API</abbr>) that provide access to one or more datasets or data processing functions.
         </li>
         <li>
+          <a href="#Class:Dataset_Series"><code>dcat:DatasetSeries</code></a> is a dataset, which represents a collection of datasets that are published separately, but share some common characteristics that groups them.
+        </li>
+        <li>
           <a href="#Class:Catalog_Record"><code>dcat:CatalogRecord</code></a> represents a metadata item in the catalog, primarily concerning the registration information, such as who added the item and when.
         </li>
     </ul>
     <aside class="ednote" title="Class Diagram need to be updated">
               <p>
-                  Add the class <code>dcat:DatasetSeries</code> and properties.
+                 Changes required for the class diagram are tracked in issue <a href="https://github.com/w3c/dxwg/issues/1320">#1320</a>. Switching the format of the diagram to SVG vector graphics is under consideration, see issue <a href="https://github.com/w3c/dxwg/issues/1294">#1294</a>.
               </p>
            </aside>
     <figure id="UML_DCAT_All_Attr">


### PR DESCRIPTION
adjusting note before class diagram and list of the class in DCAT scope section

Preview: https://raw.githack.com/w3c/dxwg/dcat-NoteBeforeDiagram/dcat/index.html

Diff: https://services.w3.org/htmldiff?doc1=https%3A%2F%2Fw3c.github.io%2Fdxwg%2Fdcat%2F&doc2=https%3A%2F%2Fraw.githack.com%2Fw3c%2Fdxwg%2Fdcat-NoteBeforeDiagram%2Fdcat%2Findex.html