### PR TITLE
making dcat:keyword a sub-property of dcterms:subject in the DCAT document

### DIFF
--- a/dcat/index.html
+++ b/dcat/index.html
@@ -1405,7 +1405,7 @@ table.simple {width:100%;}
                 In DCAT 1 [[?VOCAB-DCAT-20140116]] the domain of <code>dcat:keyword</code> was <code>dcat:Dataset</code>, which limited use of this property in other contexts. The domain has been relaxed in DCAT 2 - see Issue <a href="https://github.com/w3c/dxwg/issues/121">#121</a>.
               </p>
              <p>
-                 DCAT 3 defines dcat:keyword  as subproperty of <code>dcterms:subject</code> as the latter might accepts literals.          
+                 DCAT 3 defines <code>dcat:keyword</code> as sub-property of <code>dcterms:subject</code> as the latter might accepts literals.          
                 </p>
             </aside>
 

--- a/dcat/index.html
+++ b/dcat/index.html
@@ -1404,11 +1404,15 @@ table.simple {width:100%;}
               <p>
                 In DCAT 1 [[?VOCAB-DCAT-20140116]] the domain of <code>dcat:keyword</code> was <code>dcat:Dataset</code>, which limited use of this property in other contexts. The domain has been relaxed in DCAT 2 - see Issue <a href="https://github.com/w3c/dxwg/issues/121">#121</a>.
               </p>
+             <p>
+                 DCAT 3 defines dcat:keyword  as subproperty of <code>dcterms:subject</code> as the latter might accepts literals.          
+                </p>
             </aside>
 
             <table class="def">
-                <tr><th>RDF Property:</th><td><a href="http://www.w3.org/ns/dcat#keyword"><code>dcat:keyword</code></a></td></tr>
+                <tr><th>OWL Data Property:</th><td><a href="http://www.w3.org/ns/dcat#keyword"><code>dcat:keyword</code></a></td></tr>
                 <tr><th class="prop">Definition:</th><td>A keyword or tag describing the resource.</td></tr>
+                <tr><th class="prop">Sub-property of:</th><td><a href="http://purl.org/dc/terms/subject"><code>dcterms:subject</code></a></td></tr>
                 <tr><th class="prop">Range:</th><td><a href="http://www.w3.org/2000/01/rdf-schema#Literal"><code>rdfs:Literal</code></a></td></tr>
                 </table>
         </section>

--- a/dcat/index.html
+++ b/dcat/index.html
@@ -1405,7 +1405,7 @@ table.simple {width:100%;}
                 In DCAT 1 [[?VOCAB-DCAT-20140116]] the domain of <code>dcat:keyword</code> was <code>dcat:Dataset</code>, which limited use of this property in other contexts. The domain has been relaxed in DCAT 2 - see Issue <a href="https://github.com/w3c/dxwg/issues/121">#121</a>.
               </p>
              <p>
-                 DCAT 3 defines <code>dcat:keyword</code> as sub-property of <code>dcterms:subject</code> as the latter might accepts literals.          
+                 DCAT 3 defines <code>dcat:keyword</code> as sub-property of <code>dcterms:subject</code> as the latter might accept literals.          
                 </p>
             </aside>
 


### PR DESCRIPTION
This would close #175 and #1374, 
it aligns the REC with the RDF making dcat:keyword a sub-property of dcterms:subject. 