### PR TITLE
Dcat issue 1374 Tris

### DIFF
--- a/dcat/rdf/dcat3.jsonld
+++ b/dcat/rdf/dcat3.jsonld
@@ -1,144 +1,144 @@
 {
   "@graph" : [ {
-    "@id" : "_:b0",
-    "@type" : "owl:Restriction",
-    "maxCardinality" : "1",
-    "onProperty" : "dcat:endpointURL"
-  }, {
-    "@id" : "_:b1",
-    "affiliation" : "_:b2",
-    "foaf:name" : "David Browning"
-  }, {
     "@id" : "_:b10",
-    "@type" : "owl:Restriction",
-    "cardinality" : "1",
-    "onProperty" : "foaf:primaryTopic"
+    "homepage" : "http://okfn.org",
+    "foaf:name" : "Open Knowledge Foundation"
   }, {
     "@id" : "_:b11",
-    "foaf:name" : "Marios Meimaris"
+    "affiliation" : "_:b12",
+    "foaf:name" : "Vassilios Peristeras"
   }, {
     "@id" : "_:b12",
-    "affiliation" : "_:b13",
-    "seeAlso" : "https://orcid.org/0000-0003-3499-8262",
-    "homepage" : "https://agbeltran.github.io",
-    "foaf:name" : "Alejandra Gonzalez-Beltran"
+    "homepage" : "http://ec.europa.eu/dgs/informatics/",
+    "foaf:name" : "European Commission, DG DIGIT"
   }, {
     "@id" : "_:b13",
-    "homepage" : "http://stfc.ac.uk",
-    "foaf:name" : "Science and Technology Facilities Council, UK"
+    "seeAlso" : "http://www.eurecom.fr/~atemezin/gatemezing-foaf.rdf",
+    "foaf:name" : "Ghislain Auguste Atemezing"
   }, {
     "@id" : "_:b14",
-    "seeAlso" : "http://fadmaa.me/foaf.ttl",
-    "foaf:name" : "Fadi Maali"
+    "foaf:name" : "John Erickson"
   }, {
     "@id" : "_:b15",
+    "@type" : "owl:Restriction",
+    "minCardinality" : "1",
+    "onProperty" : "dcterms:relation"
+  }, {
+    "@id" : "_:b16",
+    "@type" : "owl:Restriction",
+    "allValuesFrom" : "dcat:Resource",
+    "onProperty" : "foaf:primaryTopic"
+  }, {
+    "@id" : "_:b17",
+    "homepage" : "http://www.w3.org/2011/gld/",
+    "foaf:name" : "Government Linked Data WG"
+  }, {
+    "@id" : "_:b18",
+    "foaf:name" : "Marios Meimaris"
+  }, {
+    "@id" : "_:b19",
+    "affiliation" : "_:b32",
+    "foaf:name" : "David Browning"
+  }, {
+    "@id" : "_:b2",
+    "foaf:name" : "Martin Alvarez-Espinar"
+  }, {
+    "@id" : "_:b20",
     "seeAlso" : "http://makxdekkers.com/makxdekkers.rdf#me",
     "homepage" : "http://makxdekkers.com/",
     "foaf:name" : "Makx Dekkers"
   }, {
-    "@id" : "_:b16",
-    "seeAlso" : "https://orcid.org/0000-0001-9300-2694",
-    "homepage" : "http://www.andrea-perego.name/foaf/#me",
-    "foaf:name" : "Andrea Perego"
-  }, {
-    "@id" : "_:b17",
-    "affiliation" : "_:b18",
-    "foaf:name" : "Rufus Pollock"
-  }, {
-    "@id" : "_:b18",
-    "homepage" : "http://okfn.org",
-    "foaf:name" : "Open Knowledge Foundation"
-  }, {
-    "@id" : "_:b19",
-    "affiliation" : "_:b20",
-    "foaf:name" : "Vassilios Peristeras"
-  }, {
-    "@id" : "_:b2",
-    "homepage" : "http://www.refinitiv.com",
-    "foaf:name" : "Refinitiv"
-  }, {
-    "@id" : "_:b20",
-    "homepage" : "http://ec.europa.eu/dgs/informatics/",
-    "foaf:name" : "European Commission, DG DIGIT"
-  }, {
     "@id" : "_:b21",
-    "foaf:name" : "Boris Villazón-Terrazas"
+    "@type" : "foaf:Person",
+    "affiliation" : "_:b4",
+    "seeAlso" : "https://orcid.org/0000-0002-3884-3420",
+    "foaf:name" : "Simon J D Cox",
+    "workInfoHomepage" : "http://people.csiro.au/Simon-Cox"
   }, {
     "@id" : "_:b22",
     "homepage" : "http://www.asahi-net.or.jp/~ax2s-kmtn/",
     "foaf:name" : "Shuji Kamitsuna"
   }, {
     "@id" : "_:b23",
+    "foaf:name" : "Boris Villazón-Terrazas"
+  }, {
+    "@id" : "_:b24",
+    "seeAlso" : "http://fadmaa.me/foaf.ttl",
+    "foaf:name" : "Fadi Maali"
+  }, {
+    "@id" : "_:b25",
+    "seeAlso" : "https://orcid.org/0000-0001-9300-2694",
+    "homepage" : "http://www.andrea-perego.name/foaf/#me",
+    "foaf:name" : "Andrea Perego"
+  }, {
+    "@id" : "_:b26",
     "seeAlso" : "https://jakub.klímek.com/#me",
     "homepage" : "https://jakub.klímek.com/",
     "foaf:name" : "Jakub Klímek"
   }, {
-    "@id" : "_:b24",
-    "@type" : "owl:Restriction",
-    "allValuesFrom" : "dcat:Resource",
-    "onProperty" : "dcterms:hasPart"
-  }, {
-    "@id" : "_:b25",
+    "@id" : "_:b27",
     "affiliation" : "http://www.w3.org/data#W3C",
     "seeAlso" : "http://philarcher.org/foaf.rdf#me",
     "homepage" : "http://www.w3.org/People/all#phila",
     "foaf:name" : "Phil Archer"
   }, {
-    "@id" : "_:b26",
+    "@id" : "_:b28",
+    "@type" : "owl:Restriction",
+    "allValuesFrom" : "dcat:Resource",
+    "onProperty" : "dcterms:hasPart"
+  }, {
+    "@id" : "_:b3",
     "seeAlso" : "https://orcid.org/0000-0001-5648-2713",
     "homepage" : [ "https://w3id.org/people/ralbertoni/", "http://www.imati.cnr.it/index.php/people/8-curricula/178-riccardo-albertoni" ],
     "foaf:name" : "Riccardo Albertoni"
   }, {
-    "@id" : "_:b27",
+    "@id" : "_:b31",
     "@type" : "owl:Restriction",
-    "minCardinality" : "1",
-    "onProperty" : "dcterms:relation"
+    "cardinality" : "1",
+    "onProperty" : "foaf:primaryTopic"
   }, {
-    "@id" : "_:b28",
-    "@type" : "foaf:Person",
-    "affiliation" : "_:b29",
-    "seeAlso" : "https://orcid.org/0000-0002-3884-3420",
-    "foaf:name" : "Simon J D Cox",
-    "workInfoHomepage" : "http://people.csiro.au/Simon-Cox"
+    "@id" : "_:b32",
+    "homepage" : "http://www.refinitiv.com",
+    "foaf:name" : "Refinitiv"
   }, {
-    "@id" : "_:b29",
+    "@id" : "_:b33",
+    "@type" : "owl:Restriction",
+    "maxCardinality" : "1",
+    "onProperty" : "dcat:endpointURL"
+  }, {
+    "@id" : "_:b4",
     "homepage" : "https://csiro.au",
     "foaf:name" : "Commonwealth Scientific and Industrial Research Organisation"
   }, {
-    "@id" : "_:b30",
-    "homepage" : "http://www.w3.org/2011/gld/",
-    "foaf:name" : "Government Linked Data WG"
-  }, {
-    "@id" : "_:b31",
-    "seeAlso" : "http://www.eurecom.fr/~atemezin/gatemezing-foaf.rdf",
-    "foaf:name" : "Ghislain Auguste Atemezing"
-  }, {
     "@id" : "_:b5",
-    "@type" : "owl:Restriction",
-    "allValuesFrom" : "dcat:Resource",
-    "onProperty" : "foaf:primaryTopic"
-  }, {
-    "@id" : "_:b6",
-    "foaf:name" : "Martin Alvarez-Espinar"
-  }, {
-    "@id" : "_:b7",
-    "foaf:name" : "Richard Cyganiak"
-  }, {
-    "@id" : "_:b8",
-    "foaf:name" : "John Erickson"
-  }, {
-    "@id" : "_:b9",
     "@type" : "owl:Class",
     "unionOf" : {
       "@list" : [ "prov:Attribution", "dcat:Relationship" ]
     }
   }, {
+    "@id" : "_:b6",
+    "foaf:name" : "Richard Cyganiak"
+  }, {
+    "@id" : "_:b7",
+    "affiliation" : "_:b8",
+    "seeAlso" : "https://orcid.org/0000-0003-3499-8262",
+    "homepage" : "https://agbeltran.github.io",
+    "foaf:name" : "Alejandra Gonzalez-Beltran"
+  }, {
+    "@id" : "_:b8",
+    "homepage" : "http://stfc.ac.uk",
+    "foaf:name" : "Science and Technology Facilities Council, UK"
+  }, {
+    "@id" : "_:b9",
+    "affiliation" : "_:b10",
+    "foaf:name" : "Rufus Pollock"
+  }, {
     "@id" : "http://www.w3.org/ns/dcat",
     "@type" : "owl:Ontology",
-    "contributor" : [ "_:b1", "_:b6", "_:b19", "_:b7", "_:b26", "_:b22", "_:b11", "_:b23", "_:b28", "_:b21", "_:b15", "_:b25", "_:b17", "_:b31", "_:b12", "_:b16" ],
-    "creator" : [ "_:b8", "_:b14" ],
+    "contributor" : [ "_:b2", "_:b3", "_:b18", "_:b19", "_:b9", "_:b20", "_:b6", "_:b13", "_:b11", "_:b21", "_:b22", "_:b7", "_:b23", "_:b25", "_:b26", "_:b27" ],
+    "creator" : [ "_:b14", "_:b24" ],
     "license" : "https://creativecommons.org/licenses/by/4.0/",
-    "modified" : [ "2021-04-08", "2020-11-30", "2012-04-24", "2017-12-19", "2013-09-20", "2021-03-09", "2013-11-28" ],
+    "modified" : [ "2021-04-08", "2020-11-30", "2012-04-24", "2017-12-19", "2021-06-23", "2013-09-20", "2021-03-09", "2013-11-28" ],
     "dcterms:modified" : "2019",
     "rdfs:comment" : [ {
       "@language" : "da",
@@ -217,7 +217,7 @@
       "@language" : "en",
       "@value" : "English language definitions updated in this revision in line with ED. Multilingual text unevenly updated."
     },
-    "maker" : "_:b30"
+    "maker" : "_:b17"
   }, {
     "@id" : "dcat:Catalog",
     "@type" : [ "owl:Class", "rdfs:Class" ],
@@ -278,7 +278,7 @@
       "@language" : "fr",
       "@value" : "Catalogue"
     } ],
-    "subClassOf" : [ "dcat:Dataset", "_:b24" ],
+    "subClassOf" : [ "dcat:Dataset", "_:b28" ],
     "skos:definition" : [ {
       "@language" : "da",
       "@value" : "En samling af metadata om ressourcer."
@@ -393,7 +393,7 @@
       "@language" : "fr",
       "@value" : "Registre du catalogue"
     } ],
-    "subClassOf" : [ "_:b5", "_:b10" ],
+    "subClassOf" : [ "_:b16", "_:b31" ],
     "skos:definition" : [ {
       "@language" : "it",
       "@value" : "Un record in un catalogo di dati che descrive un singolo dataset o servizio di dati."
@@ -480,7 +480,7 @@
       "@language" : "da",
       "@value" : "Datatjeneste"
     } ],
-    "subClassOf" : [ "dctype:Service", "dcat:Resource", "_:b0" ],
+    "subClassOf" : [ "dctype:Service", "_:b33", "dcat:Resource" ],
     "skos:altLabel" : {
       "@language" : "da",
       "@value" : "Dataservice"
@@ -859,7 +859,7 @@
       "@language" : "en",
       "@value" : "Relationship"
     } ],
-    "subClassOf" : "_:b27",
+    "subClassOf" : "_:b15",
     "skos:changeNote" : [ {
       "@language" : "it",
       "@value" : "Nuova classe aggiunta in DCAT 2.0."
@@ -2428,7 +2428,7 @@
       "@language" : "en",
       "@value" : "The function of an entity or agent with respect to another entity or resource."
     } ],
-    "domain" : "_:b9",
+    "domain" : "_:b5",
     "rdfs:label" : [ {
       "@language" : "it",
       "@value" : "tiene rol"
@@ -2580,7 +2580,6 @@
       "@value" : "klíčové slovo"
     } ],
     "range" : "rdfs:Literal",
-    "subPropertyOf" : "dcterms:subject",
     "skos:definition" : [ {
       "@language" : "cs",
       "@value" : "Klíčové slovo nebo značka popisující zdroj."
@@ -3862,22 +3861,6 @@
       "@id" : "http://www.w3.org/2004/02/skos/core#editorialNote",
       "@type" : "http://www.w3.org/1999/02/22-rdf-syntax-ns#langString"
     },
-    "onProperty" : {
-      "@id" : "http://www.w3.org/2002/07/owl#onProperty",
-      "@type" : "@id"
-    },
-    "maxCardinality" : {
-      "@id" : "http://www.w3.org/2002/07/owl#maxCardinality",
-      "@type" : "http://www.w3.org/2001/XMLSchema#nonNegativeInteger"
-    },
-    "name" : {
-      "@id" : "http://xmlns.com/foaf/0.1/name",
-      "@type" : "http://www.w3.org/2001/XMLSchema#string"
-    },
-    "affiliation" : {
-      "@id" : "http://schema.org/affiliation",
-      "@type" : "@id"
-    },
     "rest" : {
       "@id" : "http://www.w3.org/1999/02/22-rdf-syntax-ns#rest",
       "@type" : "@id"
@@ -3890,13 +3873,9 @@
       "@id" : "http://www.w3.org/2004/02/skos/core#altLabel",
       "@type" : "http://www.w3.org/1999/02/22-rdf-syntax-ns#langString"
     },
-    "allValuesFrom" : {
-      "@id" : "http://www.w3.org/2002/07/owl#allValuesFrom",
-      "@type" : "@id"
-    },
-    "cardinality" : {
-      "@id" : "http://www.w3.org/2002/07/owl#cardinality",
-      "@type" : "http://www.w3.org/2001/XMLSchema#nonNegativeInteger"
+    "name" : {
+      "@id" : "http://xmlns.com/foaf/0.1/name",
+      "@type" : "http://www.w3.org/2001/XMLSchema#string"
     },
     "homepage" : {
       "@id" : "http://xmlns.com/foaf/0.1/homepage",
@@ -3904,6 +3883,10 @@
     },
     "seeAlso" : {
       "@id" : "http://www.w3.org/2000/01/rdf-schema#seeAlso",
+      "@type" : "@id"
+    },
+    "affiliation" : {
+      "@id" : "http://schema.org/affiliation",
       "@type" : "@id"
     },
     "rangeIncludes" : {
@@ -3914,12 +3897,20 @@
       "@id" : "http://www.w3.org/2002/07/owl#unionOf",
       "@type" : "@id"
     },
+    "onProperty" : {
+      "@id" : "http://www.w3.org/2002/07/owl#onProperty",
+      "@type" : "@id"
+    },
     "minCardinality" : {
       "@id" : "http://www.w3.org/2002/07/owl#minCardinality",
       "@type" : "http://www.w3.org/2001/XMLSchema#nonNegativeInteger"
     },
-    "workInfoHomepage" : {
-      "@id" : "http://xmlns.com/foaf/0.1/workInfoHomepage",
+    "allValuesFrom" : {
+      "@id" : "http://www.w3.org/2002/07/owl#allValuesFrom",
+      "@type" : "@id"
+    },
+    "maker" : {
+      "@id" : "http://xmlns.com/foaf/0.1/maker",
       "@type" : "@id"
     },
     "versionInfo" : {
@@ -3942,10 +3933,6 @@
       "@id" : "http://purl.org/dc/terms/creator",
       "@type" : "@id"
     },
-    "maker" : {
-      "@id" : "http://xmlns.com/foaf/0.1/maker",
-      "@type" : "@id"
-    },
     "license" : {
       "@id" : "http://purl.org/dc/terms/license",
       "@type" : "@id"
@@ -3956,6 +3943,18 @@
     },
     "propertyChainAxiom" : {
       "@id" : "http://www.w3.org/2002/07/owl#propertyChainAxiom",
+      "@type" : "@id"
+    },
+    "cardinality" : {
+      "@id" : "http://www.w3.org/2002/07/owl#cardinality",
+      "@type" : "http://www.w3.org/2001/XMLSchema#nonNegativeInteger"
+    },
+    "maxCardinality" : {
+      "@id" : "http://www.w3.org/2002/07/owl#maxCardinality",
+      "@type" : "http://www.w3.org/2001/XMLSchema#nonNegativeInteger"
+    },
+    "workInfoHomepage" : {
+      "@id" : "http://xmlns.com/foaf/0.1/workInfoHomepage",
       "@type" : "@id"
     },
     "owl" : "http://www.w3.org/2002/07/owl#",

--- a/dcat/rdf/dcat3.rdf
+++ b/dcat/rdf/dcat3.rdf
@@ -16,16 +16,15 @@
     <rdfs:label xml:lang="it">Il vocabolario del catalogo dei dati</rdfs:label>
     <owl:versionInfo xml:lang="en">Questa è una copia aggiornata del vocabolario DCAT v2.0 disponibile in https://www.w3.org/ns/dcat.ttl</owl:versionInfo>
     <rdfs:comment xml:lang="da">DCAT er et RDF-vokabular som har til formål at understøtte interoperabilitet mellem datakataloger udgivet på nettet. Ved at anvende DCAT til at beskrive datasæt i datakataloger, kan udgivere øge findbarhed og gøre det gøre det lettere for applikationer at anvende metadata fra forskellige kataloger. Derudover understøttes decentraliseret udstilling af kataloger og fødererede datasætsøgninger på tværs af websider. Aggregerede DCAT-metadata kan fungere som fortegnelsesfiler der kan understøtte digital bevaring. DCAT er defineret på http://www.w3.org/TR/vocab-dcat/. Enhver forskel mellem det normative dokument og dette schema er en fejl i dette schema.</rdfs:comment>
-    <dcterms:contributor rdf:parseType="Resource">
-      <foaf:name>Boris Villazón-Terrazas</foaf:name>
-    </dcterms:contributor>
     <owl:versionInfo xml:lang="en">This is an updated copy of v2.0 of the DCAT vocabulary, taken from https://www.w3.org/ns/dcat.ttl</owl:versionInfo>
-    <rdfs:label xml:lang="fr">Le vocabulaire des jeux de données</rdfs:label>
-    <dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#date"
-    >2021-04-08</dcterms:modified>
     <dcterms:contributor rdf:parseType="Resource">
-      <foaf:name>Martin Alvarez-Espinar</foaf:name>
+      <foaf:name>David Browning</foaf:name>
+      <sdo:affiliation rdf:parseType="Resource">
+        <foaf:name>Refinitiv</foaf:name>
+        <foaf:homepage rdf:resource="http://www.refinitiv.com"/>
+      </sdo:affiliation>
     </dcterms:contributor>
+    <rdfs:label xml:lang="fr">Le vocabulaire des jeux de données</rdfs:label>
     <dcterms:contributor rdf:parseType="Resource">
       <foaf:name>Rufus Pollock</foaf:name>
       <sdo:affiliation rdf:parseType="Resource">
@@ -33,76 +32,44 @@
         <foaf:homepage rdf:resource="http://okfn.org"/>
       </sdo:affiliation>
     </dcterms:contributor>
+    <dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#date"
+    >2021-04-08</dcterms:modified>
     <dcterms:contributor rdf:parseType="Resource">
-      <foaf:name>Marios Meimaris</foaf:name>
+      <foaf:name>Richard Cyganiak</foaf:name>
     </dcterms:contributor>
-    <dcterms:creator rdf:parseType="Resource">
-      <foaf:name>John Erickson</foaf:name>
-    </dcterms:creator>
     <dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#date"
     >2020-11-30</dcterms:modified>
-    <foaf:maker rdf:parseType="Resource">
-      <foaf:name>Government Linked Data WG</foaf:name>
-      <foaf:homepage rdf:resource="http://www.w3.org/2011/gld/"/>
-    </foaf:maker>
-    <dcterms:contributor rdf:parseType="Resource">
-      <foaf:name>Alejandra Gonzalez-Beltran</foaf:name>
-      <foaf:homepage rdf:resource="https://agbeltran.github.io"/>
-      <rdfs:seeAlso rdf:resource="https://orcid.org/0000-0003-3499-8262"/>
-      <sdo:affiliation rdf:parseType="Resource">
-        <foaf:name>Science and Technology Facilities Council, UK</foaf:name>
-        <foaf:homepage rdf:resource="http://stfc.ac.uk"/>
-      </sdo:affiliation>
-    </dcterms:contributor>
     <rdfs:comment xml:lang="fr">DCAT est un vocabulaire développé pour faciliter l'interopérabilité entre les jeux de données publiées sur le Web. En utilisant DCAT pour décrire les jeux de données dans les catalogues de données, les fournisseurs de données augmentent leur découverte et permettent que les applications facilement les métadonnées de plusieurs catalogues. Il permet en plus la publication décentralisée des catalogues et facilitent la recherche fédérée des données entre plusieurs sites. Les métadonnées DCAT aggrégées peuvent servir comme un manifeste pour faciliter la préservation digitale des ressources. DCAT est définie à l'adresse http://www.w3.org/TR/vocab-dcat/. Une quelconque version de ce document normatif et ce vocabulaire est une erreur dans ce vocabulaire.</rdfs:comment>
-    <dcterms:contributor rdf:parseType="Resource">
-      <foaf:name>Andrea Perego</foaf:name>
-      <foaf:homepage rdf:resource="http://www.andrea-perego.name/foaf/#me"/>
-      <rdfs:seeAlso rdf:resource="https://orcid.org/0000-0001-9300-2694"/>
-    </dcterms:contributor>
-    <dcterms:creator rdf:parseType="Resource">
-      <foaf:name>Fadi Maali</foaf:name>
-      <rdfs:seeAlso rdf:resource="http://fadmaa.me/foaf.ttl"/>
-    </dcterms:creator>
     <rdfs:label xml:lang="es">El vocabulario de catálogo de datos</rdfs:label>
     <owl:imports rdf:resource="http://www.w3.org/2004/02/skos/core"/>
     <rdfs:comment xml:lang="cs">DCAT je RDF slovník navržený pro zprostředkování interoperability mezi datovými katalogy publikovanými na Webu. Poskytovatelé dat používáním slovníku DCAT pro popis datových sad v datových katalozích zvyšují jejich dohledatelnost a umožňují aplikacím konzumovat metadata z více katalogů. Dále je umožňena decentralizovaná publikace katalogů a federované dotazování na datové sady napříč katalogy. Agregovaná DCAT metadata mohou také sloužit jako průvodka umožňující digitální uchování informace. DCAT je definován na http://www.w3.org/TR/vocab-dcat/. Jakýkoliv nesoulad mezi odkazovaným dokumentem a tímto schématem je chybou v tomto schématu.</rdfs:comment>
+    <dcterms:contributor rdf:parseType="Resource">
+      <foaf:name>Makx Dekkers</foaf:name>
+      <foaf:homepage rdf:resource="http://makxdekkers.com/"/>
+      <rdfs:seeAlso rdf:resource="http://makxdekkers.com/makxdekkers.rdf#me"/>
+    </dcterms:contributor>
+    <dcterms:contributor rdf:parseType="Resource">
+      <foaf:name>Boris Villazón-Terrazas</foaf:name>
+    </dcterms:contributor>
     <owl:versionInfo xml:lang="es">Esta es una copia del vocabulario DCAT v2.0 disponible en https://www.w3.org/ns/dcat.ttl</owl:versionInfo>
     <dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#date"
     >2012-04-24</dcterms:modified>
     <rdfs:comment xml:lang="ar">هي أنطولوجية تسهل تبادل البيانات بين مختلف الفهارس على الوب. استخدام هذه الأنطولوجية يساعد على اكتشاف قوائم  البيانات المنشورة على الوب و يمكن التطبيقات المختلفة من الاستفادة أتوماتيكيا من البيانات المتاحة من مختلف الفهارس.</rdfs:comment>
     <skos:editorialNote xml:lang="en">English language definitions updated in this revision in line with ED. Multilingual text unevenly updated.</skos:editorialNote>
-    <dcterms:contributor rdf:parseType="Resource">
-      <foaf:name>Vassilios Peristeras</foaf:name>
-      <sdo:affiliation rdf:parseType="Resource">
-        <foaf:name>European Commission, DG DIGIT</foaf:name>
-        <foaf:homepage rdf:resource="http://ec.europa.eu/dgs/informatics/"/>
-      </sdo:affiliation>
-    </dcterms:contributor>
     <rdfs:label xml:lang="da">Datakatalogvokabular</rdfs:label>
     <dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#date"
     >2017-12-19</dcterms:modified>
+    <dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#date"
+    >2021-06-23</dcterms:modified>
     <dcterms:contributor rdf:parseType="Resource">
       <foaf:name>Shuji Kamitsuna</foaf:name>
       <foaf:homepage rdf:resource="http://www.asahi-net.or.jp/~ax2s-kmtn/"/>
     </dcterms:contributor>
-    <dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#date"
-    >2013-09-20</dcterms:modified>
-    <owl:imports rdf:resource="http://www.w3.org/ns/prov-o#"/>
     <dcterms:contributor rdf:parseType="Resource">
-      <foaf:name>Richard Cyganiak</foaf:name>
-    </dcterms:contributor>
-    <rdfs:comment xml:lang="ja">DCATは、ウェブ上で公開されたデータ・カタログ間の相互運用性の促進を目的とするRDFの語彙です。このドキュメントでは、その利用のために、スキーマを定義し、例を提供します。データ・カタログ内のデータセットを記述するためにDCATを用いると、公開者が、発見可能性を増加させ、アプリケーションが複数のカタログのメタデータを容易に利用できるようになります。さらに、カタログの分散公開を可能にし、複数のサイトにまたがるデータセットの統合検索を促進します。集約されたDCATメタデータは、ディジタル保存を促進するためのマニフェスト・ファイルとして使用できます。</rdfs:comment>
-    <owl:versionInfo xml:lang="da">Dette er en opdateret kopi af DCAT v. 2.0 som er tilgænglig på https://www.w3.org/ns/dcat.ttl</owl:versionInfo>
-    <rdfs:comment xml:lang="en">DCAT is an RDF vocabulary designed to facilitate interoperability between data catalogs published on the Web. By using DCAT to describe datasets in data catalogs, publishers increase discoverability and enable applications easily to consume metadata from multiple catalogs. It further enables decentralized publishing of catalogs and facilitates federated dataset search across sites. Aggregated DCAT metadata can serve as a manifest file to facilitate digital preservation. DCAT is defined at http://www.w3.org/TR/vocab-dcat/. Any variance between that normative document and this schema is an error in this schema.</rdfs:comment>
-    <dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#date"
-    >2021-03-09</dcterms:modified>
-    <dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#date"
-    >2013-11-28</dcterms:modified>
-    <dcterms:contributor rdf:parseType="Resource">
-      <foaf:name>Makx Dekkers</foaf:name>
-      <foaf:homepage rdf:resource="http://makxdekkers.com/"/>
-      <rdfs:seeAlso rdf:resource="http://makxdekkers.com/makxdekkers.rdf#me"/>
+      <foaf:name>Phil Archer</foaf:name>
+      <foaf:homepage rdf:resource="http://www.w3.org/People/all#phila"/>
+      <rdfs:seeAlso rdf:resource="http://philarcher.org/foaf.rdf#me"/>
+      <sdo:affiliation rdf:resource="http://www.w3.org/data#W3C"/>
     </dcterms:contributor>
     <dcterms:contributor>
       <foaf:Person>
@@ -115,43 +82,78 @@
         </sdo:affiliation>
       </foaf:Person>
     </dcterms:contributor>
+    <dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#date"
+    >2013-09-20</dcterms:modified>
+    <dcterms:contributor rdf:parseType="Resource">
+      <foaf:name>Marios Meimaris</foaf:name>
+    </dcterms:contributor>
+    <owl:imports rdf:resource="http://www.w3.org/ns/prov-o#"/>
+    <rdfs:comment xml:lang="ja">DCATは、ウェブ上で公開されたデータ・カタログ間の相互運用性の促進を目的とするRDFの語彙です。このドキュメントでは、その利用のために、スキーマを定義し、例を提供します。データ・カタログ内のデータセットを記述するためにDCATを用いると、公開者が、発見可能性を増加させ、アプリケーションが複数のカタログのメタデータを容易に利用できるようになります。さらに、カタログの分散公開を可能にし、複数のサイトにまたがるデータセットの統合検索を促進します。集約されたDCATメタデータは、ディジタル保存を促進するためのマニフェスト・ファイルとして使用できます。</rdfs:comment>
+    <owl:versionInfo xml:lang="da">Dette er en opdateret kopi af DCAT v. 2.0 som er tilgænglig på https://www.w3.org/ns/dcat.ttl</owl:versionInfo>
+    <rdfs:comment xml:lang="en">DCAT is an RDF vocabulary designed to facilitate interoperability between data catalogs published on the Web. By using DCAT to describe datasets in data catalogs, publishers increase discoverability and enable applications easily to consume metadata from multiple catalogs. It further enables decentralized publishing of catalogs and facilitates federated dataset search across sites. Aggregated DCAT metadata can serve as a manifest file to facilitate digital preservation. DCAT is defined at http://www.w3.org/TR/vocab-dcat/. Any variance between that normative document and this schema is an error in this schema.</rdfs:comment>
+    <dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#date"
+    >2021-03-09</dcterms:modified>
+    <dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#date"
+    >2013-11-28</dcterms:modified>
+    <dcterms:creator rdf:parseType="Resource">
+      <foaf:name>Fadi Maali</foaf:name>
+      <rdfs:seeAlso rdf:resource="http://fadmaa.me/foaf.ttl"/>
+    </dcterms:creator>
     <dcterms:modified>2019</dcterms:modified>
+    <dcterms:creator rdf:parseType="Resource">
+      <foaf:name>John Erickson</foaf:name>
+    </dcterms:creator>
     <dcterms:license rdf:resource="https://creativecommons.org/licenses/by/4.0/"/>
     <owl:imports rdf:resource="http://purl.org/dc/terms/"/>
+    <dcterms:contributor rdf:parseType="Resource">
+      <foaf:name>Andrea Perego</foaf:name>
+      <foaf:homepage rdf:resource="http://www.andrea-perego.name/foaf/#me"/>
+      <rdfs:seeAlso rdf:resource="https://orcid.org/0000-0001-9300-2694"/>
+    </dcterms:contributor>
     <rdfs:comment xml:lang="es">DCAT es un vocabulario RDF diseñado para facilitar la interoperabilidad entre catálogos de datos publicados en la Web. Utilizando DCAT para describir datos disponibles en catálogos se aumenta la posibilidad de que sean descubiertos y se permite que las aplicaciones consuman fácilmente los metadatos de varios catálogos.</rdfs:comment>
+    <dcterms:contributor rdf:parseType="Resource">
+      <foaf:name>Vassilios Peristeras</foaf:name>
+      <sdo:affiliation rdf:parseType="Resource">
+        <foaf:name>European Commission, DG DIGIT</foaf:name>
+        <foaf:homepage rdf:resource="http://ec.europa.eu/dgs/informatics/"/>
+      </sdo:affiliation>
+    </dcterms:contributor>
+    <dcterms:contributor rdf:parseType="Resource">
+      <foaf:name>Alejandra Gonzalez-Beltran</foaf:name>
+      <foaf:homepage rdf:resource="https://agbeltran.github.io"/>
+      <rdfs:seeAlso rdf:resource="https://orcid.org/0000-0003-3499-8262"/>
+      <sdo:affiliation rdf:parseType="Resource">
+        <foaf:name>Science and Technology Facilities Council, UK</foaf:name>
+        <foaf:homepage rdf:resource="http://stfc.ac.uk"/>
+      </sdo:affiliation>
+    </dcterms:contributor>
+    <dcterms:contributor rdf:parseType="Resource">
+      <foaf:name>Martin Alvarez-Espinar</foaf:name>
+    </dcterms:contributor>
     <rdfs:label xml:lang="ar">أنطولوجية فهارس قوائم البيانات</rdfs:label>
     <rdfs:label xml:lang="el">Το λεξιλόγιο των καταλόγων δεδομένων</rdfs:label>
-    <owl:versionInfo xml:lang="cs">Toto je aktualizovaná kopie slovníku DCAT verze 2.0, převzatá z https://www.w3.org/ns/dcat.ttl</owl:versionInfo>
-    <rdfs:comment xml:lang="el">Το DCAT είναι ένα RDF λεξιλόγιο που σχεδιάσθηκε για να κάνει εφικτή τη διαλειτουργικότητα μεταξύ καταλόγων δεδομένων στον Παγκόσμιο Ιστό. Χρησιμοποιώντας το DCAT για την περιγραφή συνόλων δεδομένων, οι εκδότες αυτών αυξάνουν την ανακαλυψιμότητα και επιτρέπουν στις εφαρμογές την εύκολη κατανάλωση μεταδεδομένων από πολλαπλούς καταλόγους. Επιπλέον, δίνει τη δυνατότητα για αποκεντρωμένη έκδοση και διάθεση καταλόγων και επιτρέπει δυνατότητες ενοποιημένης αναζήτησης μεταξύ διαφορετικών πηγών. Συγκεντρωτικά μεταδεδομένα που έχουν περιγραφεί με το DCAT μπορούν να χρησιμοποιηθούν σαν ένα δηλωτικό αρχείο (manifest file) ώστε να διευκολύνουν την ψηφιακή συντήρηση.</rdfs:comment>
-    <dcterms:contributor rdf:parseType="Resource">
-      <foaf:name>Riccardo Albertoni</foaf:name>
-      <foaf:homepage rdf:resource="https://w3id.org/people/ralbertoni/"/>
-      <foaf:homepage rdf:resource="http://www.imati.cnr.it/index.php/people/8-curricula/178-riccardo-albertoni"/>
-      <rdfs:seeAlso rdf:resource="https://orcid.org/0000-0001-5648-2713"/>
-    </dcterms:contributor>
     <dcterms:contributor rdf:parseType="Resource">
       <foaf:name>Jakub Klímek</foaf:name>
       <foaf:homepage rdf:resource="https://jakub.klímek.com/"/>
       <rdfs:seeAlso rdf:resource="https://jakub.klímek.com/#me"/>
     </dcterms:contributor>
+    <owl:versionInfo xml:lang="cs">Toto je aktualizovaná kopie slovníku DCAT verze 2.0, převzatá z https://www.w3.org/ns/dcat.ttl</owl:versionInfo>
+    <rdfs:comment xml:lang="el">Το DCAT είναι ένα RDF λεξιλόγιο που σχεδιάσθηκε για να κάνει εφικτή τη διαλειτουργικότητα μεταξύ καταλόγων δεδομένων στον Παγκόσμιο Ιστό. Χρησιμοποιώντας το DCAT για την περιγραφή συνόλων δεδομένων, οι εκδότες αυτών αυξάνουν την ανακαλυψιμότητα και επιτρέπουν στις εφαρμογές την εύκολη κατανάλωση μεταδεδομένων από πολλαπλούς καταλόγους. Επιπλέον, δίνει τη δυνατότητα για αποκεντρωμένη έκδοση και διάθεση καταλόγων και επιτρέπει δυνατότητες ενοποιημένης αναζήτησης μεταξύ διαφορετικών πηγών. Συγκεντρωτικά μεταδεδομένα που έχουν περιγραφεί με το DCAT μπορούν να χρησιμοποιηθούν σαν ένα δηλωτικό αρχείο (manifest file) ώστε να διευκολύνουν την ψηφιακή συντήρηση.</rdfs:comment>
     <rdfs:label xml:lang="ja">データ・カタログ語彙（DCAT）</rdfs:label>
-    <dcterms:contributor rdf:parseType="Resource">
-      <foaf:name>David Browning</foaf:name>
-      <sdo:affiliation rdf:parseType="Resource">
-        <foaf:name>Refinitiv</foaf:name>
-        <foaf:homepage rdf:resource="http://www.refinitiv.com"/>
-      </sdo:affiliation>
-    </dcterms:contributor>
-    <rdfs:comment xml:lang="it">DCAT è un vocabolario RDF progettato per facilitare l'interoperabilità tra i cataloghi di dati pubblicati nel Web. Utilizzando DCAT per descrivere i dataset nei cataloghi di dati, i fornitori migliorano la capacità di individuazione dei dati e abilitano le  applicazioni al consumo di dati provenienti da cataloghi differenti. DCAT permette di decentralizzare la pubblicazione di cataloghi e facilita la ricerca federata dei dataset. L'aggregazione dei metadati federati può fungere da file manifesto per facilitare la conservazione digitale. DCAT è definito all'indirizzo http://www.w3.org/TR/vocab-dcat/. Qualsiasi scostamento tra tale definizione normativa e questo schema è da considerarsi un errore di questo schema.</rdfs:comment>
     <dcterms:contributor rdf:parseType="Resource">
       <foaf:name>Ghislain Auguste Atemezing</foaf:name>
       <rdfs:seeAlso rdf:resource="http://www.eurecom.fr/~atemezin/gatemezing-foaf.rdf"/>
     </dcterms:contributor>
+    <rdfs:comment xml:lang="it">DCAT è un vocabolario RDF progettato per facilitare l'interoperabilità tra i cataloghi di dati pubblicati nel Web. Utilizzando DCAT per descrivere i dataset nei cataloghi di dati, i fornitori migliorano la capacità di individuazione dei dati e abilitano le  applicazioni al consumo di dati provenienti da cataloghi differenti. DCAT permette di decentralizzare la pubblicazione di cataloghi e facilita la ricerca federata dei dataset. L'aggregazione dei metadati federati può fungere da file manifesto per facilitare la conservazione digitale. DCAT è definito all'indirizzo http://www.w3.org/TR/vocab-dcat/. Qualsiasi scostamento tra tale definizione normativa e questo schema è da considerarsi un errore di questo schema.</rdfs:comment>
+    <foaf:maker rdf:parseType="Resource">
+      <foaf:name>Government Linked Data WG</foaf:name>
+      <foaf:homepage rdf:resource="http://www.w3.org/2011/gld/"/>
+    </foaf:maker>
     <dcterms:contributor rdf:parseType="Resource">
-      <foaf:name>Phil Archer</foaf:name>
-      <foaf:homepage rdf:resource="http://www.w3.org/People/all#phila"/>
-      <rdfs:seeAlso rdf:resource="http://philarcher.org/foaf.rdf#me"/>
-      <sdo:affiliation rdf:resource="http://www.w3.org/data#W3C"/>
+      <foaf:name>Riccardo Albertoni</foaf:name>
+      <foaf:homepage rdf:resource="https://w3id.org/people/ralbertoni/"/>
+      <foaf:homepage rdf:resource="http://www.imati.cnr.it/index.php/people/8-curricula/178-riccardo-albertoni"/>
+      <rdfs:seeAlso rdf:resource="https://orcid.org/0000-0001-5648-2713"/>
     </dcterms:contributor>
     <rdfs:label xml:lang="en">The data catalog vocabulary</rdfs:label>
   </owl:Ontology>
@@ -215,8 +217,10 @@
     <rdfs:comment xml:lang="en">A site or end-point providing operations related to the discovery of, access to, or processing functions on, data or related resources.</rdfs:comment>
     <rdfs:comment xml:lang="cs">Umístění či přístupový bod poskytující operace související s hledáním, přistupem k, či výkonem funkcí na datech či souvisejících zdrojích.</rdfs:comment>
     <skos:changeNote xml:lang="en">New class added in DCAT 2.0.</skos:changeNote>
-    <skos:scopeNote xml:lang="da">Hvis en dcat:DataService er bundet til en eller flere specifikke datasæt kan dette indikeres ved hjælp af egenskaben dcat:servesDataset. </skos:scopeNote>
     <skos:changeNote xml:lang="cs">Nová třída přidaná ve verzi DCAT 2.0.</skos:changeNote>
+    <skos:scopeNote xml:lang="da">Hvis en dcat:DataService er bundet til en eller flere specifikke datasæt kan dette indikeres ved hjælp af egenskaben dcat:servesDataset. </skos:scopeNote>
+    <rdfs:label xml:lang="it">Servizio di dati</rdfs:label>
+    <skos:scopeNote xml:lang="en">The kind of service can be indicated using the dcterms:type property. Its value may be taken from a controlled vocabulary such as the INSPIRE spatial data service type vocabulary.</skos:scopeNote>
     <rdfs:subClassOf>
       <owl:Restriction>
         <owl:onProperty>
@@ -226,8 +230,6 @@
         >1</owl:maxCardinality>
       </owl:Restriction>
     </rdfs:subClassOf>
-    <rdfs:label xml:lang="it">Servizio di dati</rdfs:label>
-    <skos:scopeNote xml:lang="en">The kind of service can be indicated using the dcterms:type property. Its value may be taken from a controlled vocabulary such as the INSPIRE spatial data service type vocabulary.</skos:scopeNote>
     <rdfs:subClassOf rdf:resource="http://purl.org/dc/dcmitype/Service"/>
     <skos:altLabel xml:lang="da">Dataservice</skos:altLabel>
     <skos:definition xml:lang="en">A site or end-point providing operations related to the discovery of, access to, or processing functions on, data or related resources.</skos:definition>
@@ -264,14 +266,6 @@
     <skos:definition xml:lang="cs">Záznam v datovém katalogu popisující jednu datovou sadu či datovou službu.</skos:definition>
     <rdfs:label xml:lang="es">Registro del catálogo</rdfs:label>
     <rdfs:label xml:lang="it">Record di catalogo</rdfs:label>
-    <skos:scopeNote xml:lang="it">Questa classe è opzionale e non tutti i cataloghi la utilizzeranno. Esiste per cataloghi in cui si opera una distinzione tra i metadati relativi al dataset ed i metadati relativi alla gestione del dataset nel catalogo. Ad esempio, la  proprietà per indicare la data di pubblicazione del dataset rifletterà la data in cui l'informazione è stata originariamente messa a disposizione dalla casa editrice, mentre la data di pubblicazione per il record nel catalogo rifletterà la data in cui il dataset è stato aggiunto al catalogo. Nei casi dove solo quest'ultima sia nota, si utilizzerà esclusivamente la data di  pubblicazione relativa al record del catalogo. Si noti che l'Ontologia W3C PROV permette di descrivere ulteriori informazioni sulla provenienza, quali i dettagli del processo, la procedura e l'agente coinvolto in una particolare modifica di un dataset.</skos:scopeNote>
-    <skos:scopeNote xml:lang="cs">Tato třída je volitelná a ne všechny katalogy ji využijí. Existuje pro katalogy, ve kterých se rozlišují metadata datové sady či datové služby a metadata o záznamu o datové sadě či datové službě v katalogu. Například datum publikace datové sady odráží datum, kdy byla datová sada původně zveřejněna poskytovatelem dat, zatímco datum publikace katalogizačního záznamu je datum zanesení datové sady do katalogu. V případech kdy se obě data liší, nebo je známo jen to druhé, by mělo být specifikováno jen datum publikace katalogizačního záznamu. Všimněte si, že ontologie W3C PROV umožňuje popsat další informace o původu jako například podrobnosti o procesu konkrétní změny datové sady a jeho účastnících.</skos:scopeNote>
-    <skos:definition xml:lang="es">Un registro en un catálogo de datos que describe un solo conjunto de datos o un servicio de datos.</skos:definition>
-    <rdfs:comment xml:lang="da">En post i et datakatalog der beskriver registreringen af et enkelt datasæt eller en datatjeneste.</rdfs:comment>
-    <skos:definition xml:lang="da">En post i et datakatalog der beskriver registreringen af et enkelt datasæt eller en datatjeneste.</skos:definition>
-    <rdfs:comment xml:lang="cs">Záznam v datovém katalogu popisující jednu datovou sadu či datovou službu.</rdfs:comment>
-    <rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Class"/>
-    <rdfs:comment xml:lang="fr">Un registre du catalogue ou une entrée du catalogue, décrivant un seul jeu de données.</rdfs:comment>
     <rdfs:subClassOf>
       <owl:Restriction>
         <owl:onProperty>
@@ -282,6 +276,23 @@
         </owl:allValuesFrom>
       </owl:Restriction>
     </rdfs:subClassOf>
+    <skos:scopeNote xml:lang="it">Questa classe è opzionale e non tutti i cataloghi la utilizzeranno. Esiste per cataloghi in cui si opera una distinzione tra i metadati relativi al dataset ed i metadati relativi alla gestione del dataset nel catalogo. Ad esempio, la  proprietà per indicare la data di pubblicazione del dataset rifletterà la data in cui l'informazione è stata originariamente messa a disposizione dalla casa editrice, mentre la data di pubblicazione per il record nel catalogo rifletterà la data in cui il dataset è stato aggiunto al catalogo. Nei casi dove solo quest'ultima sia nota, si utilizzerà esclusivamente la data di  pubblicazione relativa al record del catalogo. Si noti che l'Ontologia W3C PROV permette di descrivere ulteriori informazioni sulla provenienza, quali i dettagli del processo, la procedura e l'agente coinvolto in una particolare modifica di un dataset.</skos:scopeNote>
+    <skos:scopeNote xml:lang="cs">Tato třída je volitelná a ne všechny katalogy ji využijí. Existuje pro katalogy, ve kterých se rozlišují metadata datové sady či datové služby a metadata o záznamu o datové sadě či datové službě v katalogu. Například datum publikace datové sady odráží datum, kdy byla datová sada původně zveřejněna poskytovatelem dat, zatímco datum publikace katalogizačního záznamu je datum zanesení datové sady do katalogu. V případech kdy se obě data liší, nebo je známo jen to druhé, by mělo být specifikováno jen datum publikace katalogizačního záznamu. Všimněte si, že ontologie W3C PROV umožňuje popsat další informace o původu jako například podrobnosti o procesu konkrétní změny datové sady a jeho účastnících.</skos:scopeNote>
+    <skos:definition xml:lang="es">Un registro en un catálogo de datos que describe un solo conjunto de datos o un servicio de datos.</skos:definition>
+    <rdfs:comment xml:lang="da">En post i et datakatalog der beskriver registreringen af et enkelt datasæt eller en datatjeneste.</rdfs:comment>
+    <skos:definition xml:lang="da">En post i et datakatalog der beskriver registreringen af et enkelt datasæt eller en datatjeneste.</skos:definition>
+    <rdfs:comment xml:lang="cs">Záznam v datovém katalogu popisující jednu datovou sadu či datovou službu.</rdfs:comment>
+    <rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Class"/>
+    <rdfs:subClassOf>
+      <owl:Restriction>
+        <owl:onProperty>
+          <owl:ObjectProperty rdf:about="http://xmlns.com/foaf/0.1/primaryTopic"/>
+        </owl:onProperty>
+        <owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger"
+        >1</owl:cardinality>
+      </owl:Restriction>
+    </rdfs:subClassOf>
+    <rdfs:comment xml:lang="fr">Un registre du catalogue ou une entrée du catalogue, décrivant un seul jeu de données.</rdfs:comment>
     <skos:definition xml:lang="ja">1つのデータセットを記述したデータ・カタログ内のレコード。</skos:definition>
     <rdfs:label xml:lang="en">Catalog Record</rdfs:label>
     <skos:scopeNote xml:lang="es">Esta clase es opcional y no todos los catálogos la utilizarán. Esta clase existe para catálogos que hacen una distinción entre los metadatos acerca de un conjunto de datos o un servicio de datos y los metadatos acerca de una entrada en ese conjunto de datos en el catálogo. Por ejemplo, la propiedad sobre la fecha de la publicación de los datos refleja la fecha en que la información fue originalmente publicada, mientras que la fecha de publicación del registro del catálogo es la fecha en que los datos se agregaron al mismo. En caso en que ambas fechas fueran diferentes, o en que sólo la fecha de publicación del registro del catálogo estuviera disponible, sólo debe especificarse en el registro del catálogo. Tengan en cuenta que la ontología PROV de W3C permite describir otra información sobre la proveniencia de los datos, como por ejemplo detalles del proceso y de los agentes involucrados en algún cambio específico a los datos.</skos:scopeNote>
@@ -295,15 +306,6 @@
     <skos:scopeNote xml:lang="en">This class is optional and not all catalogs will use it. It exists for catalogs where a distinction is made between metadata about a dataset or data service and metadata about the entry for the dataset or data service in the catalog. For example, the publication date property of the dataset reflects the date when the information was originally made available by the publishing agency, while the publication date of the catalog record is the date when the dataset was added to the catalog. In cases where both dates differ, or where only the latter is known, the publication date should only be specified for the catalog record. Notice that the W3C PROV Ontology allows describing further provenance information such as the details of the process and the agent involved in a particular change to a dataset.</skos:scopeNote>
     <skos:scopeNote xml:lang="el">Αυτή η κλάση είναι προαιρετική και δεν χρησιμοποιείται από όλους τους καταλόγους. Υπάρχει για τις περιπτώσεις καταλόγων όπου γίνεται διαχωρισμός μεταξύ των μεταδεδομένων για το σύνολο των δεδομένων και των μεταδεδομένων για την καταγραφή του συνόλου δεδομένων εντός του καταλόγου. Για παράδειγμα, η ιδιότητα της ημερομηνίας δημοσίευσης του συνόλου δεδομένων δείχνει την ημερομηνία κατά την οποία οι πληροφορίες έγιναν διαθέσιμες από τον φορέα δημοσίευσης, ενώ η ημερομηνία δημοσίευσης της καταγραφής του καταλόγου δείχνει την ημερομηνία που το σύνολο δεδομένων προστέθηκε στον κατάλογο. Σε περιπτώσεις που οι δύο ημερομηνίες διαφέρουν, ή που μόνο η τελευταία είναι γνωστή, η ημερομηνία δημοσίευσης θα πρέπει να δίνεται για την καταγραφή του καταλόγου. Να σημειωθεί πως η οντολογία W3C PROV επιτρέπει την περιγραφή επιπλέον πληροφοριών ιστορικού όπως λεπτομέρειες για τη διαδικασία και τον δράστη που εμπλέκονται σε μία συγκεκριμένη αλλαγή εντός του συνόλου δεδομένων.</skos:scopeNote>
     <skos:scopeNote xml:lang="da">Denne klasse er valgfri og ikke alle kataloger vil anvende denne klasse. Den kan anvendes i de kataloger hvor der skelnes mellem metadata om datasættet eller datatjenesten og metadata om selve posten til registreringen af datasættet eller datatjenesten i kataloget. Udgivelsesdatoen for datasættet afspejler for eksempel den dato hvor informationerne oprindeligt blev gjort tilgængelige af udgiveren, hvorimod udgivelsesdatoen for katalogposten er den dato hvor datasættet blev føjet til kataloget. I de tilfælde hvor de to datoer er forskellige eller hvor blot sidstnævnte er kendt, bør udgivelsesdatoen kun angives for katalogposten. Bemærk at W3Cs PROV ontologi gør til muligt at tilføje yderligere proveniensoplysninger eksempelvis om processen eller aktøren involveret i en given ændring af datasættet.</skos:scopeNote>
-    <rdfs:subClassOf>
-      <owl:Restriction>
-        <owl:onProperty>
-          <owl:ObjectProperty rdf:about="http://xmlns.com/foaf/0.1/primaryTopic"/>
-        </owl:onProperty>
-        <owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger"
-        >1</owl:cardinality>
-      </owl:Restriction>
-    </rdfs:subClassOf>
     <skos:definition xml:lang="el">Μία καταγραφή ενός καταλόγου, η οποία περιγράφει ένα συγκεκριμένο σύνολο δεδομένων.</skos:definition>
     <rdfs:label xml:lang="fr">Registre du catalogue</rdfs:label>
     <skos:scopeNote xml:lang="fr">C'est une classe facultative et tous les catalogues ne l'utiliseront pas. Cette classe existe pour les catalogues	ayant une distinction entre les métadonnées sur le jeu de données et les métadonnées sur une entrée du jeu de données dans le catalogue.</skos:scopeNote>
@@ -364,6 +366,12 @@
     <rdfs:comment xml:lang="cs">Asociační třída pro připojení dodatečných informací ke vztahu mezi zdroji DCAT.</rdfs:comment>
     <rdfs:comment xml:lang="en">An association class for attaching additional information to a relationship between DCAT Resources.</rdfs:comment>
     <rdfs:label xml:lang="da">Relation</rdfs:label>
+    <skos:definition xml:lang="cs">Asociační třída pro připojení dodatečných informací ke vztahu mezi zdroji DCAT.</skos:definition>
+    <skos:changeNote xml:lang="en">New class added in DCAT 2.0.</skos:changeNote>
+    <skos:definition xml:lang="es">Una clase de asociación para adjuntar información adicional a una relación entre recursos DCAT.</skos:definition>
+    <skos:scopeNote xml:lang="cs">Používá se pro charakterizaci vztahu mezi datovými sadami a případně i jinými zdroji, kde druh vztahu je sice znám, ale není přiměřeně charakterizován standardními vlastnostmi slovníku Dublin Core (dcterms:hasPart, dcterms:isPartOf, dcterms:conformsTo, dcterms:isFormatOf, dcterms:hasFormat, dcterms:isVersionOf, dcterms:hasVersion, dcterms:replaces, dcterms:isReplacedBy, dcterms:references, dcterms:isReferencedBy, dcterms:requires, dcterms:isRequiredBy) či vlastnostmi slovníku PROV-O (prov:wasDerivedFrom, prov:wasInfluencedBy, prov:wasQuotedFrom, prov:wasRevisionOf, prov:hadPrimarySource, prov:alternateOf, prov:specializationOf).</skos:scopeNote>
+    <rdfs:label xml:lang="cs">Vztah</rdfs:label>
+    <skos:changeNote xml:lang="da">Ny klasse i DCAT 2.0.</skos:changeNote>
     <rdfs:subClassOf>
       <owl:Restriction>
         <owl:onProperty rdf:resource="http://purl.org/dc/terms/relation"/>
@@ -371,12 +379,6 @@
         >1</owl:minCardinality>
       </owl:Restriction>
     </rdfs:subClassOf>
-    <skos:definition xml:lang="cs">Asociační třída pro připojení dodatečných informací ke vztahu mezi zdroji DCAT.</skos:definition>
-    <skos:changeNote xml:lang="en">New class added in DCAT 2.0.</skos:changeNote>
-    <skos:definition xml:lang="es">Una clase de asociación para adjuntar información adicional a una relación entre recursos DCAT.</skos:definition>
-    <skos:scopeNote xml:lang="cs">Používá se pro charakterizaci vztahu mezi datovými sadami a případně i jinými zdroji, kde druh vztahu je sice znám, ale není přiměřeně charakterizován standardními vlastnostmi slovníku Dublin Core (dcterms:hasPart, dcterms:isPartOf, dcterms:conformsTo, dcterms:isFormatOf, dcterms:hasFormat, dcterms:isVersionOf, dcterms:hasVersion, dcterms:replaces, dcterms:isReplacedBy, dcterms:references, dcterms:isReferencedBy, dcterms:requires, dcterms:isRequiredBy) či vlastnostmi slovníku PROV-O (prov:wasDerivedFrom, prov:wasInfluencedBy, prov:wasQuotedFrom, prov:wasRevisionOf, prov:hadPrimarySource, prov:alternateOf, prov:specializationOf).</skos:scopeNote>
-    <rdfs:label xml:lang="cs">Vztah</rdfs:label>
-    <skos:changeNote xml:lang="da">Ny klasse i DCAT 2.0.</skos:changeNote>
     <skos:scopeNote xml:lang="it">Viene utilizzato per caratterizzare la relazione tra insiemi di dati, e potenzialmente altri tipi di risorse, nei casi in cui la natura della relazione è nota ma non adeguatamente caratterizzata dalle proprietà dello standard 'Dublin Core' (dcterms:hasPart, dcterms:isPartOf, dcterms:conformsTo, dcterms:isFormatOf, dcterms:hasFormat, dcterms:isVersionOf, dcterms:hasVersion, dcterms:replaces, dcterms:isReplacedBy, dcterms:references, dcterms:isReferencedBy, dcterms:require, dcterms:isRequiredBy) o dalle propietà fornite da PROV-O  (prov:wasDerivedFrom, prov:wasInfluencedBy, prov:wasQuotedFrom, prov:wasRevisionOf, prov: hadPrimarySource, prov:alternateOf, prov:specializationOf).</skos:scopeNote>
     <skos:scopeNote xml:lang="en">Use to characterize a relationship between datasets, and potentially other resources, where the nature of the relationship is known but is not adequately characterized by the standard Dublin Core properties (dcterms:hasPart, dcterms:isPartOf, dcterms:conformsTo, dcterms:isFormatOf, dcterms:hasFormat, dcterms:isVersionOf, dcterms:hasVersion, dcterms:replaces, dcterms:isReplacedBy, dcterms:references, dcterms:isReferencedBy, dcterms:requires, dcterms:isRequiredBy) or PROV-O properties (prov:wasDerivedFrom, prov:wasInfluencedBy, prov:wasQuotedFrom, prov:wasRevisionOf, prov:hadPrimarySource, prov:alternateOf, prov:specializationOf).</skos:scopeNote>
     <rdfs:comment xml:lang="da">En associationsklasse til brug for tilknytning af yderligere information til en relation mellem DCAT-ressourcer.</rdfs:comment>
@@ -451,16 +453,16 @@
     <rdfs:label xml:lang="en">Catalog</rdfs:label>
     <skos:scopeNote xml:lang="ja">通常、ウェブ・ベースのデータ・カタログは、このクラスの1つのインスタンスとして表わされます。</skos:scopeNote>
     <rdfs:label xml:lang="fr">Catalogue</rdfs:label>
-    <skos:definition xml:lang="ar">مجموعة من توصيفات قوائم البيانات</skos:definition>
-    <skos:scopeNote xml:lang="el">Συνήθως, ένας κατάλογος δεδομένων στον Παγκόσμιο Ιστό αναπαρίσταται ως ένα στιγμιότυπο αυτής της κλάσης.</skos:scopeNote>
-    <rdfs:comment xml:lang="el">Μια επιμελημένη συλλογή μεταδεδομένων περί συνόλων δεδομένων</rdfs:comment>
-    <rdfs:comment xml:lang="en">A curated collection of metadata about resources (e.g., datasets and data services in the context of a data catalog).</rdfs:comment>
     <rdfs:subClassOf>
       <owl:Restriction>
         <owl:onProperty rdf:resource="http://purl.org/dc/terms/hasPart"/>
         <owl:allValuesFrom rdf:resource="http://www.w3.org/ns/dcat#Resource"/>
       </owl:Restriction>
     </rdfs:subClassOf>
+    <skos:definition xml:lang="ar">مجموعة من توصيفات قوائم البيانات</skos:definition>
+    <skos:scopeNote xml:lang="el">Συνήθως, ένας κατάλογος δεδομένων στον Παγκόσμιο Ιστό αναπαρίσταται ως ένα στιγμιότυπο αυτής της κλάσης.</skos:scopeNote>
+    <rdfs:comment xml:lang="el">Μια επιμελημένη συλλογή μεταδεδομένων περί συνόλων δεδομένων</rdfs:comment>
+    <rdfs:comment xml:lang="en">A curated collection of metadata about resources (e.g., datasets and data services in the context of a data catalog).</rdfs:comment>
     <rdfs:comment xml:lang="ar">مجموعة من توصيفات قوائم البيانات</rdfs:comment>
     <rdfs:comment xml:lang="cs">Řízená kolekce metadat o datových sadách a datových službách</rdfs:comment>
   </owl:Class>
@@ -888,6 +890,14 @@
     <rdfs:label xml:lang="it">tiene rol</rdfs:label>
     <skos:editorialNote xml:lang="cs">Přidáno do DCAT pro doplnění vlastnosti prov:hadRole (jejíž užití je omezeno na role v kontextu aktivity, s definičním oborem prov:Association).</skos:editorialNote>
     <skos:changeNote xml:lang="en">New property added in DCAT 2.0.</skos:changeNote>
+    <rdfs:domain>
+      <owl:Class>
+        <owl:unionOf rdf:parseType="Collection">
+          <rdf:Description rdf:about="http://www.w3.org/ns/prov#Attribution"/>
+          <owl:Class rdf:about="http://www.w3.org/ns/dcat#Relationship"/>
+        </owl:unionOf>
+      </owl:Class>
+    </rdfs:domain>
     <skos:definition xml:lang="da">Den funktion en entitet eller aktør har i forhold til en anden ressource.</skos:definition>
     <skos:editorialNote xml:lang="da">Introduceret i DCAT for at supplere prov:hadRole (hvis anvendelse er begrænset til roller i forbindelse med en aktivitet med domænet prov:Association).</skos:editorialNote>
     <rdfs:comment xml:lang="it">La funzione di un'entità o un agente rispetto ad un'altra entità o risorsa.</rdfs:comment>
@@ -900,14 +910,6 @@
     <skos:changeNote xml:lang="it">Nuova proprietà aggiunta in DCAT 2.0.</skos:changeNote>
     <skos:changeNote xml:lang="es">Nueva propiedad agregada en DCAT 2.0.</skos:changeNote>
     <rdfs:label xml:lang="en">hadRole</rdfs:label>
-    <rdfs:domain>
-      <owl:Class>
-        <owl:unionOf rdf:parseType="Collection">
-          <rdf:Description rdf:about="http://www.w3.org/ns/prov#Attribution"/>
-          <owl:Class rdf:about="http://www.w3.org/ns/dcat#Relationship"/>
-        </owl:unionOf>
-      </owl:Class>
-    </rdfs:domain>
     <skos:definition xml:lang="es">La función de una entidad o agente con respecto a otra entidad o recurso.</skos:definition>
     <skos:definition xml:lang="cs">Funkce entity či agenta ve vztahu k jiné entitě či zdroji.</skos:definition>
     <skos:scopeNote xml:lang="en">May be used in a qualified-relation to specify the role of an Entity with respect to another Entity.  It is recommended that the value be taken from a controlled vocabulary of entity roles such as: ISO 19115 DS_AssociationTypeCode http://registry.it.csiro.au/def/isotc211/DS_AssociationTypeCode; IANA Registry of Link Relations https://www.iana.org/assignments/link-relation; DataCite metadata schema; MARC relators https://id.loc.gov/vocabulary/relators.</skos:scopeNote>
@@ -1042,7 +1044,6 @@
     <skos:definition xml:lang="es">Una palabra clave o etiqueta que describe un recurso.</skos:definition>
     <skos:definition xml:lang="da">Et nøgleord eller tag til beskrivelse af en ressource.</skos:definition>
     <rdfs:label xml:lang="it">parola chiave</rdfs:label>
-    <rdfs:subPropertyOf rdf:resource="http://purl.org/dc/terms/subject"/>
     <rdfs:label xml:lang="cs">klíčové slovo</rdfs:label>
     <rdfs:comment xml:lang="ja">データセットを記述しているキーワードまたはタグ。</rdfs:comment>
     <rdfs:comment xml:lang="ar">كلمة  مفتاحيه توصف قائمة البيانات</rdfs:comment>
@@ -1169,10 +1170,6 @@
     <skos:scopeNote xml:lang="es">El rango es una URL. Si la distribución es accesible solamente través de una página de destino (es decir, si no se conoce una URL de descarga directa), entonces el enlance a la página de destino debe ser duplicado como accessURL en la distribución.</skos:scopeNote>
     <rdfs:label xml:lang="ja">アクセスURL</rdfs:label>
     <rdfs:comment xml:lang="cs">URL zdroje, přes které je přístupná distribuce datové sady. Příkladem může být vstupní stránka, RSS kanál či SPARQL endpoint. Použijte ve všech případech kromě URL souboru ke stažení, pro které je lepší použít dcat:downloadURL.</rdfs:comment>
-    <owl:propertyChainAxiom rdf:parseType="Collection">
-      <owl:ObjectProperty rdf:about="http://www.w3.org/ns/dcat#accessService"/>
-      <owl:ObjectProperty rdf:about="http://www.w3.org/ns/dcat#endpointURL"/>
-    </owl:propertyChainAxiom>
     <rdfs:comment xml:lang="el">Μπορεί να είναι οποιουδήποτε είδους URL που δίνει πρόσβαση στη διανομή ενός συνόλου δεδομένων. Π.χ. ιστοσελίδα αρχικής πρόσβασης, μεταφόρτωση, feed URL, σημείο διάθεσης SPARQL. Να χρησιμοποιείται όταν ο κατάλογος δεν περιέχει πληροφορίες εαν πρόκειται ή όχι για μεταφορτώσιμο αρχείο.</rdfs:comment>
     <rdfs:comment xml:lang="it">Un URL di una risorsa che consente di accedere a una distribuzione del set di dati. Per esempio, pagina di destinazione, feed, endpoint SPARQL. Da utilizzare per tutti i casi, tranne  quando  si tratta di un semplice link per il download nel qual caso è preferito downloadURL.</rdfs:comment>
     <skos:scopeNote xml:lang="el">Η τιμή είναι ένα URL. Αν η/οι διανομή/ές είναι προσβάσιμη/ες μόνο μέσω μίας ιστοσελίδας αρχικής πρόσβασης (δηλαδή αν δεν υπάρχουν γνωστές διευθύνσεις άμεσης μεταφόρτωσης), τότε ο σύνδεσμος της ιστοσελίδας αρχικής πρόσβασης πρέπει να αναπαραχθεί ως accessURL σε μία διανομή.</skos:scopeNote>
@@ -1190,6 +1187,10 @@
     <rdfs:label xml:lang="ar">رابط وصول</rdfs:label>
     <rdfs:label xml:lang="es">URL de acceso</rdfs:label>
     <skos:scopeNote xml:lang="ja">確実にダウンロードでない場合や、ダウンロードかどうかが不明である場合は、downloadURLではなく、accessURLを用いてください。ランディング・ページを通じてしか配信にアクセスできない場合（つまり、直接的なダウンロードURLが不明）は、配信におけるaccessURLとしてランディング・ページのリンクをコピーすべきです（SHOULD）。</skos:scopeNote>
+    <owl:propertyChainAxiom rdf:parseType="Collection">
+      <owl:ObjectProperty rdf:about="http://www.w3.org/ns/dcat#accessService"/>
+      <owl:ObjectProperty rdf:about="http://www.w3.org/ns/dcat#endpointURL"/>
+    </owl:propertyChainAxiom>
     <rdfs:label xml:lang="it">indirizzo di accesso</rdfs:label>
     <rdfs:comment xml:lang="ar">أي رابط يتيح الوصول إلى البيانات. إذا كان الرابط هو ربط مباشر لملف يمكن تحميله استخدم الخاصية downloadURL</rdfs:comment>
     <skos:definition xml:lang="cs">URL zdroje, přes které je přístupná distribuce datové sady. Příkladem může být vstupní stránka, RSS kanál či SPARQL endpoint. Použijte ve všech případech kromě URL souboru ke stažení, pro které je lepší použít dcat:downloadURL.</skos:definition>

--- a/dcat/rdf/dcat3.ttl
+++ b/dcat/rdf/dcat3.ttl
@@ -122,6 +122,7 @@
   dcterms:modified "2020-11-30"^^xsd:date ;
   dcterms:modified "2021-03-09"^^xsd:date ;
   dcterms:modified "2021-04-08"^^xsd:date ;
+  dcterms:modified "2021-06-23"^^xsd:date ;
   rdfs:comment "DCAT es un vocabulario RDF diseñado para facilitar la interoperabilidad entre catálogos de datos publicados en la Web. Utilizando DCAT para describir datos disponibles en catálogos se aumenta la posibilidad de que sean descubiertos y se permite que las aplicaciones consuman fácilmente los metadatos de varios catálogos."@es ;
   rdfs:comment "DCAT est un vocabulaire développé pour faciliter l'interopérabilité entre les jeux de données publiées sur le Web. En utilisant DCAT pour décrire les jeux de données dans les catalogues de données, les fournisseurs de données augmentent leur découverte et permettent que les applications facilement les métadonnées de plusieurs catalogues. Il permet en plus la publication décentralisée des catalogues et facilitent la recherche fédérée des données entre plusieurs sites. Les métadonnées DCAT aggrégées peuvent servir comme un manifeste pour faciliter la préservation digitale des ressources. DCAT est définie à l'adresse http://www.w3.org/TR/vocab-dcat/. Une quelconque version de ce document normatif et ce vocabulaire est une erreur dans ce vocabulaire."@fr ;
   rdfs:comment "DCAT is an RDF vocabulary designed to facilitate interoperability between data catalogs published on the Web. By using DCAT to describe datasets in data catalogs, publishers increase discoverability and enable applications easily to consume metadata from multiple catalogs. It further enables decentralized publishing of catalogs and facilitates federated dataset search across sites. Aggregated DCAT metadata can serve as a manifest file to facilitate digital preservation. DCAT is defined at http://www.w3.org/TR/vocab-dcat/. Any variance between that normative document and this schema is an error in this schema."@en ;
@@ -1032,7 +1033,6 @@ dcat:keyword
   rdfs:label "キーワード/タグ"@ja ;
   rdfs:label "nøgleord"@da ;
   rdfs:range rdfs:Literal ;
-  rdfs:subPropertyOf dcterms:subject ;
   skos:definition "A keyword or tag describing a resource."@en ;
   skos:definition "Klíčové slovo nebo značka popisující zdroj."@cs ;
   skos:definition "Un mot-clé ou étiquette décrivant une ressource."@fr ;


### PR DESCRIPTION

This PR aligns the HTML and  RDFS removing 'dcat:keyword` sub-property of `dcterms:subject` in all the RDF files.

Assuming the group does not find an agreement on having `dcat:keyword` sub-property of `dcterms:subject` - see issues #1374 and #175 -  we need to align HTML and RDF in the current version:  the HTML does not include the sub-property between `dcat:keyword` and `dcterms:subject`, while the RDFs do.

This PR is alternative to  PR #1384 .