### PR TITLE
Fixing wrong issue links in Document History

### DIFF
--- a/dcat/index.html
+++ b/dcat/index.html
@@ -6463,8 +6463,8 @@ ga-courts:jc-wms
 
 <ul>
     <li><p><a href="#basic-example"></a> has been updated to tell a more coherent story (see  issue <a href="https://github.com/w3c/dxwg/issues/1155">#1155</a>) and express temporal coverage by using <a href="#Class:Period_of_Time"><code>dcterms:PeriodOfTime</code></a>, <a href="#Property:period_start_date"><code>dcat:startDate</code></a>, and <a href="#Property:period_end_date"><code>dcat:endDate</code></a>.</p></li> 
-<li>The usage notes of properties <a href="#Property:location_bbox"><code title="http://www.w3.org/ns/dcat#bbox">dcat:bbox</code></a> and <a href="#Property:location_centroid"><code title="http://www.w3.org/ns/dcat#centroid">dcat:centroid</code></a> have been revised to make it clearer that they are supposed to be used only with geometry literals - see Issue <a href="https://github.com/w3c/dxwg/issues/1359">#1364</a>.</li>
-<li>The property <a href="#Property:resource_theme"><code title="http://www.w3.org/ns/dcat#theme">dcat:theme</code></a>  have been explicitly defined as an OWL object property and its range is dropped, see Issue <a href="https://github.com/w3c/dxwg/issues/1359">#1359</a>.</li>
+<li>The usage notes of properties <a href="#Property:location_bbox"><code title="http://www.w3.org/ns/dcat#bbox">dcat:bbox</code></a> and <a href="#Property:location_centroid"><code title="http://www.w3.org/ns/dcat#centroid">dcat:centroid</code></a> have been revised to make it clearer that they are supposed to be used only with geometry literals - see Issue <a href="https://github.com/w3c/dxwg/issues/1359">#1359</a>.</li>
+<li>The property <a href="#Property:resource_theme"><code title="http://www.w3.org/ns/dcat#theme">dcat:theme</code></a>  have been explicitly defined as an OWL object property and its range is dropped, see Issue <a href="https://github.com/w3c/dxwg/issues/1364">#1364</a>.</li>
    
 </ul>
 


### PR DESCRIPTION
Just fixing two minor wrong links in the DCAT document history.