### PR TITLE
PR for fixing #1394 

### DIFF
--- a/dcat/rdf/dcat2.jsonld
+++ b/dcat/rdf/dcat2.jsonld
@@ -1,137 +1,127 @@
 {
   "@graph" : [ {
     "@id" : "_:b0",
-    "@type" : "owl:Restriction",
-    "allValuesFrom" : "dcat:Resource",
-    "onProperty" : "foaf:primaryTopic"
+    "homepage" : "http://stfc.ac.uk",
+    "foaf:name" : "Science and Technology Facilities Council, UK"
   }, {
-    "@id" : "_:b1",
-    "foaf:name" : "John Erickson"
-  }, {
-    "@id" : "_:b10",
-    "seeAlso" : "http://fadmaa.me/foaf.ttl",
-    "foaf:name" : "Fadi Maali"
-  }, {
-    "@id" : "_:b12",
-    "foaf:name" : "Marios Meimaris"
-  }, {
-    "@id" : "_:b13",
-    "homepage" : "https://csiro.au",
-    "foaf:name" : "Commonwealth Scientific and Industrial Research Organisation"
-  }, {
-    "@id" : "_:b14",
-    "affiliation" : "_:b15",
-    "foaf:name" : "David Browning"
-  }, {
-    "@id" : "_:b15",
-    "homepage" : "http://www.refinitiv.com",
-    "foaf:name" : "Refinitiv"
-  }, {
-    "@id" : "_:b18",
+    "@id" : "_:b11",
     "homepage" : "http://www.asahi-net.or.jp/~ax2s-kmtn/",
     "foaf:name" : "Shuji Kamitsuna"
   }, {
-    "@id" : "_:b19",
-    "homepage" : "http://www.w3.org/2011/gld/",
-    "foaf:name" : "Government Linked Data WG"
+    "@id" : "_:b12",
+    "seeAlso" : "http://fadmaa.me/foaf.ttl",
+    "foaf:name" : "Fadi Maali"
   }, {
-    "@id" : "_:b2",
-    "affiliation" : "_:b3",
-    "foaf:name" : "Vassilios Peristeras"
+    "@id" : "_:b13",
+    "foaf:name" : "Marios Meimaris"
   }, {
-    "@id" : "_:b20",
-    "@type" : "foaf:Person",
-    "affiliation" : "_:b13",
-    "seeAlso" : "https://orcid.org/0000-0002-3884-3420",
-    "foaf:name" : "Simon J D Cox",
-    "workInfoHomepage" : "http://people.csiro.au/Simon-Cox"
+    "@id" : "_:b14",
+    "seeAlso" : "http://www.eurecom.fr/~atemezin/gatemezing-foaf.rdf",
+    "foaf:name" : "Ghislain Auguste Atemezing"
   }, {
-    "@id" : "_:b21",
+    "@id" : "_:b15",
+    "seeAlso" : "http://makxdekkers.com/makxdekkers.rdf#me",
+    "homepage" : "http://makxdekkers.com/",
+    "foaf:name" : "Makx Dekkers"
+  }, {
+    "@id" : "_:b16",
     "foaf:name" : "Richard Cyganiak"
   }, {
-    "@id" : "_:b22",
-    "foaf:name" : "Martin Alvarez-Espinar"
+    "@id" : "_:b17",
+    "homepage" : "http://okfn.org",
+    "foaf:name" : "Open Knowledge Foundation"
   }, {
-    "@id" : "_:b23",
+    "@id" : "_:b18",
+    "affiliation" : "_:b17",
+    "foaf:name" : "Rufus Pollock"
+  }, {
+    "@id" : "_:b19",
+    "foaf:name" : "John Erickson"
+  }, {
+    "@id" : "_:b2",
+    "seeAlso" : "https://orcid.org/0000-0001-5648-2713",
+    "homepage" : [ "https://w3id.org/people/ralbertoni/", "http://www.imati.cnr.it/index.php/people/8-curricula/178-riccardo-albertoni" ],
+    "foaf:name" : "Riccardo Albertoni"
+  }, {
+    "@id" : "_:b20",
+    "foaf:name" : "Boris Villazón-Terrazas"
+  }, {
+    "@id" : "_:b21",
     "affiliation" : "http://www.w3.org/data#W3C",
     "seeAlso" : "http://philarcher.org/foaf.rdf#me",
     "homepage" : "http://www.w3.org/People/all#phila",
     "foaf:name" : "Phil Archer"
   }, {
-    "@id" : "_:b24",
-    "affiliation" : "_:b32",
-    "foaf:name" : "Rufus Pollock"
-  }, {
-    "@id" : "_:b25",
-    "seeAlso" : "https://orcid.org/0000-0001-9300-2694",
-    "homepage" : "http://www.andrea-perego.name/foaf/#me",
-    "foaf:name" : "Andrea Perego"
-  }, {
-    "@id" : "_:b26",
+    "@id" : "_:b22",
     "seeAlso" : "https://jakub.klímek.com/#me",
     "homepage" : "https://jakub.klímek.com/",
     "foaf:name" : "Jakub Klímek"
   }, {
-    "@id" : "_:b27",
-    "seeAlso" : "http://www.eurecom.fr/~atemezin/gatemezing-foaf.rdf",
-    "foaf:name" : "Ghislain Auguste Atemezing"
+    "@id" : "_:b23",
+    "homepage" : "http://www.w3.org/2011/gld/",
+    "foaf:name" : "Government Linked Data WG"
   }, {
-    "@id" : "_:b28",
-    "seeAlso" : "http://makxdekkers.com/makxdekkers.rdf#me",
-    "homepage" : "http://makxdekkers.com/",
-    "foaf:name" : "Makx Dekkers"
-  }, {
-    "@id" : "_:b29",
-    "foaf:name" : "Boris Villazón-Terrazas"
-  }, {
-    "@id" : "_:b3",
-    "homepage" : "http://ec.europa.eu/dgs/informatics/",
-    "foaf:name" : "European Commission, DG DIGIT"
-  }, {
-    "@id" : "_:b30",
-    "@type" : "owl:Restriction",
-    "cardinality" : "1",
-    "onProperty" : "foaf:primaryTopic"
-  }, {
-    "@id" : "_:b32",
-    "homepage" : "http://okfn.org",
-    "foaf:name" : "Open Knowledge Foundation"
-  }, {
-    "@id" : "_:b4",
-    "affiliation" : "_:b5",
+    "@id" : "_:b24",
+    "affiliation" : "_:b0",
     "seeAlso" : "https://orcid.org/0000-0003-3499-8262",
     "homepage" : "https://agbeltran.github.io",
     "foaf:name" : "Alejandra Gonzalez-Beltran"
   }, {
+    "@id" : "_:b25",
+    "affiliation" : "_:b4",
+    "foaf:name" : "Vassilios Peristeras"
+  }, {
+    "@id" : "_:b26",
+    "affiliation" : "_:b29",
+    "foaf:name" : "David Browning"
+  }, {
+    "@id" : "_:b28",
+    "@type" : "owl:Restriction",
+    "cardinality" : "1",
+    "onProperty" : "foaf:primaryTopic"
+  }, {
+    "@id" : "_:b29",
+    "homepage" : "http://www.refinitiv.com",
+    "foaf:name" : "Refinitiv"
+  }, {
+    "@id" : "_:b3",
+    "foaf:name" : "Martin Alvarez-Espinar"
+  }, {
+    "@id" : "_:b30",
+    "@type" : "owl:Restriction",
+    "allValuesFrom" : "dcat:Resource",
+    "onProperty" : "foaf:primaryTopic"
+  }, {
+    "@id" : "_:b4",
+    "homepage" : "http://ec.europa.eu/dgs/informatics/",
+    "foaf:name" : "European Commission, DG DIGIT"
+  }, {
     "@id" : "_:b5",
-    "homepage" : "http://stfc.ac.uk",
-    "foaf:name" : "Science and Technology Facilities Council, UK"
+    "@type" : "foaf:Person",
+    "affiliation" : "_:b6",
+    "seeAlso" : "https://orcid.org/0000-0002-3884-3420",
+    "foaf:name" : "Simon J D Cox",
+    "workInfoHomepage" : "http://people.csiro.au/Simon-Cox"
   }, {
     "@id" : "_:b6",
+    "homepage" : "https://csiro.au",
+    "foaf:name" : "Commonwealth Scientific and Industrial Research Organisation"
+  }, {
+    "@id" : "_:b7",
+    "seeAlso" : "https://orcid.org/0000-0001-9300-2694",
+    "homepage" : "http://www.andrea-perego.name/foaf/#me",
+    "foaf:name" : "Andrea Perego"
+  }, {
+    "@id" : "_:b8",
     "@type" : "owl:Class",
     "unionOf" : {
       "@list" : [ "prov:Attribution", "dcat:Relationship" ]
     }
   }, {
-    "@id" : "_:b7",
-    "@type" : "owl:Restriction",
-    "minCardinality" : "1",
-    "onProperty" : "dct:relation"
-  }, {
-    "@id" : "_:b8",
-    "@type" : "owl:Restriction",
-    "maxCardinality" : "1",
-    "onProperty" : "dcat:endpointURL"
-  }, {
-    "@id" : "_:b9",
-    "seeAlso" : "https://orcid.org/0000-0001-5648-2713",
-    "homepage" : [ "https://w3id.org/people/ralbertoni/", "http://www.imati.cnr.it/index.php/people/8-curricula/178-riccardo-albertoni" ],
-    "foaf:name" : "Riccardo Albertoni"
-  }, {
     "@id" : "http://www.w3.org/ns/dcat",
     "@type" : "owl:Ontology",
-    "contributor" : [ "_:b23", "_:b12", "_:b21", "_:b24", "_:b25", "_:b2", "_:b14", "_:b4", "_:b18", "_:b26", "_:b9", "_:b27", "_:b20", "_:b28", "_:b29", "_:b22" ],
-    "creator" : [ "_:b1", "_:b10" ],
+    "contributor" : [ "_:b11", "_:b13", "_:b7", "_:b5", "_:b3", "_:b20", "_:b18", "_:b21", "_:b22", "_:b2", "_:b14", "_:b24", "_:b25", "_:b15", "_:b26", "_:b16" ],
+    "creator" : [ "_:b19", "_:b12" ],
     "license" : "https://creativecommons.org/licenses/by/4.0/",
     "modified" : [ "2020-11-30", "2012-04-24", "2017-12-19", "2013-09-20", "2013-11-28", "2021-09-14" ],
     "dct:modified" : "2019",
@@ -212,7 +202,7 @@
       "@language" : "en",
       "@value" : "English language definitions updated in this revision in line with ED. Multilingual text unevenly updated."
     },
-    "maker" : "_:b19"
+    "maker" : "_:b23"
   }, {
     "@id" : "dcat:Catalog",
     "@type" : [ "rdfs:Class", "owl:Class" ],
@@ -385,7 +375,7 @@
       "@language" : "fr",
       "@value" : "Registre du catalogue"
     } ],
-    "subClassOf" : [ "_:b30", "_:b0" ],
+    "subClassOf" : [ "_:b28", "_:b30" ],
     "skos:definition" : [ {
       "@language" : "it",
       "@value" : "Un record in un catalogo di dati che descrive un singolo dataset o servizio di dati."
@@ -416,6 +406,9 @@
       "@value" : "English definition updated in this revision. Multilingual text not yet updated except the Spanish one and the Czech one and Italian one."
     },
     "skos:scopeNote" : [ {
+      "@language" : "ja",
+      "@value" : "このクラスはオプションで、すべてのカタログがそれを用いるとは限りません。これは、データセットに関するメタデータとカタログ内のデータセットのエントリーに関するメタデータとで区別が行われるカタログのために存在しています。例えば、データセットの公開日プロパティーは、公開機関が情報を最初に利用可能とした日付を示しますが、カタログ・レコードの公開日は、データセットがカタログに追加された日付です。両方の日付が異っていたり、後者だけが分かっている場合は、カタログ・レコードに対してのみ公開日を指定すべきです。W3CのPROVオントロジー[prov-o]を用いれば、データセットに対する特定の変更に関連するプロセスやエージェントの詳細などの、さらに詳しい来歴情報の記述が可能となることに注意してください。"
+    }, {
       "@language" : "it",
       "@value" : "Questa classe è opzionale e non tutti i cataloghi la utilizzeranno. Esiste per cataloghi in cui si opera una distinzione tra i metadati relativi al dataset ed i metadati relativi alla gestione del dataset nel catalogo. Ad esempio, la  proprietà per indicare la data di pubblicazione del dataset rifletterà la data in cui l'informazione è stata originariamente messa a disposizione dalla casa editrice, mentre la data di pubblicazione per il record nel catalogo rifletterà la data in cui il dataset è stato aggiunto al catalogo. Nei casi dove solo quest'ultima sia nota, si utilizzerà esclusivamente la data di  pubblicazione relativa al record del catalogo. Si noti che l'Ontologia W3C PROV permette di descrivere ulteriori informazioni sulla provenienza, quali i dettagli del processo, la procedura e l'agente coinvolto in una particolare modifica di un dataset."
     }, {
@@ -433,9 +426,6 @@
     }, {
       "@language" : "da",
       "@value" : "Denne klasse er valgfri og ikke alle kataloger vil anvende denne klasse. Den kan anvendes i de kataloger hvor der skelnes mellem metadata om datasættet eller datatjenesten og metadata om selve posten til registreringen af datasættet eller datatjenesten i kataloget. Udgivelsesdatoen for datasættet afspejler for eksempel den dato hvor informationerne oprindeligt blev gjort tilgængelige af udgiveren, hvorimod udgivelsesdatoen for katalogposten er den dato hvor datasættet blev føjet til kataloget. I de tilfælde hvor de to datoer er forskellige eller hvor blot sidstnævnte er kendt, bør udgivelsesdatoen kun angives for katalogposten. Bemærk at W3Cs PROV ontologi gør til muligt at tilføje yderligere proveniensoplysninger eksempelvis om processen eller aktøren involveret i en given ændring af datasættet."
-    }, {
-      "@language" : "ja",
-      "@value" : "このクラスはオプションで、すべてのカタログがそれを用いるとは限りません。これは、データセットに関するメタデータとカタログ内のデータセットのエントリーに関するメタデータとで区別が行われるカタログのために存在しています。例えば、データセットの公開日プロパティーは、公開機関が情報を最初に利用可能とした日付を示しますが、カタログ・レコードの公開日は、データセットがカタログに追加された日付です。両方の日付が異っていたり、後者だけが分かっている場合は、カタログ・レコードに対してのみ公開日を指定すべきです。W3CのPROVオントロジー[prov-o]を用いれば、データセットに対する特定の変更に関連するプロセスやエージェントの詳細などの、さらに詳しい来歴情報の記述が可能となることに注意してください。"
     }, {
       "@language" : "fr",
       "@value" : "C'est une classe facultative et tous les catalogues ne l'utiliseront pas. Cette classe existe pour les catalogues\tayant une distinction entre les métadonnées sur le jeu de données et les métadonnées sur une entrée du jeu de données dans le catalogue."
@@ -472,7 +462,7 @@
       "@language" : "da",
       "@value" : "Datatjeneste"
     } ],
-    "subClassOf" : [ "_:b8", "dctype:Service", "dcat:Resource" ],
+    "subClassOf" : [ "dctype:Service", "dcat:Resource" ],
     "skos:altLabel" : {
       "@language" : "da",
       "@value" : "Dataservice"
@@ -851,7 +841,6 @@
       "@language" : "en",
       "@value" : "Relationship"
     } ],
-    "subClassOf" : "_:b7",
     "skos:changeNote" : [ {
       "@language" : "it",
       "@value" : "Nuova classe aggiunta in DCAT 2.0."
@@ -2399,7 +2388,7 @@
       "@language" : "en",
       "@value" : "The function of an entity or agent with respect to another entity or resource."
     } ],
-    "domain" : "_:b6",
+    "domain" : "_:b8",
     "rdfs:label" : [ {
       "@language" : "it",
       "@value" : "tiene rol"
@@ -3826,52 +3815,12 @@
       "@id" : "http://www.w3.org/2000/01/rdf-schema#range",
       "@type" : "@id"
     },
-    "onProperty" : {
-      "@id" : "http://www.w3.org/2002/07/owl#onProperty",
-      "@type" : "@id"
-    },
-    "allValuesFrom" : {
-      "@id" : "http://www.w3.org/2002/07/owl#allValuesFrom",
-      "@type" : "@id"
-    },
-    "editorialNote" : {
-      "@id" : "http://www.w3.org/2004/02/skos/core#editorialNote",
-      "@type" : "http://www.w3.org/1999/02/22-rdf-syntax-ns#langString"
-    },
-    "altLabel" : {
-      "@id" : "http://www.w3.org/2004/02/skos/core#altLabel",
-      "@type" : "http://www.w3.org/1999/02/22-rdf-syntax-ns#langString"
-    },
     "name" : {
       "@id" : "http://xmlns.com/foaf/0.1/name",
       "@type" : "http://www.w3.org/2001/XMLSchema#string"
     },
-    "affiliation" : {
-      "@id" : "http://schema.org/affiliation",
-      "@type" : "@id"
-    },
     "homepage" : {
       "@id" : "http://xmlns.com/foaf/0.1/homepage",
-      "@type" : "@id"
-    },
-    "seeAlso" : {
-      "@id" : "http://www.w3.org/2000/01/rdf-schema#seeAlso",
-      "@type" : "@id"
-    },
-    "minCardinality" : {
-      "@id" : "http://www.w3.org/2002/07/owl#minCardinality",
-      "@type" : "http://www.w3.org/2001/XMLSchema#nonNegativeInteger"
-    },
-    "maxCardinality" : {
-      "@id" : "http://www.w3.org/2002/07/owl#maxCardinality",
-      "@type" : "http://www.w3.org/2001/XMLSchema#nonNegativeInteger"
-    },
-    "unionOf" : {
-      "@id" : "http://www.w3.org/2002/07/owl#unionOf",
-      "@type" : "@id"
-    },
-    "rangeIncludes" : {
-      "@id" : "http://schema.org/rangeIncludes",
       "@type" : "@id"
     },
     "rest" : {
@@ -3882,17 +3831,45 @@
       "@id" : "http://www.w3.org/1999/02/22-rdf-syntax-ns#first",
       "@type" : "@id"
     },
+    "seeAlso" : {
+      "@id" : "http://www.w3.org/2000/01/rdf-schema#seeAlso",
+      "@type" : "@id"
+    },
+    "editorialNote" : {
+      "@id" : "http://www.w3.org/2004/02/skos/core#editorialNote",
+      "@type" : "http://www.w3.org/1999/02/22-rdf-syntax-ns#langString"
+    },
+    "altLabel" : {
+      "@id" : "http://www.w3.org/2004/02/skos/core#altLabel",
+      "@type" : "http://www.w3.org/1999/02/22-rdf-syntax-ns#langString"
+    },
     "workInfoHomepage" : {
       "@id" : "http://xmlns.com/foaf/0.1/workInfoHomepage",
       "@type" : "@id"
     },
-    "contributor" : {
-      "@id" : "http://purl.org/dc/terms/contributor",
+    "affiliation" : {
+      "@id" : "http://schema.org/affiliation",
+      "@type" : "@id"
+    },
+    "rangeIncludes" : {
+      "@id" : "http://schema.org/rangeIncludes",
+      "@type" : "@id"
+    },
+    "unionOf" : {
+      "@id" : "http://www.w3.org/2002/07/owl#unionOf",
+      "@type" : "@id"
+    },
+    "creator" : {
+      "@id" : "http://purl.org/dc/terms/creator",
       "@type" : "@id"
     },
     "versionInfo" : {
       "@id" : "http://www.w3.org/2002/07/owl#versionInfo",
       "@type" : "http://www.w3.org/1999/02/22-rdf-syntax-ns#langString"
+    },
+    "contributor" : {
+      "@id" : "http://purl.org/dc/terms/contributor",
+      "@type" : "@id"
     },
     "modified" : {
       "@id" : "http://purl.org/dc/terms/modified",
@@ -3900,10 +3877,6 @@
     },
     "imports" : {
       "@id" : "http://www.w3.org/2002/07/owl#imports",
-      "@type" : "@id"
-    },
-    "creator" : {
-      "@id" : "http://purl.org/dc/terms/creator",
       "@type" : "@id"
     },
     "license" : {
@@ -3922,9 +3895,17 @@
       "@id" : "http://www.w3.org/2002/07/owl#propertyChainAxiom",
       "@type" : "@id"
     },
+    "onProperty" : {
+      "@id" : "http://www.w3.org/2002/07/owl#onProperty",
+      "@type" : "@id"
+    },
     "cardinality" : {
       "@id" : "http://www.w3.org/2002/07/owl#cardinality",
       "@type" : "http://www.w3.org/2001/XMLSchema#nonNegativeInteger"
+    },
+    "allValuesFrom" : {
+      "@id" : "http://www.w3.org/2002/07/owl#allValuesFrom",
+      "@type" : "@id"
     },
     "dct" : "http://purl.org/dc/terms/",
     "owl" : "http://www.w3.org/2002/07/owl#",

--- a/dcat/rdf/dcat2.jsonld
+++ b/dcat/rdf/dcat2.jsonld
@@ -3,142 +3,137 @@
     "@id" : "_:b0",
     "@type" : "owl:Restriction",
     "allValuesFrom" : "dcat:Resource",
-    "onProperty" : "dct:hasPart"
+    "onProperty" : "foaf:primaryTopic"
+  }, {
+    "@id" : "_:b1",
+    "foaf:name" : "John Erickson"
   }, {
     "@id" : "_:b10",
-    "homepage" : "http://www.refinitiv.com",
-    "foaf:name" : "Refinitiv"
-  }, {
-    "@id" : "_:b11",
-    "seeAlso" : "http://makxdekkers.com/makxdekkers.rdf#me",
-    "homepage" : "http://makxdekkers.com/",
-    "foaf:name" : "Makx Dekkers"
-  }, {
-    "@id" : "_:b12",
-    "foaf:name" : "Richard Cyganiak"
-  }, {
-    "@id" : "_:b13",
-    "homepage" : "http://www.asahi-net.or.jp/~ax2s-kmtn/",
-    "foaf:name" : "Shuji Kamitsuna"
-  }, {
-    "@id" : "_:b14",
-    "foaf:name" : "Boris Villazón-Terrazas"
-  }, {
-    "@id" : "_:b15",
-    "seeAlso" : "https://jakub.klímek.com/#me",
-    "homepage" : "https://jakub.klímek.com/",
-    "foaf:name" : "Jakub Klímek"
-  }, {
-    "@id" : "_:b16",
     "seeAlso" : "http://fadmaa.me/foaf.ttl",
     "foaf:name" : "Fadi Maali"
   }, {
-    "@id" : "_:b17",
+    "@id" : "_:b12",
     "foaf:name" : "Marios Meimaris"
   }, {
-    "@id" : "_:b18",
-    "@type" : "owl:Restriction",
-    "maxCardinality" : "1",
-    "onProperty" : "dcat:endpointURL"
+    "@id" : "_:b13",
+    "homepage" : "https://csiro.au",
+    "foaf:name" : "Commonwealth Scientific and Industrial Research Organisation"
   }, {
-    "@id" : "_:b19",
-    "homepage" : "http://ec.europa.eu/dgs/informatics/",
-    "foaf:name" : "European Commission, DG DIGIT"
-  }, {
-    "@id" : "_:b20",
-    "foaf:name" : "John Erickson"
-  }, {
-    "@id" : "_:b21",
-    "affiliation" : "_:b29",
-    "foaf:name" : "Rufus Pollock"
-  }, {
-    "@id" : "_:b22",
-    "affiliation" : "_:b10",
+    "@id" : "_:b14",
+    "affiliation" : "_:b15",
     "foaf:name" : "David Browning"
   }, {
-    "@id" : "_:b23",
-    "affiliation" : "_:b19",
-    "foaf:name" : "Vassilios Peristeras"
+    "@id" : "_:b15",
+    "homepage" : "http://www.refinitiv.com",
+    "foaf:name" : "Refinitiv"
   }, {
-    "@id" : "_:b24",
+    "@id" : "_:b18",
+    "homepage" : "http://www.asahi-net.or.jp/~ax2s-kmtn/",
+    "foaf:name" : "Shuji Kamitsuna"
+  }, {
+    "@id" : "_:b19",
     "homepage" : "http://www.w3.org/2011/gld/",
     "foaf:name" : "Government Linked Data WG"
   }, {
-    "@id" : "_:b25",
+    "@id" : "_:b2",
+    "affiliation" : "_:b3",
+    "foaf:name" : "Vassilios Peristeras"
+  }, {
+    "@id" : "_:b20",
     "@type" : "foaf:Person",
-    "affiliation" : "_:b31",
+    "affiliation" : "_:b13",
     "seeAlso" : "https://orcid.org/0000-0002-3884-3420",
     "foaf:name" : "Simon J D Cox",
     "workInfoHomepage" : "http://people.csiro.au/Simon-Cox"
   }, {
-    "@id" : "_:b26",
-    "seeAlso" : "http://www.eurecom.fr/~atemezin/gatemezing-foaf.rdf",
-    "foaf:name" : "Ghislain Auguste Atemezing"
+    "@id" : "_:b21",
+    "foaf:name" : "Richard Cyganiak"
   }, {
-    "@id" : "_:b27",
-    "affiliation" : "_:b7",
-    "seeAlso" : "https://orcid.org/0000-0003-3499-8262",
-    "homepage" : "https://agbeltran.github.io",
-    "foaf:name" : "Alejandra Gonzalez-Beltran"
-  }, {
-    "@id" : "_:b29",
-    "homepage" : "http://okfn.org",
-    "foaf:name" : "Open Knowledge Foundation"
-  }, {
-    "@id" : "_:b3",
-    "@type" : "owl:Class",
-    "unionOf" : {
-      "@list" : [ "prov:Attribution", "dcat:Relationship" ]
-    }
-  }, {
-    "@id" : "_:b31",
-    "homepage" : "https://csiro.au",
-    "foaf:name" : "Commonwealth Scientific and Industrial Research Organisation"
-  }, {
-    "@id" : "_:b32",
-    "@type" : "owl:Restriction",
-    "allValuesFrom" : "dcat:Resource",
-    "onProperty" : "foaf:primaryTopic"
-  }, {
-    "@id" : "_:b33",
-    "@type" : "owl:Restriction",
-    "cardinality" : "1",
-    "onProperty" : "foaf:primaryTopic"
-  }, {
-    "@id" : "_:b4",
-    "seeAlso" : "https://orcid.org/0000-0001-5648-2713",
-    "homepage" : [ "https://w3id.org/people/ralbertoni/", "http://www.imati.cnr.it/index.php/people/8-curricula/178-riccardo-albertoni" ],
-    "foaf:name" : "Riccardo Albertoni"
-  }, {
-    "@id" : "_:b5",
+    "@id" : "_:b22",
     "foaf:name" : "Martin Alvarez-Espinar"
   }, {
-    "@id" : "_:b6",
+    "@id" : "_:b23",
     "affiliation" : "http://www.w3.org/data#W3C",
     "seeAlso" : "http://philarcher.org/foaf.rdf#me",
     "homepage" : "http://www.w3.org/People/all#phila",
     "foaf:name" : "Phil Archer"
   }, {
-    "@id" : "_:b7",
-    "homepage" : "http://stfc.ac.uk",
-    "foaf:name" : "Science and Technology Facilities Council, UK"
+    "@id" : "_:b24",
+    "affiliation" : "_:b32",
+    "foaf:name" : "Rufus Pollock"
   }, {
-    "@id" : "_:b8",
-    "@type" : "owl:Restriction",
-    "minCardinality" : "1",
-    "onProperty" : "dct:relation"
-  }, {
-    "@id" : "_:b9",
+    "@id" : "_:b25",
     "seeAlso" : "https://orcid.org/0000-0001-9300-2694",
     "homepage" : "http://www.andrea-perego.name/foaf/#me",
     "foaf:name" : "Andrea Perego"
   }, {
+    "@id" : "_:b26",
+    "seeAlso" : "https://jakub.klímek.com/#me",
+    "homepage" : "https://jakub.klímek.com/",
+    "foaf:name" : "Jakub Klímek"
+  }, {
+    "@id" : "_:b27",
+    "seeAlso" : "http://www.eurecom.fr/~atemezin/gatemezing-foaf.rdf",
+    "foaf:name" : "Ghislain Auguste Atemezing"
+  }, {
+    "@id" : "_:b28",
+    "seeAlso" : "http://makxdekkers.com/makxdekkers.rdf#me",
+    "homepage" : "http://makxdekkers.com/",
+    "foaf:name" : "Makx Dekkers"
+  }, {
+    "@id" : "_:b29",
+    "foaf:name" : "Boris Villazón-Terrazas"
+  }, {
+    "@id" : "_:b3",
+    "homepage" : "http://ec.europa.eu/dgs/informatics/",
+    "foaf:name" : "European Commission, DG DIGIT"
+  }, {
+    "@id" : "_:b30",
+    "@type" : "owl:Restriction",
+    "cardinality" : "1",
+    "onProperty" : "foaf:primaryTopic"
+  }, {
+    "@id" : "_:b32",
+    "homepage" : "http://okfn.org",
+    "foaf:name" : "Open Knowledge Foundation"
+  }, {
+    "@id" : "_:b4",
+    "affiliation" : "_:b5",
+    "seeAlso" : "https://orcid.org/0000-0003-3499-8262",
+    "homepage" : "https://agbeltran.github.io",
+    "foaf:name" : "Alejandra Gonzalez-Beltran"
+  }, {
+    "@id" : "_:b5",
+    "homepage" : "http://stfc.ac.uk",
+    "foaf:name" : "Science and Technology Facilities Council, UK"
+  }, {
+    "@id" : "_:b6",
+    "@type" : "owl:Class",
+    "unionOf" : {
+      "@list" : [ "prov:Attribution", "dcat:Relationship" ]
+    }
+  }, {
+    "@id" : "_:b7",
+    "@type" : "owl:Restriction",
+    "minCardinality" : "1",
+    "onProperty" : "dct:relation"
+  }, {
+    "@id" : "_:b8",
+    "@type" : "owl:Restriction",
+    "maxCardinality" : "1",
+    "onProperty" : "dcat:endpointURL"
+  }, {
+    "@id" : "_:b9",
+    "seeAlso" : "https://orcid.org/0000-0001-5648-2713",
+    "homepage" : [ "https://w3id.org/people/ralbertoni/", "http://www.imati.cnr.it/index.php/people/8-curricula/178-riccardo-albertoni" ],
+    "foaf:name" : "Riccardo Albertoni"
+  }, {
     "@id" : "http://www.w3.org/ns/dcat",
     "@type" : "owl:Ontology",
-    "contributor" : [ "_:b4", "_:b9", "_:b14", "_:b17", "_:b15", "_:b13", "_:b11", "_:b21", "_:b22", "_:b23", "_:b5", "_:b25", "_:b26", "_:b12", "_:b6", "_:b27" ],
-    "creator" : [ "_:b20", "_:b16" ],
+    "contributor" : [ "_:b23", "_:b12", "_:b21", "_:b24", "_:b25", "_:b2", "_:b14", "_:b4", "_:b18", "_:b26", "_:b9", "_:b27", "_:b20", "_:b28", "_:b29", "_:b22" ],
+    "creator" : [ "_:b1", "_:b10" ],
     "license" : "https://creativecommons.org/licenses/by/4.0/",
-    "modified" : [ "2012-04-24", "2017-12-19", "2013-09-20", "2013-11-28", "2020-11-30"  ],
+    "modified" : [ "2020-11-30", "2012-04-24", "2017-12-19", "2013-09-20", "2013-11-28", "2021-09-14" ],
     "dct:modified" : "2019",
     "rdfs:comment" : [ {
       "@language" : "da",
@@ -217,60 +212,60 @@
       "@language" : "en",
       "@value" : "English language definitions updated in this revision in line with ED. Multilingual text unevenly updated."
     },
-    "maker" : "_:b24"
+    "maker" : "_:b19"
   }, {
     "@id" : "dcat:Catalog",
-    "@type" : [ "owl:Class", "rdfs:Class" ],
+    "@type" : [ "rdfs:Class", "owl:Class" ],
     "rdfs:comment" : [ {
+      "@language" : "en",
+      "@value" : "A curated collection of metadata about resources (e.g., datasets and data services in the context of a data catalog)."
+    }, {
       "@language" : "it",
       "@value" : "Una raccolta curata di metadati sulle risorse (ad es. sui dataset e relativi servizi nel contesto di cataloghi di dati)."
+    }, {
+      "@language" : "cs",
+      "@value" : "Řízená kolekce metadat o datových sadách a datových službách"
+    }, {
+      "@language" : "es",
+      "@value" : "Una colección curada de metadatos sobre recursos (por ejemplo, conjuntos de datos y servicios de datos en el contexto de un catálogo de datos)."
+    }, {
+      "@language" : "el",
+      "@value" : "Μια επιμελημένη συλλογή μεταδεδομένων περί συνόλων δεδομένων"
+    }, {
+      "@language" : "fr",
+      "@value" : "Une collection élaborée de métadonnées sur les jeux de données"
+    }, {
+      "@language" : "ar",
+      "@value" : "مجموعة من توصيفات قوائم البيانات"
     }, {
       "@language" : "da",
       "@value" : "En udvalgt og arrangeret samling af metadata om ressourcer (fx datasæt og datatjenester i kontekst af et datakatalog). "
     }, {
       "@language" : "ja",
       "@value" : "データ・カタログは、データセットに関するキュレートされたメタデータの集合です。"
-    }, {
-      "@language" : "es",
-      "@value" : "Una colección curada de metadatos sobre recursos (por ejemplo, conjuntos de datos y servicios de datos en el contexto de un catálogo de datos)."
-    }, {
-      "@language" : "fr",
-      "@value" : "Une collection élaborée de métadonnées sur les jeux de données"
-    }, {
-      "@language" : "el",
-      "@value" : "Μια επιμελημένη συλλογή μεταδεδομένων περί συνόλων δεδομένων"
-    }, {
-      "@language" : "en",
-      "@value" : "A curated collection of metadata about resources (e.g., datasets and data services in the context of a data catalog)."
-    }, {
-      "@language" : "ar",
-      "@value" : "مجموعة من توصيفات قوائم البيانات"
-    }, {
-      "@language" : "cs",
-      "@value" : "Řízená kolekce metadat o datových sadách a datových službách"
     } ],
     "isDefinedBy" : "http://www.w3.org/TR/vocab-dcat/",
     "rdfs:label" : [ {
-      "@language" : "es",
-      "@value" : "Catálogo"
-    }, {
-      "@language" : "ar",
-      "@value" : "فهرس قوائم البيانات"
-    }, {
-      "@language" : "it",
-      "@value" : "Catalogo"
-    }, {
-      "@language" : "cs",
+      "@language" : "da",
       "@value" : "Katalog"
     }, {
-      "@language" : "da",
+      "@language" : "cs",
       "@value" : "Katalog"
     }, {
       "@language" : "el",
       "@value" : "Κατάλογος"
     }, {
+      "@language" : "it",
+      "@value" : "Catalogo"
+    }, {
+      "@language" : "ar",
+      "@value" : "فهرس قوائم البيانات"
+    }, {
       "@language" : "ja",
       "@value" : "カタログ"
+    }, {
+      "@language" : "es",
+      "@value" : "Catálogo"
     }, {
       "@language" : "en",
       "@value" : "Catalog"
@@ -278,34 +273,34 @@
       "@language" : "fr",
       "@value" : "Catalogue"
     } ],
-    "subClassOf" : [ "_:b0", "dcat:Dataset" ],
+    "subClassOf" : "dcat:Dataset",
     "skos:definition" : [ {
+      "@language" : "ja",
+      "@value" : "データ・カタログは、データセットに関するキュレートされたメタデータの集合です。"
+    }, {
+      "@language" : "cs",
+      "@value" : "Řízená kolekce metadat o datových sadách a datových službách."
+    }, {
+      "@language" : "it",
+      "@value" : "Una raccolta curata di metadati sulle risorse (ad es. sui dataset e relativi servizi nel contesto di cataloghi di dati)."
+    }, {
+      "@language" : "ar",
+      "@value" : "مجموعة من توصيفات قوائم البيانات"
+    }, {
+      "@language" : "es",
+      "@value" : "Una colección curada de metadatos sobre recursos (por ejemplo, conjuntos de datos y servicios de datos en el contexto de un catálogo de datos)."
+    }, {
       "@language" : "el",
       "@value" : "Μια επιμελημένη συλλογή μεταδεδομένων περί συνόλων δεδομένων."
     }, {
       "@language" : "fr",
       "@value" : "Une collection élaborée de métadonnées sur les jeux de données."
     }, {
-      "@language" : "ja",
-      "@value" : "データ・カタログは、データセットに関するキュレートされたメタデータの集合です。"
-    }, {
-      "@language" : "it",
-      "@value" : "Una raccolta curata di metadati sulle risorse (ad es. sui dataset e relativi servizi nel contesto di cataloghi di dati)."
-    }, {
-      "@language" : "es",
-      "@value" : "Una colección curada de metadatos sobre recursos (por ejemplo, conjuntos de datos y servicios de datos en el contexto de un catálogo de datos)."
-    }, {
-      "@language" : "cs",
-      "@value" : "Řízená kolekce metadat o datových sadách a datových službách."
-    }, {
       "@language" : "da",
       "@value" : "En samling af metadata om ressourcer (fx datasæt og datatjenester i kontekst af et datakatalog)."
     }, {
       "@language" : "en",
       "@value" : "A curated collection of metadata about resources (e.g., datasets and data services in the context of a data catalog)."
-    }, {
-      "@language" : "ar",
-      "@value" : "مجموعة من توصيفات قوائم البيانات"
     } ],
     "skos:editorialNote" : {
       "@language" : "en",
@@ -315,23 +310,23 @@
       "@language" : "es",
       "@value" : "Normalmente, un catálogo de datos disponible en la web se representa como una única instancia de esta clase."
     }, {
-      "@language" : "cs",
-      "@value" : "Webový datový katalog je typicky reprezentován jako jedna instance této třídy."
-    }, {
-      "@language" : "it",
-      "@value" : "Normalmente, un catalogo di dati nel web viene rappresentato come una singola istanza di questa classe."
-    }, {
       "@language" : "da",
       "@value" : "Et webbaseret datakatalog repræsenteres typisk ved en enkelt instans af denne klasse."
+    }, {
+      "@language" : "el",
+      "@value" : "Συνήθως, ένας κατάλογος δεδομένων στον Παγκόσμιο Ιστό αναπαρίσταται ως ένα στιγμιότυπο αυτής της κλάσης."
+    }, {
+      "@language" : "cs",
+      "@value" : "Webový datový katalog je typicky reprezentován jako jedna instance této třídy."
     }, {
       "@language" : "en",
       "@value" : "A web-based data catalog is typically represented as a single instance of this class."
     }, {
+      "@language" : "it",
+      "@value" : "Normalmente, un catalogo di dati nel web viene rappresentato come una singola istanza di questa classe."
+    }, {
       "@language" : "ja",
       "@value" : "通常、ウェブ・ベースのデータ・カタログは、このクラスの1つのインスタンスとして表わされます。"
-    }, {
-      "@language" : "el",
-      "@value" : "Συνήθως, ένας κατάλογος δεδομένων στον Παγκόσμιο Ιστό αναπαρίσταται ως ένα στιγμιότυπο αυτής της κλάσης."
     } ]
   }, {
     "@id" : "dcat:CatalogRecord",
@@ -390,13 +385,13 @@
       "@language" : "fr",
       "@value" : "Registre du catalogue"
     } ],
-    "subClassOf" : [ "_:b32", "_:b33" ],
+    "subClassOf" : [ "_:b30", "_:b0" ],
     "skos:definition" : [ {
-      "@language" : "cs",
-      "@value" : "Záznam v datovém katalogu popisující jednu datovou sadu či datovou službu."
-    }, {
       "@language" : "it",
       "@value" : "Un record in un catalogo di dati che descrive un singolo dataset o servizio di dati."
+    }, {
+      "@language" : "cs",
+      "@value" : "Záznam v datovém katalogu popisující jednu datovou sadu či datovou službu."
     }, {
       "@language" : "es",
       "@value" : "Un registro en un catálogo de datos que describe un solo conjunto de datos o un servicio de datos."
@@ -421,9 +416,6 @@
       "@value" : "English definition updated in this revision. Multilingual text not yet updated except the Spanish one and the Czech one and Italian one."
     },
     "skos:scopeNote" : [ {
-      "@language" : "ja",
-      "@value" : "このクラスはオプションで、すべてのカタログがそれを用いるとは限りません。これは、データセットに関するメタデータとカタログ内のデータセットのエントリーに関するメタデータとで区別が行われるカタログのために存在しています。例えば、データセットの公開日プロパティーは、公開機関が情報を最初に利用可能とした日付を示しますが、カタログ・レコードの公開日は、データセットがカタログに追加された日付です。両方の日付が異っていたり、後者だけが分かっている場合は、カタログ・レコードに対してのみ公開日を指定すべきです。W3CのPROVオントロジー[prov-o]を用いれば、データセットに対する特定の変更に関連するプロセスやエージェントの詳細などの、さらに詳しい来歴情報の記述が可能となることに注意してください。"
-    }, {
       "@language" : "it",
       "@value" : "Questa classe è opzionale e non tutti i cataloghi la utilizzeranno. Esiste per cataloghi in cui si opera una distinzione tra i metadati relativi al dataset ed i metadati relativi alla gestione del dataset nel catalogo. Ad esempio, la  proprietà per indicare la data di pubblicazione del dataset rifletterà la data in cui l'informazione è stata originariamente messa a disposizione dalla casa editrice, mentre la data di pubblicazione per il record nel catalogo rifletterà la data in cui il dataset è stato aggiunto al catalogo. Nei casi dove solo quest'ultima sia nota, si utilizzerà esclusivamente la data di  pubblicazione relativa al record del catalogo. Si noti che l'Ontologia W3C PROV permette di descrivere ulteriori informazioni sulla provenienza, quali i dettagli del processo, la procedura e l'agente coinvolto in una particolare modifica di un dataset."
     }, {
@@ -441,6 +433,9 @@
     }, {
       "@language" : "da",
       "@value" : "Denne klasse er valgfri og ikke alle kataloger vil anvende denne klasse. Den kan anvendes i de kataloger hvor der skelnes mellem metadata om datasættet eller datatjenesten og metadata om selve posten til registreringen af datasættet eller datatjenesten i kataloget. Udgivelsesdatoen for datasættet afspejler for eksempel den dato hvor informationerne oprindeligt blev gjort tilgængelige af udgiveren, hvorimod udgivelsesdatoen for katalogposten er den dato hvor datasættet blev føjet til kataloget. I de tilfælde hvor de to datoer er forskellige eller hvor blot sidstnævnte er kendt, bør udgivelsesdatoen kun angives for katalogposten. Bemærk at W3Cs PROV ontologi gør til muligt at tilføje yderligere proveniensoplysninger eksempelvis om processen eller aktøren involveret i en given ændring af datasættet."
+    }, {
+      "@language" : "ja",
+      "@value" : "このクラスはオプションで、すべてのカタログがそれを用いるとは限りません。これは、データセットに関するメタデータとカタログ内のデータセットのエントリーに関するメタデータとで区別が行われるカタログのために存在しています。例えば、データセットの公開日プロパティーは、公開機関が情報を最初に利用可能とした日付を示しますが、カタログ・レコードの公開日は、データセットがカタログに追加された日付です。両方の日付が異っていたり、後者だけが分かっている場合は、カタログ・レコードに対してのみ公開日を指定すべきです。W3CのPROVオントロジー[prov-o]を用いれば、データセットに対する特定の変更に関連するプロセスやエージェントの詳細などの、さらに詳しい来歴情報の記述が可能となることに注意してください。"
     }, {
       "@language" : "fr",
       "@value" : "C'est une classe facultative et tous les catalogues ne l'utiliseront pas. Cette classe existe pour les catalogues\tayant une distinction entre les métadonnées sur le jeu de données et les métadonnées sur une entrée du jeu de données dans le catalogue."
@@ -477,7 +472,7 @@
       "@language" : "da",
       "@value" : "Datatjeneste"
     } ],
-    "subClassOf" : [ "_:b18", "dctype:Service", "dcat:Resource" ],
+    "subClassOf" : [ "_:b8", "dctype:Service", "dcat:Resource" ],
     "skos:altLabel" : {
       "@language" : "da",
       "@value" : "Dataservice"
@@ -856,7 +851,7 @@
       "@language" : "en",
       "@value" : "Relationship"
     } ],
-    "subClassOf" : "_:b8",
+    "subClassOf" : "_:b7",
     "skos:changeNote" : [ {
       "@language" : "it",
       "@value" : "Nuova classe aggiunta in DCAT 2.0."
@@ -2404,7 +2399,7 @@
       "@language" : "en",
       "@value" : "The function of an entity or agent with respect to another entity or resource."
     } ],
-    "domain" : "_:b3",
+    "domain" : "_:b6",
     "rdfs:label" : [ {
       "@language" : "it",
       "@value" : "tiene rol"
@@ -3847,21 +3842,13 @@
       "@id" : "http://www.w3.org/2004/02/skos/core#altLabel",
       "@type" : "http://www.w3.org/1999/02/22-rdf-syntax-ns#langString"
     },
-    "rest" : {
-      "@id" : "http://www.w3.org/1999/02/22-rdf-syntax-ns#rest",
-      "@type" : "@id"
-    },
-    "first" : {
-      "@id" : "http://www.w3.org/1999/02/22-rdf-syntax-ns#first",
-      "@type" : "@id"
-    },
-    "unionOf" : {
-      "@id" : "http://www.w3.org/2002/07/owl#unionOf",
-      "@type" : "@id"
-    },
     "name" : {
       "@id" : "http://xmlns.com/foaf/0.1/name",
       "@type" : "http://www.w3.org/2001/XMLSchema#string"
+    },
+    "affiliation" : {
+      "@id" : "http://schema.org/affiliation",
+      "@type" : "@id"
     },
     "homepage" : {
       "@id" : "http://xmlns.com/foaf/0.1/homepage",
@@ -3869,14 +3856,6 @@
     },
     "seeAlso" : {
       "@id" : "http://www.w3.org/2000/01/rdf-schema#seeAlso",
-      "@type" : "@id"
-    },
-    "affiliation" : {
-      "@id" : "http://schema.org/affiliation",
-      "@type" : "@id"
-    },
-    "rangeIncludes" : {
-      "@id" : "http://schema.org/rangeIncludes",
       "@type" : "@id"
     },
     "minCardinality" : {
@@ -3887,32 +3866,52 @@
       "@id" : "http://www.w3.org/2002/07/owl#maxCardinality",
       "@type" : "http://www.w3.org/2001/XMLSchema#nonNegativeInteger"
     },
-    "creator" : {
-      "@id" : "http://purl.org/dc/terms/creator",
+    "unionOf" : {
+      "@id" : "http://www.w3.org/2002/07/owl#unionOf",
+      "@type" : "@id"
+    },
+    "rangeIncludes" : {
+      "@id" : "http://schema.org/rangeIncludes",
+      "@type" : "@id"
+    },
+    "rest" : {
+      "@id" : "http://www.w3.org/1999/02/22-rdf-syntax-ns#rest",
+      "@type" : "@id"
+    },
+    "first" : {
+      "@id" : "http://www.w3.org/1999/02/22-rdf-syntax-ns#first",
+      "@type" : "@id"
+    },
+    "workInfoHomepage" : {
+      "@id" : "http://xmlns.com/foaf/0.1/workInfoHomepage",
+      "@type" : "@id"
+    },
+    "contributor" : {
+      "@id" : "http://purl.org/dc/terms/contributor",
       "@type" : "@id"
     },
     "versionInfo" : {
       "@id" : "http://www.w3.org/2002/07/owl#versionInfo",
       "@type" : "http://www.w3.org/1999/02/22-rdf-syntax-ns#langString"
     },
-    "contributor" : {
-      "@id" : "http://purl.org/dc/terms/contributor",
-      "@type" : "@id"
+    "modified" : {
+      "@id" : "http://purl.org/dc/terms/modified",
+      "@type" : "http://www.w3.org/2001/XMLSchema#date"
     },
     "imports" : {
       "@id" : "http://www.w3.org/2002/07/owl#imports",
       "@type" : "@id"
     },
-    "modified" : {
-      "@id" : "http://purl.org/dc/terms/modified",
-      "@type" : "http://www.w3.org/2001/XMLSchema#date"
-    },
-    "maker" : {
-      "@id" : "http://xmlns.com/foaf/0.1/maker",
+    "creator" : {
+      "@id" : "http://purl.org/dc/terms/creator",
       "@type" : "@id"
     },
     "license" : {
       "@id" : "http://purl.org/dc/terms/license",
+      "@type" : "@id"
+    },
+    "maker" : {
+      "@id" : "http://xmlns.com/foaf/0.1/maker",
       "@type" : "@id"
     },
     "subClassOf" : {
@@ -3926,10 +3925,6 @@
     "cardinality" : {
       "@id" : "http://www.w3.org/2002/07/owl#cardinality",
       "@type" : "http://www.w3.org/2001/XMLSchema#nonNegativeInteger"
-    },
-    "workInfoHomepage" : {
-      "@id" : "http://xmlns.com/foaf/0.1/workInfoHomepage",
-      "@type" : "@id"
     },
     "dct" : "http://purl.org/dc/terms/",
     "owl" : "http://www.w3.org/2002/07/owl#",

--- a/dcat/rdf/dcat2.rdf
+++ b/dcat/rdf/dcat2.rdf
@@ -16,79 +16,6 @@
     <rdfs:label xml:lang="it">Il vocabolario del catalogo dei dati</rdfs:label>
     <owl:versionInfo xml:lang="en">Questa è una copia aggiornata del vocabolario DCAT v2.0 disponibile in https://www.w3.org/ns/dcat.ttl</owl:versionInfo>
     <rdfs:comment xml:lang="da">DCAT er et RDF-vokabular som har til formål at understøtte interoperabilitet mellem datakataloger udgivet på nettet. Ved at anvende DCAT til at beskrive datasæt i datakataloger, kan udgivere øge findbarhed og gøre det gøre det lettere for applikationer at anvende metadata fra forskellige kataloger. Derudover understøttes decentraliseret udstilling af kataloger og fødererede datasætsøgninger på tværs af websider. Aggregerede DCAT-metadata kan fungere som fortegnelsesfiler der kan understøtte digital bevaring. DCAT er defineret på http://www.w3.org/TR/vocab-dcat/. Enhver forskel mellem det normative dokument og dette schema er en fejl i dette schema.</rdfs:comment>
-    <owl:versionInfo xml:lang="en">This is an updated copy of v2.0 of the DCAT vocabulary, taken from https://www.w3.org/ns/dcat.ttl</owl:versionInfo>
-    <rdfs:label xml:lang="fr">Le vocabulaire des jeux de données</rdfs:label>
-    <dct:contributor rdf:parseType="Resource">
-      <foaf:name>Makx Dekkers</foaf:name>
-      <foaf:homepage rdf:resource="http://makxdekkers.com/"/>
-      <rdfs:seeAlso rdf:resource="http://makxdekkers.com/makxdekkers.rdf#me"/>
-    </dct:contributor>
-    <dct:contributor rdf:parseType="Resource">
-      <foaf:name>David Browning</foaf:name>
-      <sdo:affiliation rdf:parseType="Resource">
-        <foaf:name>Refinitiv</foaf:name>
-        <foaf:homepage rdf:resource="http://www.refinitiv.com"/>
-      </sdo:affiliation>
-    </dct:contributor>
-    <dct:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#date"
-    >2020-11-30</dct:modified>
-    <rdfs:comment xml:lang="fr">DCAT est un vocabulaire développé pour faciliter l'interopérabilité entre les jeux de données publiées sur le Web. En utilisant DCAT pour décrire les jeux de données dans les catalogues de données, les fournisseurs de données augmentent leur découverte et permettent que les applications facilement les métadonnées de plusieurs catalogues. Il permet en plus la publication décentralisée des catalogues et facilitent la recherche fédérée des données entre plusieurs sites. Les métadonnées DCAT aggrégées peuvent servir comme un manifeste pour faciliter la préservation digitale des ressources. DCAT est définie à l'adresse http://www.w3.org/TR/vocab-dcat/. Une quelconque version de ce document normatif et ce vocabulaire est une erreur dans ce vocabulaire.</rdfs:comment>
-    <dct:creator rdf:parseType="Resource">
-      <foaf:name>John Erickson</foaf:name>
-    </dct:creator>
-    <rdfs:label xml:lang="es">El vocabulario de catálogo de datos</rdfs:label>
-    <owl:imports rdf:resource="http://www.w3.org/2004/02/skos/core"/>
-    <rdfs:comment xml:lang="cs">DCAT je RDF slovník navržený pro zprostředkování interoperability mezi datovými katalogy publikovanými na Webu. Poskytovatelé dat používáním slovníku DCAT pro popis datových sad v datových katalozích zvyšují jejich dohledatelnost a umožňují aplikacím konzumovat metadata z více katalogů. Dále je umožňena decentralizovaná publikace katalogů a federované dotazování na datové sady napříč katalogy. Agregovaná DCAT metadata mohou také sloužit jako průvodka umožňující digitální uchování informace. DCAT je definován na http://www.w3.org/TR/vocab-dcat/. Jakýkoliv nesoulad mezi odkazovaným dokumentem a tímto schématem je chybou v tomto schématu.</rdfs:comment>
-    <dct:contributor rdf:parseType="Resource">
-      <foaf:name>Marios Meimaris</foaf:name>
-    </dct:contributor>
-    <owl:versionInfo xml:lang="es">Esta es una copia del vocabulario DCAT v2.0 disponible en https://www.w3.org/ns/dcat.ttl</owl:versionInfo>
-    <dct:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#date"
-    >2012-04-24</dct:modified>
-    <rdfs:comment xml:lang="ar">هي أنطولوجية تسهل تبادل البيانات بين مختلف الفهارس على الوب. استخدام هذه الأنطولوجية يساعد على اكتشاف قوائم  البيانات المنشورة على الوب و يمكن التطبيقات المختلفة من الاستفادة أتوماتيكيا من البيانات المتاحة من مختلف الفهارس.</rdfs:comment>
-    <skos:editorialNote xml:lang="en">English language definitions updated in this revision in line with ED. Multilingual text unevenly updated.</skos:editorialNote>
-    <dct:contributor rdf:parseType="Resource">
-      <foaf:name>Phil Archer</foaf:name>
-      <foaf:homepage rdf:resource="http://www.w3.org/People/all#phila"/>
-      <rdfs:seeAlso rdf:resource="http://philarcher.org/foaf.rdf#me"/>
-      <sdo:affiliation rdf:resource="http://www.w3.org/data#W3C"/>
-    </dct:contributor>
-    <dct:contributor rdf:parseType="Resource">
-      <foaf:name>Shuji Kamitsuna</foaf:name>
-      <foaf:homepage rdf:resource="http://www.asahi-net.or.jp/~ax2s-kmtn/"/>
-    </dct:contributor>
-    <rdfs:label xml:lang="da">Datakatalogvokabular</rdfs:label>
-    <dct:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#date"
-    >2017-12-19</dct:modified>
-    <dct:contributor rdf:parseType="Resource">
-      <foaf:name>Martin Alvarez-Espinar</foaf:name>
-    </dct:contributor>
-    <foaf:maker rdf:parseType="Resource">
-      <foaf:name>Government Linked Data WG</foaf:name>
-      <foaf:homepage rdf:resource="http://www.w3.org/2011/gld/"/>
-    </foaf:maker>
-    <dct:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#date"
-    >2013-09-20</dct:modified>
-    <dct:contributor rdf:parseType="Resource">
-      <foaf:name>Vassilios Peristeras</foaf:name>
-      <sdo:affiliation rdf:parseType="Resource">
-        <foaf:name>European Commission, DG DIGIT</foaf:name>
-        <foaf:homepage rdf:resource="http://ec.europa.eu/dgs/informatics/"/>
-      </sdo:affiliation>
-    </dct:contributor>
-    <owl:imports rdf:resource="http://www.w3.org/ns/prov-o#"/>
-    <rdfs:comment xml:lang="ja">DCATは、ウェブ上で公開されたデータ・カタログ間の相互運用性の促進を目的とするRDFの語彙です。このドキュメントでは、その利用のために、スキーマを定義し、例を提供します。データ・カタログ内のデータセットを記述するためにDCATを用いると、公開者が、発見可能性を増加させ、アプリケーションが複数のカタログのメタデータを容易に利用できるようになります。さらに、カタログの分散公開を可能にし、複数のサイトにまたがるデータセットの統合検索を促進します。集約されたDCATメタデータは、ディジタル保存を促進するためのマニフェスト・ファイルとして使用できます。</rdfs:comment>
-    <rdfs:comment xml:lang="en">DCAT is an RDF vocabulary designed to facilitate interoperability between data catalogs published on the Web. By using DCAT to describe datasets in data catalogs, publishers increase discoverability and enable applications easily to consume metadata from multiple catalogs. It further enables decentralized publishing of catalogs and facilitates federated dataset search across sites. Aggregated DCAT metadata can serve as a manifest file to facilitate digital preservation. DCAT is defined at http://www.w3.org/TR/vocab-dcat/. Any variance between that normative document and this schema is an error in this schema.</rdfs:comment>
-    <owl:versionInfo xml:lang="da">Dette er en opdateret kopi af DCAT v. 2.0 som er tilgænglig på https://www.w3.org/ns/dcat.ttl</owl:versionInfo>
-    <dct:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#date"
-    >2013-11-28</dct:modified>
-    <dct:modified>2019</dct:modified>
-    <dct:contributor rdf:parseType="Resource">
-      <foaf:name>Ghislain Auguste Atemezing</foaf:name>
-      <rdfs:seeAlso rdf:resource="http://www.eurecom.fr/~atemezin/gatemezing-foaf.rdf"/>
-    </dct:contributor>
-    <dct:license rdf:resource="https://creativecommons.org/licenses/by/4.0/"/>
-    <owl:imports rdf:resource="http://purl.org/dc/terms/"/>
     <dct:contributor>
       <foaf:Person>
         <foaf:workInfoHomepage rdf:resource="http://people.csiro.au/Simon-Cox"/>
@@ -100,46 +27,12 @@
         </sdo:affiliation>
       </foaf:Person>
     </dct:contributor>
-    <dct:creator rdf:parseType="Resource">
-      <foaf:name>Fadi Maali</foaf:name>
-      <rdfs:seeAlso rdf:resource="http://fadmaa.me/foaf.ttl"/>
-    </dct:creator>
     <dct:contributor rdf:parseType="Resource">
-      <foaf:name>Andrea Perego</foaf:name>
-      <foaf:homepage rdf:resource="http://www.andrea-perego.name/foaf/#me"/>
-      <rdfs:seeAlso rdf:resource="https://orcid.org/0000-0001-9300-2694"/>
+      <foaf:name>Phil Archer</foaf:name>
+      <foaf:homepage rdf:resource="http://www.w3.org/People/all#phila"/>
+      <rdfs:seeAlso rdf:resource="http://philarcher.org/foaf.rdf#me"/>
+      <sdo:affiliation rdf:resource="http://www.w3.org/data#W3C"/>
     </dct:contributor>
-    <rdfs:comment xml:lang="es">DCAT es un vocabulario RDF diseñado para facilitar la interoperabilidad entre catálogos de datos publicados en la Web. Utilizando DCAT para describir datos disponibles en catálogos se aumenta la posibilidad de que sean descubiertos y se permite que las aplicaciones consuman fácilmente los metadatos de varios catálogos.</rdfs:comment>
-    <dct:contributor rdf:parseType="Resource">
-      <foaf:name>Richard Cyganiak</foaf:name>
-    </dct:contributor>
-    <rdfs:label xml:lang="ar">أنطولوجية فهارس قوائم البيانات</rdfs:label>
-    <rdfs:label xml:lang="el">Το λεξιλόγιο των καταλόγων δεδομένων</rdfs:label>
-    <dct:contributor rdf:parseType="Resource">
-      <foaf:name>Riccardo Albertoni</foaf:name>
-      <foaf:homepage rdf:resource="https://w3id.org/people/ralbertoni/"/>
-      <foaf:homepage rdf:resource="http://www.imati.cnr.it/index.php/people/8-curricula/178-riccardo-albertoni"/>
-      <rdfs:seeAlso rdf:resource="https://orcid.org/0000-0001-5648-2713"/>
-    </dct:contributor>
-    <dct:contributor rdf:parseType="Resource">
-      <foaf:name>Jakub Klímek</foaf:name>
-      <foaf:homepage rdf:resource="https://jakub.klímek.com/"/>
-      <rdfs:seeAlso rdf:resource="https://jakub.klímek.com/#me"/>
-    </dct:contributor>
-    <owl:versionInfo xml:lang="cs">Toto je aktualizovaná kopie slovníku DCAT verze 2.0, převzatá z https://www.w3.org/ns/dcat.ttl</owl:versionInfo>
-    <rdfs:comment xml:lang="el">Το DCAT είναι ένα RDF λεξιλόγιο που σχεδιάσθηκε για να κάνει εφικτή τη διαλειτουργικότητα μεταξύ καταλόγων δεδομένων στον Παγκόσμιο Ιστό. Χρησιμοποιώντας το DCAT για την περιγραφή συνόλων δεδομένων, οι εκδότες αυτών αυξάνουν την ανακαλυψιμότητα και επιτρέπουν στις εφαρμογές την εύκολη κατανάλωση μεταδεδομένων από πολλαπλούς καταλόγους. Επιπλέον, δίνει τη δυνατότητα για αποκεντρωμένη έκδοση και διάθεση καταλόγων και επιτρέπει δυνατότητες ενοποιημένης αναζήτησης μεταξύ διαφορετικών πηγών. Συγκεντρωτικά μεταδεδομένα που έχουν περιγραφεί με το DCAT μπορούν να χρησιμοποιηθούν σαν ένα δηλωτικό αρχείο (manifest file) ώστε να διευκολύνουν την ψηφιακή συντήρηση.</rdfs:comment>
-    <dct:contributor rdf:parseType="Resource">
-      <foaf:name>Rufus Pollock</foaf:name>
-      <sdo:affiliation rdf:parseType="Resource">
-        <foaf:name>Open Knowledge Foundation</foaf:name>
-        <foaf:homepage rdf:resource="http://okfn.org"/>
-      </sdo:affiliation>
-    </dct:contributor>
-    <rdfs:label xml:lang="ja">データ・カタログ語彙（DCAT）</rdfs:label>
-    <dct:contributor rdf:parseType="Resource">
-      <foaf:name>Boris Villazón-Terrazas</foaf:name>
-    </dct:contributor>
-    <rdfs:comment xml:lang="it">DCAT è un vocabolario RDF progettato per facilitare l'interoperabilità tra i cataloghi di dati pubblicati nel Web. Utilizzando DCAT per descrivere i dataset nei cataloghi di dati, i fornitori migliorano la capacità di individuazione dei dati e abilitano le  applicazioni al consumo di dati provenienti da cataloghi differenti. DCAT permette di decentralizzare la pubblicazione di cataloghi e facilita la ricerca federata dei dataset. L'aggregazione dei metadati federati può fungere da file manifesto per facilitare la conservazione digitale. DCAT è definito all'indirizzo http://www.w3.org/TR/vocab-dcat/. Qualsiasi scostamento tra tale definizione normativa e questo schema è da considerarsi un errore di questo schema.</rdfs:comment>
     <dct:contributor rdf:parseType="Resource">
       <foaf:name>Alejandra Gonzalez-Beltran</foaf:name>
       <foaf:homepage rdf:resource="https://agbeltran.github.io"/>
@@ -149,6 +42,113 @@
         <foaf:homepage rdf:resource="http://stfc.ac.uk"/>
       </sdo:affiliation>
     </dct:contributor>
+    <owl:versionInfo xml:lang="en">This is an updated copy of v2.0 of the DCAT vocabulary, taken from https://www.w3.org/ns/dcat.ttl</owl:versionInfo>
+    <rdfs:label xml:lang="fr">Le vocabulaire des jeux de données</rdfs:label>
+    <dct:contributor rdf:parseType="Resource">
+      <foaf:name>Vassilios Peristeras</foaf:name>
+      <sdo:affiliation rdf:parseType="Resource">
+        <foaf:name>European Commission, DG DIGIT</foaf:name>
+        <foaf:homepage rdf:resource="http://ec.europa.eu/dgs/informatics/"/>
+      </sdo:affiliation>
+    </dct:contributor>
+    <dct:contributor rdf:parseType="Resource">
+      <foaf:name>Riccardo Albertoni</foaf:name>
+      <foaf:homepage rdf:resource="https://w3id.org/people/ralbertoni/"/>
+      <foaf:homepage rdf:resource="http://www.imati.cnr.it/index.php/people/8-curricula/178-riccardo-albertoni"/>
+      <rdfs:seeAlso rdf:resource="https://orcid.org/0000-0001-5648-2713"/>
+    </dct:contributor>
+    <dct:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#date"
+    >2020-11-30</dct:modified>
+    <rdfs:comment xml:lang="fr">DCAT est un vocabulaire développé pour faciliter l'interopérabilité entre les jeux de données publiées sur le Web. En utilisant DCAT pour décrire les jeux de données dans les catalogues de données, les fournisseurs de données augmentent leur découverte et permettent que les applications facilement les métadonnées de plusieurs catalogues. Il permet en plus la publication décentralisée des catalogues et facilitent la recherche fédérée des données entre plusieurs sites. Les métadonnées DCAT aggrégées peuvent servir comme un manifeste pour faciliter la préservation digitale des ressources. DCAT est définie à l'adresse http://www.w3.org/TR/vocab-dcat/. Une quelconque version de ce document normatif et ce vocabulaire est une erreur dans ce vocabulaire.</rdfs:comment>
+    <rdfs:label xml:lang="es">El vocabulario de catálogo de datos</rdfs:label>
+    <owl:imports rdf:resource="http://www.w3.org/2004/02/skos/core"/>
+    <rdfs:comment xml:lang="cs">DCAT je RDF slovník navržený pro zprostředkování interoperability mezi datovými katalogy publikovanými na Webu. Poskytovatelé dat používáním slovníku DCAT pro popis datových sad v datových katalozích zvyšují jejich dohledatelnost a umožňují aplikacím konzumovat metadata z více katalogů. Dále je umožňena decentralizovaná publikace katalogů a federované dotazování na datové sady napříč katalogy. Agregovaná DCAT metadata mohou také sloužit jako průvodka umožňující digitální uchování informace. DCAT je definován na http://www.w3.org/TR/vocab-dcat/. Jakýkoliv nesoulad mezi odkazovaným dokumentem a tímto schématem je chybou v tomto schématu.</rdfs:comment>
+    <owl:versionInfo xml:lang="es">Esta es una copia del vocabulario DCAT v2.0 disponible en https://www.w3.org/ns/dcat.ttl</owl:versionInfo>
+    <dct:contributor rdf:parseType="Resource">
+      <foaf:name>Richard Cyganiak</foaf:name>
+    </dct:contributor>
+    <dct:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#date"
+    >2012-04-24</dct:modified>
+    <rdfs:comment xml:lang="ar">هي أنطولوجية تسهل تبادل البيانات بين مختلف الفهارس على الوب. استخدام هذه الأنطولوجية يساعد على اكتشاف قوائم  البيانات المنشورة على الوب و يمكن التطبيقات المختلفة من الاستفادة أتوماتيكيا من البيانات المتاحة من مختلف الفهارس.</rdfs:comment>
+    <skos:editorialNote xml:lang="en">English language definitions updated in this revision in line with ED. Multilingual text unevenly updated.</skos:editorialNote>
+    <dct:contributor rdf:parseType="Resource">
+      <foaf:name>Rufus Pollock</foaf:name>
+      <sdo:affiliation rdf:parseType="Resource">
+        <foaf:name>Open Knowledge Foundation</foaf:name>
+        <foaf:homepage rdf:resource="http://okfn.org"/>
+      </sdo:affiliation>
+    </dct:contributor>
+    <rdfs:label xml:lang="da">Datakatalogvokabular</rdfs:label>
+    <dct:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#date"
+    >2017-12-19</dct:modified>
+    <dct:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#date"
+    >2013-09-20</dct:modified>
+    <dct:contributor rdf:parseType="Resource">
+      <foaf:name>Andrea Perego</foaf:name>
+      <foaf:homepage rdf:resource="http://www.andrea-perego.name/foaf/#me"/>
+      <rdfs:seeAlso rdf:resource="https://orcid.org/0000-0001-9300-2694"/>
+    </dct:contributor>
+    <foaf:maker rdf:parseType="Resource">
+      <foaf:name>Government Linked Data WG</foaf:name>
+      <foaf:homepage rdf:resource="http://www.w3.org/2011/gld/"/>
+    </foaf:maker>
+    <dct:contributor rdf:parseType="Resource">
+      <foaf:name>David Browning</foaf:name>
+      <sdo:affiliation rdf:parseType="Resource">
+        <foaf:name>Refinitiv</foaf:name>
+        <foaf:homepage rdf:resource="http://www.refinitiv.com"/>
+      </sdo:affiliation>
+    </dct:contributor>
+    <owl:imports rdf:resource="http://www.w3.org/ns/prov-o#"/>
+    <rdfs:comment xml:lang="ja">DCATは、ウェブ上で公開されたデータ・カタログ間の相互運用性の促進を目的とするRDFの語彙です。このドキュメントでは、その利用のために、スキーマを定義し、例を提供します。データ・カタログ内のデータセットを記述するためにDCATを用いると、公開者が、発見可能性を増加させ、アプリケーションが複数のカタログのメタデータを容易に利用できるようになります。さらに、カタログの分散公開を可能にし、複数のサイトにまたがるデータセットの統合検索を促進します。集約されたDCATメタデータは、ディジタル保存を促進するためのマニフェスト・ファイルとして使用できます。</rdfs:comment>
+    <dct:contributor rdf:parseType="Resource">
+      <foaf:name>Marios Meimaris</foaf:name>
+    </dct:contributor>
+    <rdfs:comment xml:lang="en">DCAT is an RDF vocabulary designed to facilitate interoperability between data catalogs published on the Web. By using DCAT to describe datasets in data catalogs, publishers increase discoverability and enable applications easily to consume metadata from multiple catalogs. It further enables decentralized publishing of catalogs and facilitates federated dataset search across sites. Aggregated DCAT metadata can serve as a manifest file to facilitate digital preservation. DCAT is defined at http://www.w3.org/TR/vocab-dcat/. Any variance between that normative document and this schema is an error in this schema.</rdfs:comment>
+    <owl:versionInfo xml:lang="da">Dette er en opdateret kopi af DCAT v. 2.0 som er tilgænglig på https://www.w3.org/ns/dcat.ttl</owl:versionInfo>
+    <dct:contributor rdf:parseType="Resource">
+      <foaf:name>Shuji Kamitsuna</foaf:name>
+      <foaf:homepage rdf:resource="http://www.asahi-net.or.jp/~ax2s-kmtn/"/>
+    </dct:contributor>
+    <dct:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#date"
+    >2013-11-28</dct:modified>
+    <dct:modified>2019</dct:modified>
+    <dct:license rdf:resource="https://creativecommons.org/licenses/by/4.0/"/>
+    <owl:imports rdf:resource="http://purl.org/dc/terms/"/>
+    <dct:creator rdf:parseType="Resource">
+      <foaf:name>Fadi Maali</foaf:name>
+      <rdfs:seeAlso rdf:resource="http://fadmaa.me/foaf.ttl"/>
+    </dct:creator>
+    <dct:contributor rdf:parseType="Resource">
+      <foaf:name>Ghislain Auguste Atemezing</foaf:name>
+      <rdfs:seeAlso rdf:resource="http://www.eurecom.fr/~atemezin/gatemezing-foaf.rdf"/>
+    </dct:contributor>
+    <rdfs:comment xml:lang="es">DCAT es un vocabulario RDF diseñado para facilitar la interoperabilidad entre catálogos de datos publicados en la Web. Utilizando DCAT para describir datos disponibles en catálogos se aumenta la posibilidad de que sean descubiertos y se permite que las aplicaciones consuman fácilmente los metadatos de varios catálogos.</rdfs:comment>
+    <dct:contributor rdf:parseType="Resource">
+      <foaf:name>Jakub Klímek</foaf:name>
+      <foaf:homepage rdf:resource="https://jakub.klímek.com/"/>
+      <rdfs:seeAlso rdf:resource="https://jakub.klímek.com/#me"/>
+    </dct:contributor>
+    <rdfs:label xml:lang="ar">أنطولوجية فهارس قوائم البيانات</rdfs:label>
+    <rdfs:label xml:lang="el">Το λεξιλόγιο των καταλόγων δεδομένων</rdfs:label>
+    <dct:contributor rdf:parseType="Resource">
+      <foaf:name>Makx Dekkers</foaf:name>
+      <foaf:homepage rdf:resource="http://makxdekkers.com/"/>
+      <rdfs:seeAlso rdf:resource="http://makxdekkers.com/makxdekkers.rdf#me"/>
+    </dct:contributor>
+    <owl:versionInfo xml:lang="cs">Toto je aktualizovaná kopie slovníku DCAT verze 2.0, převzatá z https://www.w3.org/ns/dcat.ttl</owl:versionInfo>
+    <rdfs:comment xml:lang="el">Το DCAT είναι ένα RDF λεξιλόγιο που σχεδιάσθηκε για να κάνει εφικτή τη διαλειτουργικότητα μεταξύ καταλόγων δεδομένων στον Παγκόσμιο Ιστό. Χρησιμοποιώντας το DCAT για την περιγραφή συνόλων δεδομένων, οι εκδότες αυτών αυξάνουν την ανακαλυψιμότητα και επιτρέπουν στις εφαρμογές την εύκολη κατανάλωση μεταδεδομένων από πολλαπλούς καταλόγους. Επιπλέον, δίνει τη δυνατότητα για αποκεντρωμένη έκδοση και διάθεση καταλόγων και επιτρέπει δυνατότητες ενοποιημένης αναζήτησης μεταξύ διαφορετικών πηγών. Συγκεντρωτικά μεταδεδομένα που έχουν περιγραφεί με το DCAT μπορούν να χρησιμοποιηθούν σαν ένα δηλωτικό αρχείο (manifest file) ώστε να διευκολύνουν την ψηφιακή συντήρηση.</rdfs:comment>
+    <dct:contributor rdf:parseType="Resource">
+      <foaf:name>Martin Alvarez-Espinar</foaf:name>
+    </dct:contributor>
+    <dct:contributor rdf:parseType="Resource">
+      <foaf:name>Boris Villazón-Terrazas</foaf:name>
+    </dct:contributor>
+    <rdfs:label xml:lang="ja">データ・カタログ語彙（DCAT）</rdfs:label>
+    <rdfs:comment xml:lang="it">DCAT è un vocabolario RDF progettato per facilitare l'interoperabilità tra i cataloghi di dati pubblicati nel Web. Utilizzando DCAT per descrivere i dataset nei cataloghi di dati, i fornitori migliorano la capacità di individuazione dei dati e abilitano le  applicazioni al consumo di dati provenienti da cataloghi differenti. DCAT permette di decentralizzare la pubblicazione di cataloghi e facilita la ricerca federata dei dataset. L'aggregazione dei metadati federati può fungere da file manifesto per facilitare la conservazione digitale. DCAT è definito all'indirizzo http://www.w3.org/TR/vocab-dcat/. Qualsiasi scostamento tra tale definizione normativa e questo schema è da considerarsi un errore di questo schema.</rdfs:comment>
+    <dct:creator rdf:parseType="Resource">
+      <foaf:name>John Erickson</foaf:name>
+    </dct:creator>
     <dct:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#date"
     >2021-09-14</dct:modified>
     <rdfs:label xml:lang="en">The data catalog vocabulary</rdfs:label>
@@ -270,15 +270,6 @@
     <rdfs:comment xml:lang="es">Un sitio o end-point que provee operaciones relacionadas a funciones de descubrimiento, acceso, o procesamiento de datos o recursos relacionados.</rdfs:comment>
     <rdfs:label xml:lang="es">Servicio de datos</rdfs:label>
     <skos:changeNote xml:lang="es">Nueva clase añadida en DCAT 2.0.</skos:changeNote>
-    <rdfs:subClassOf>
-      <owl:Restriction>
-        <owl:onProperty>
-          <owl:ObjectProperty rdf:about="http://www.w3.org/ns/dcat#endpointURL"/>
-        </owl:onProperty>
-        <owl:maxCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger"
-        >1</owl:maxCardinality>
-      </owl:Restriction>
-    </rdfs:subClassOf>
     <skos:definition xml:lang="it">Un sito o end-point che fornisce operazioni relative alla scoperta, all'accesso o all'elaborazione di funzioni su dati o risorse correlate.</skos:definition>
     <skos:scopeNote xml:lang="it">Il tipo di servizio può essere indicato usando la proprietà dct:type. Il suo valore può essere preso da un vocabolario controllato come il vocabolario dei tipi di servizi per dati spaziali di INSPIRE.</skos:scopeNote>
     <rdfs:label xml:lang="da">Datatjeneste</rdfs:label>
@@ -303,6 +294,11 @@
     <rdfs:label xml:lang="es">Registro del catálogo</rdfs:label>
     <rdfs:label xml:lang="it">Record di catalogo</rdfs:label>
     <skos:scopeNote xml:lang="it">Questa classe è opzionale e non tutti i cataloghi la utilizzeranno. Esiste per cataloghi in cui si opera una distinzione tra i metadati relativi al dataset ed i metadati relativi alla gestione del dataset nel catalogo. Ad esempio, la  proprietà per indicare la data di pubblicazione del dataset rifletterà la data in cui l'informazione è stata originariamente messa a disposizione dalla casa editrice, mentre la data di pubblicazione per il record nel catalogo rifletterà la data in cui il dataset è stato aggiunto al catalogo. Nei casi dove solo quest'ultima sia nota, si utilizzerà esclusivamente la data di  pubblicazione relativa al record del catalogo. Si noti che l'Ontologia W3C PROV permette di descrivere ulteriori informazioni sulla provenienza, quali i dettagli del processo, la procedura e l'agente coinvolto in una particolare modifica di un dataset.</skos:scopeNote>
+    <skos:scopeNote xml:lang="cs">Tato třída je volitelná a ne všechny katalogy ji využijí. Existuje pro katalogy, ve kterých se rozlišují metadata datové sady či datové služby a metadata o záznamu o datové sadě či datové službě v katalogu. Například datum publikace datové sady odráží datum, kdy byla datová sada původně zveřejněna poskytovatelem dat, zatímco datum publikace katalogizačního záznamu je datum zanesení datové sady do katalogu. V případech kdy se obě data liší, nebo je známo jen to druhé, by mělo být specifikováno jen datum publikace katalogizačního záznamu. Všimněte si, že ontologie W3C PROV umožňuje popsat další informace o původu jako například podrobnosti o procesu konkrétní změny datové sady a jeho účastnících.</skos:scopeNote>
+    <skos:definition xml:lang="es">Un registro en un catálogo de datos que describe un solo conjunto de datos o un servicio de datos.</skos:definition>
+    <rdfs:comment xml:lang="da">En post i et datakatalog der beskriver registreringen af et enkelt datasæt eller en datatjeneste.</rdfs:comment>
+    <skos:definition xml:lang="da">En post i et datakatalog der beskriver registreringen af et enkelt datasæt eller en datatjeneste.</skos:definition>
+    <rdfs:comment xml:lang="cs">Záznam v datovém katalogu popisující jednu datovou sadu či datovou službu.</rdfs:comment>
     <rdfs:subClassOf>
       <owl:Restriction>
         <owl:onProperty>
@@ -312,21 +308,6 @@
         >1</owl:cardinality>
       </owl:Restriction>
     </rdfs:subClassOf>
-    <skos:scopeNote xml:lang="cs">Tato třída je volitelná a ne všechny katalogy ji využijí. Existuje pro katalogy, ve kterých se rozlišují metadata datové sady či datové služby a metadata o záznamu o datové sadě či datové službě v katalogu. Například datum publikace datové sady odráží datum, kdy byla datová sada původně zveřejněna poskytovatelem dat, zatímco datum publikace katalogizačního záznamu je datum zanesení datové sady do katalogu. V případech kdy se obě data liší, nebo je známo jen to druhé, by mělo být specifikováno jen datum publikace katalogizačního záznamu. Všimněte si, že ontologie W3C PROV umožňuje popsat další informace o původu jako například podrobnosti o procesu konkrétní změny datové sady a jeho účastnících.</skos:scopeNote>
-    <rdfs:subClassOf>
-      <owl:Restriction>
-        <owl:onProperty>
-          <owl:ObjectProperty rdf:about="http://xmlns.com/foaf/0.1/primaryTopic"/>
-        </owl:onProperty>
-        <owl:allValuesFrom>
-          <owl:Class rdf:about="http://www.w3.org/ns/dcat#Resource"/>
-        </owl:allValuesFrom>
-      </owl:Restriction>
-    </rdfs:subClassOf>
-    <skos:definition xml:lang="es">Un registro en un catálogo de datos que describe un solo conjunto de datos o un servicio de datos.</skos:definition>
-    <rdfs:comment xml:lang="da">En post i et datakatalog der beskriver registreringen af et enkelt datasæt eller en datatjeneste.</rdfs:comment>
-    <skos:definition xml:lang="da">En post i et datakatalog der beskriver registreringen af et enkelt datasæt eller en datatjeneste.</skos:definition>
-    <rdfs:comment xml:lang="cs">Záznam v datovém katalogu popisující jednu datovou sadu či datovou službu.</rdfs:comment>
     <rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Class"/>
     <rdfs:comment xml:lang="fr">Un registre du catalogue ou une entrée du catalogue, décrivant un seul jeu de données.</rdfs:comment>
     <skos:definition xml:lang="ja">1つのデータセットを記述したデータ・カタログ内のレコード。</skos:definition>
@@ -341,6 +322,16 @@
     <rdfs:comment xml:lang="es">Un registro en un catálogo de datos que describe un solo conjunto de datos o un servicio de datos.</rdfs:comment>
     <skos:scopeNote xml:lang="en">This class is optional and not all catalogs will use it. It exists for catalogs where a distinction is made between metadata about a dataset or data service and metadata about the entry for the dataset or data service in the catalog. For example, the publication date property of the dataset reflects the date when the information was originally made available by the publishing agency, while the publication date of the catalog record is the date when the dataset was added to the catalog. In cases where both dates differ, or where only the latter is known, the publication date should only be specified for the catalog record. Notice that the W3C PROV Ontology allows describing further provenance information such as the details of the process and the agent involved in a particular change to a dataset.</skos:scopeNote>
     <skos:scopeNote xml:lang="el">Αυτή η κλάση είναι προαιρετική και δεν χρησιμοποιείται από όλους τους καταλόγους. Υπάρχει για τις περιπτώσεις καταλόγων όπου γίνεται διαχωρισμός μεταξύ των μεταδεδομένων για το σύνολο των δεδομένων και των μεταδεδομένων για την καταγραφή του συνόλου δεδομένων εντός του καταλόγου. Για παράδειγμα, η ιδιότητα της ημερομηνίας δημοσίευσης του συνόλου δεδομένων δείχνει την ημερομηνία κατά την οποία οι πληροφορίες έγιναν διαθέσιμες από τον φορέα δημοσίευσης, ενώ η ημερομηνία δημοσίευσης της καταγραφής του καταλόγου δείχνει την ημερομηνία που το σύνολο δεδομένων προστέθηκε στον κατάλογο. Σε περιπτώσεις που οι δύο ημερομηνίες διαφέρουν, ή που μόνο η τελευταία είναι γνωστή, η ημερομηνία δημοσίευσης θα πρέπει να δίνεται για την καταγραφή του καταλόγου. Να σημειωθεί πως η οντολογία W3C PROV επιτρέπει την περιγραφή επιπλέον πληροφοριών ιστορικού όπως λεπτομέρειες για τη διαδικασία και τον δράστη που εμπλέκονται σε μία συγκεκριμένη αλλαγή εντός του συνόλου δεδομένων.</skos:scopeNote>
+    <rdfs:subClassOf>
+      <owl:Restriction>
+        <owl:onProperty>
+          <owl:ObjectProperty rdf:about="http://xmlns.com/foaf/0.1/primaryTopic"/>
+        </owl:onProperty>
+        <owl:allValuesFrom>
+          <owl:Class rdf:about="http://www.w3.org/ns/dcat#Resource"/>
+        </owl:allValuesFrom>
+      </owl:Restriction>
+    </rdfs:subClassOf>
     <skos:scopeNote xml:lang="da">Denne klasse er valgfri og ikke alle kataloger vil anvende denne klasse. Den kan anvendes i de kataloger hvor der skelnes mellem metadata om datasættet eller datatjenesten og metadata om selve posten til registreringen af datasættet eller datatjenesten i kataloget. Udgivelsesdatoen for datasættet afspejler for eksempel den dato hvor informationerne oprindeligt blev gjort tilgængelige af udgiveren, hvorimod udgivelsesdatoen for katalogposten er den dato hvor datasættet blev føjet til kataloget. I de tilfælde hvor de to datoer er forskellige eller hvor blot sidstnævnte er kendt, bør udgivelsesdatoen kun angives for katalogposten. Bemærk at W3Cs PROV ontologi gør til muligt at tilføje yderligere proveniensoplysninger eksempelvis om processen eller aktøren involveret i en given ændring af datasættet.</skos:scopeNote>
     <skos:definition xml:lang="el">Μία καταγραφή ενός καταλόγου, η οποία περιγράφει ένα συγκεκριμένο σύνολο δεδομένων.</skos:definition>
     <rdfs:label xml:lang="fr">Registre du catalogue</rdfs:label>
@@ -398,13 +389,6 @@
     <skos:scopeNote xml:lang="es">Se usa para caracterizar la relación entre conjuntos de datos, y potencialmente otros recursos, donde la naturaleza de la relación se conoce pero no está caracterizada adecuadamente con propiedades del estándar 'Dublin Core' (dct:hasPart, dct:isPartOf, dct:conformsTo, dct:isFormatOf, dct:hasFormat, dct:isVersionOf, dct:hasVersion, dct:replaces, dct:isReplacedBy, dct:references, dct:isReferencedBy, dct:requires, dct:isRequiredBy) or PROV-O properties (prov:wasDerivedFrom, prov:wasInfluencedBy, prov:wasQuotedFrom, prov:wasRevisionOf, prov:hadPrimarySource, prov:alternateOf, prov:specializationOf).</skos:scopeNote>
     <rdfs:label xml:lang="it">Relazione</rdfs:label>
     <skos:definition xml:lang="da">En associationsklasse til brug for tilknytning af yderligere information til en relation mellem DCAT-ressourcer.</skos:definition>
-    <rdfs:subClassOf>
-      <owl:Restriction>
-        <owl:onProperty rdf:resource="http://purl.org/dc/terms/relation"/>
-        <owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger"
-        >1</owl:minCardinality>
-      </owl:Restriction>
-    </rdfs:subClassOf>
     <skos:changeNote xml:lang="cs">Nová třída přidaná ve verzi DCAT 2.0.</skos:changeNote>
     <rdfs:comment xml:lang="cs">Asociační třída pro připojení dodatečných informací ke vztahu mezi zdroji DCAT.</rdfs:comment>
     <rdfs:comment xml:lang="en">An association class for attaching additional information to a relationship between DCAT Resources.</rdfs:comment>
@@ -878,8 +862,16 @@
     <skos:changeNote xml:lang="en">New property added in DCAT 2.0.</skos:changeNote>
     <skos:definition xml:lang="da">Den funktion en entitet eller aktør har i forhold til en anden ressource.</skos:definition>
     <skos:editorialNote xml:lang="da">Introduceret i DCAT for at supplere prov:hadRole (hvis anvendelse er begrænset til roller i forbindelse med en aktivitet med domænet prov:Association).</skos:editorialNote>
-    <rdfs:comment xml:lang="it">La funzione di un'entità o un agente rispetto ad un'altra entità o risorsa.</rdfs:comment>
     <rdfs:label xml:lang="cs">sehraná role</rdfs:label>
+    <rdfs:comment xml:lang="it">La funzione di un'entità o un agente rispetto ad un'altra entità o risorsa.</rdfs:comment>
+    <rdfs:domain>
+      <owl:Class>
+        <owl:unionOf rdf:parseType="Collection">
+          <rdf:Description rdf:about="http://www.w3.org/ns/prov#Attribution"/>
+          <owl:Class rdf:about="http://www.w3.org/ns/dcat#Relationship"/>
+        </owl:unionOf>
+      </owl:Class>
+    </rdfs:domain>
     <skos:scopeNote xml:lang="it">Può essere utilizzata in una relazione qualificata per specificare il ruolo di un'entità rispetto a un'altra entità. Si raccomanda che il valore sia preso da un vocabolario controllato di ruoli di entità come ISO 19115 DS_AssociationTypeCode http://registry.it.csiro.au/def/isotc211/DS_AssociationTypeCode, IANA Registry of Link Relations https://www.iana.org/assignments/link-relation, DataCite metadata schema, o MARC relators https://id.loc.gov/vocabulary/relators.</skos:scopeNote>
     <skos:definition xml:lang="it">La funzione di un'entità o un agente rispetto ad un'altra entità o risorsa.</skos:definition>
     <skos:definition xml:lang="en">The function of an entity or agent with respect to another entity or resource.</skos:definition>
@@ -889,14 +881,6 @@
     <skos:changeNote xml:lang="es">Nueva propiedad agregada en DCAT 2.0.</skos:changeNote>
     <rdfs:label xml:lang="en">hadRole</rdfs:label>
     <skos:definition xml:lang="es">La función de una entidad o agente con respecto a otra entidad o recurso.</skos:definition>
-    <rdfs:domain>
-      <owl:Class>
-        <owl:unionOf rdf:parseType="Collection">
-          <rdf:Description rdf:about="http://www.w3.org/ns/prov#Attribution"/>
-          <owl:Class rdf:about="http://www.w3.org/ns/dcat#Relationship"/>
-        </owl:unionOf>
-      </owl:Class>
-    </rdfs:domain>
     <skos:definition xml:lang="cs">Funkce entity či agenta ve vztahu k jiné entitě či zdroji.</skos:definition>
     <skos:scopeNote xml:lang="en">May be used in a qualified-relation to specify the role of an Entity with respect to another Entity.  It is recommended that the value be taken from a controlled vocabulary of entity roles such as: ISO 19115 DS_AssociationTypeCode http://registry.it.csiro.au/def/isotc211/DS_AssociationTypeCode; IANA Registry of Link Relations https://www.iana.org/assignments/link-relation; DataCite metadata schema; MARC relators https://id.loc.gov/vocabulary/relators.</skos:scopeNote>
     <skos:editorialNote xml:lang="en">Introduced into DCAT to complement prov:hadRole (whose use is limited to roles in the context of an activity, with the domain of prov:Association.</skos:editorialNote>
@@ -1148,12 +1132,12 @@
     <rdfs:domain rdf:resource="http://www.w3.org/ns/dcat#Distribution"/>
     <skos:editorialNote xml:lang="en">rdfs:label, rdfs:comment and skos:scopeNote have been modified. Non-english versions except for Italian must be updated.</skos:editorialNote>
     <skos:scopeNote xml:lang="da">Hvis en eller flere distributioner kun er tilgængelige via en destinationsside (dvs. en URL til direkte download er ikke kendt), så bør destinationssidelinket gentages som adgangsadresse for distributionen.</skos:scopeNote>
+    <rdfs:comment xml:lang="es">Puede ser cualquier tipo de URL que de acceso a una distribución del conjunto de datos, e.g., página de destino, descarga, URL feed, punto de acceso SPARQL. Esta propriedad se debe usar cuando su catálogo de datos no tiene información sobre donde está o cuando no se puede descargar.</rdfs:comment>
+    <rdfs:label xml:lang="fr">URL d'accès</rdfs:label>
     <owl:propertyChainAxiom rdf:parseType="Collection">
       <owl:ObjectProperty rdf:about="http://www.w3.org/ns/dcat#accessService"/>
       <owl:ObjectProperty rdf:about="http://www.w3.org/ns/dcat#endpointURL"/>
     </owl:propertyChainAxiom>
-    <rdfs:comment xml:lang="es">Puede ser cualquier tipo de URL que de acceso a una distribución del conjunto de datos, e.g., página de destino, descarga, URL feed, punto de acceso SPARQL. Esta propriedad se debe usar cuando su catálogo de datos no tiene información sobre donde está o cuando no se puede descargar.</rdfs:comment>
-    <rdfs:label xml:lang="fr">URL d'accès</rdfs:label>
     <skos:definition xml:lang="it">Un URL di una risorsa che consente di accedere a una distribuzione del set di dati. Per esempio, pagina di destinazione, feed, endpoint SPARQL. Da utilizzare per tutti i casi, tranne  quando  si tratta di un semplice link per il download nel qual caso è preferito downloadURL.</skos:definition>
     <skos:scopeNote xml:lang="cs">Pokud jsou distribuce přístupné pouze přes vstupní stránku (tj. URL pro přímé stažení nejsou známa), pak by URL přístupové stránky mělo být duplikováno ve vlastnosti distribuce accessURL.</skos:scopeNote>
     <rdfs:comment xml:lang="da">En URL for en ressource som giver adgang til en repræsentation af datsættet. Fx destinationsside, feed, SPARQL-endpoint. Anvendes i alle sammenhænge undtagen til angivelse af et simpelt download link hvor anvendelse af egenskaben downloadURL foretrækkes.</rdfs:comment>

--- a/dcat/rdf/dcat2.rdf
+++ b/dcat/rdf/dcat2.rdf
@@ -16,62 +16,12 @@
     <rdfs:label xml:lang="it">Il vocabolario del catalogo dei dati</rdfs:label>
     <owl:versionInfo xml:lang="en">Questa è una copia aggiornata del vocabolario DCAT v2.0 disponibile in https://www.w3.org/ns/dcat.ttl</owl:versionInfo>
     <rdfs:comment xml:lang="da">DCAT er et RDF-vokabular som har til formål at understøtte interoperabilitet mellem datakataloger udgivet på nettet. Ved at anvende DCAT til at beskrive datasæt i datakataloger, kan udgivere øge findbarhed og gøre det gøre det lettere for applikationer at anvende metadata fra forskellige kataloger. Derudover understøttes decentraliseret udstilling af kataloger og fødererede datasætsøgninger på tværs af websider. Aggregerede DCAT-metadata kan fungere som fortegnelsesfiler der kan understøtte digital bevaring. DCAT er defineret på http://www.w3.org/TR/vocab-dcat/. Enhver forskel mellem det normative dokument og dette schema er en fejl i dette schema.</rdfs:comment>
-    <dct:contributor rdf:parseType="Resource">
-      <foaf:name>Marios Meimaris</foaf:name>
-    </dct:contributor>
     <owl:versionInfo xml:lang="en">This is an updated copy of v2.0 of the DCAT vocabulary, taken from https://www.w3.org/ns/dcat.ttl</owl:versionInfo>
     <rdfs:label xml:lang="fr">Le vocabulaire des jeux de données</rdfs:label>
-    <dct:contributor rdf:parseType="Resource">
-      <foaf:name>Andrea Perego</foaf:name>
-      <foaf:homepage rdf:resource="http://www.andrea-perego.name/foaf/#me"/>
-      <rdfs:seeAlso rdf:resource="https://orcid.org/0000-0001-9300-2694"/>
-    </dct:contributor>
-    <dct:creator rdf:parseType="Resource">
-      <foaf:name>Fadi Maali</foaf:name>
-      <rdfs:seeAlso rdf:resource="http://fadmaa.me/foaf.ttl"/>
-    </dct:creator>
-    <dct:contributor rdf:parseType="Resource">
-      <foaf:name>Riccardo Albertoni</foaf:name>
-      <foaf:homepage rdf:resource="https://w3id.org/people/ralbertoni/"/>
-      <foaf:homepage rdf:resource="http://www.imati.cnr.it/index.php/people/8-curricula/178-riccardo-albertoni"/>
-      <rdfs:seeAlso rdf:resource="https://orcid.org/0000-0001-5648-2713"/>
-    </dct:contributor>
-    <rdfs:comment xml:lang="fr">DCAT est un vocabulaire développé pour faciliter l'interopérabilité entre les jeux de données publiées sur le Web. En utilisant DCAT pour décrire les jeux de données dans les catalogues de données, les fournisseurs de données augmentent leur découverte et permettent que les applications facilement les métadonnées de plusieurs catalogues. Il permet en plus la publication décentralisée des catalogues et facilitent la recherche fédérée des données entre plusieurs sites. Les métadonnées DCAT aggrégées peuvent servir comme un manifeste pour faciliter la préservation digitale des ressources. DCAT est définie à l'adresse http://www.w3.org/TR/vocab-dcat/. Une quelconque version de ce document normatif et ce vocabulaire est une erreur dans ce vocabulaire.</rdfs:comment>
-    <rdfs:label xml:lang="es">El vocabulario de catálogo de datos</rdfs:label>
-    <owl:imports rdf:resource="http://www.w3.org/2004/02/skos/core"/>
-    <rdfs:comment xml:lang="cs">DCAT je RDF slovník navržený pro zprostředkování interoperability mezi datovými katalogy publikovanými na Webu. Poskytovatelé dat používáním slovníku DCAT pro popis datových sad v datových katalozích zvyšují jejich dohledatelnost a umožňují aplikacím konzumovat metadata z více katalogů. Dále je umožňena decentralizovaná publikace katalogů a federované dotazování na datové sady napříč katalogy. Agregovaná DCAT metadata mohou také sloužit jako průvodka umožňující digitální uchování informace. DCAT je definován na http://www.w3.org/TR/vocab-dcat/. Jakýkoliv nesoulad mezi odkazovaným dokumentem a tímto schématem je chybou v tomto schématu.</rdfs:comment>
-    <owl:versionInfo xml:lang="es">Esta es una copia del vocabulario DCAT v2.0 disponible en https://www.w3.org/ns/dcat.ttl</owl:versionInfo>
-    <dct:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#date"
-    >2012-04-24</dct:modified>
-    <rdfs:comment xml:lang="ar">هي أنطولوجية تسهل تبادل البيانات بين مختلف الفهارس على الوب. استخدام هذه الأنطولوجية يساعد على اكتشاف قوائم  البيانات المنشورة على الوب و يمكن التطبيقات المختلفة من الاستفادة أتوماتيكيا من البيانات المتاحة من مختلف الفهارس.</rdfs:comment>
-    <skos:editorialNote xml:lang="en">English language definitions updated in this revision in line with ED. Multilingual text unevenly updated.</skos:editorialNote>
     <dct:contributor rdf:parseType="Resource">
       <foaf:name>Makx Dekkers</foaf:name>
       <foaf:homepage rdf:resource="http://makxdekkers.com/"/>
       <rdfs:seeAlso rdf:resource="http://makxdekkers.com/makxdekkers.rdf#me"/>
-    </dct:contributor>
-    <rdfs:label xml:lang="da">Datakatalogvokabular</rdfs:label>
-    <dct:contributor rdf:parseType="Resource">
-      <foaf:name>Vassilios Peristeras</foaf:name>
-      <sdo:affiliation rdf:parseType="Resource">
-        <foaf:name>European Commission, DG DIGIT</foaf:name>
-        <foaf:homepage rdf:resource="http://ec.europa.eu/dgs/informatics/"/>
-      </sdo:affiliation>
-    </dct:contributor>
-    <dct:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#date"
-    >2017-12-19</dct:modified>
-    <foaf:maker rdf:parseType="Resource">
-      <foaf:name>Government Linked Data WG</foaf:name>
-      <foaf:homepage rdf:resource="http://www.w3.org/2011/gld/"/>
-    </foaf:maker>
-    <dct:contributor rdf:parseType="Resource">
-      <foaf:name>Alejandra Gonzalez-Beltran</foaf:name>
-      <foaf:homepage rdf:resource="https://agbeltran.github.io"/>
-      <rdfs:seeAlso rdf:resource="https://orcid.org/0000-0003-3499-8262"/>
-      <sdo:affiliation rdf:parseType="Resource">
-        <foaf:name>Science and Technology Facilities Council, UK</foaf:name>
-        <foaf:homepage rdf:resource="http://stfc.ac.uk"/>
-      </sdo:affiliation>
     </dct:contributor>
     <dct:contributor rdf:parseType="Resource">
       <foaf:name>David Browning</foaf:name>
@@ -81,26 +31,62 @@
       </sdo:affiliation>
     </dct:contributor>
     <dct:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#date"
-    >2013-09-20</dct:modified>
+    >2020-11-30</dct:modified>
+    <rdfs:comment xml:lang="fr">DCAT est un vocabulaire développé pour faciliter l'interopérabilité entre les jeux de données publiées sur le Web. En utilisant DCAT pour décrire les jeux de données dans les catalogues de données, les fournisseurs de données augmentent leur découverte et permettent que les applications facilement les métadonnées de plusieurs catalogues. Il permet en plus la publication décentralisée des catalogues et facilitent la recherche fédérée des données entre plusieurs sites. Les métadonnées DCAT aggrégées peuvent servir comme un manifeste pour faciliter la préservation digitale des ressources. DCAT est définie à l'adresse http://www.w3.org/TR/vocab-dcat/. Une quelconque version de ce document normatif et ce vocabulaire est une erreur dans ce vocabulaire.</rdfs:comment>
+    <dct:creator rdf:parseType="Resource">
+      <foaf:name>John Erickson</foaf:name>
+    </dct:creator>
+    <rdfs:label xml:lang="es">El vocabulario de catálogo de datos</rdfs:label>
+    <owl:imports rdf:resource="http://www.w3.org/2004/02/skos/core"/>
+    <rdfs:comment xml:lang="cs">DCAT je RDF slovník navržený pro zprostředkování interoperability mezi datovými katalogy publikovanými na Webu. Poskytovatelé dat používáním slovníku DCAT pro popis datových sad v datových katalozích zvyšují jejich dohledatelnost a umožňují aplikacím konzumovat metadata z více katalogů. Dále je umožňena decentralizovaná publikace katalogů a federované dotazování na datové sady napříč katalogy. Agregovaná DCAT metadata mohou také sloužit jako průvodka umožňující digitální uchování informace. DCAT je definován na http://www.w3.org/TR/vocab-dcat/. Jakýkoliv nesoulad mezi odkazovaným dokumentem a tímto schématem je chybou v tomto schématu.</rdfs:comment>
+    <dct:contributor rdf:parseType="Resource">
+      <foaf:name>Marios Meimaris</foaf:name>
+    </dct:contributor>
+    <owl:versionInfo xml:lang="es">Esta es una copia del vocabulario DCAT v2.0 disponible en https://www.w3.org/ns/dcat.ttl</owl:versionInfo>
+    <dct:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#date"
+    >2012-04-24</dct:modified>
+    <rdfs:comment xml:lang="ar">هي أنطولوجية تسهل تبادل البيانات بين مختلف الفهارس على الوب. استخدام هذه الأنطولوجية يساعد على اكتشاف قوائم  البيانات المنشورة على الوب و يمكن التطبيقات المختلفة من الاستفادة أتوماتيكيا من البيانات المتاحة من مختلف الفهارس.</rdfs:comment>
+    <skos:editorialNote xml:lang="en">English language definitions updated in this revision in line with ED. Multilingual text unevenly updated.</skos:editorialNote>
+    <dct:contributor rdf:parseType="Resource">
+      <foaf:name>Phil Archer</foaf:name>
+      <foaf:homepage rdf:resource="http://www.w3.org/People/all#phila"/>
+      <rdfs:seeAlso rdf:resource="http://philarcher.org/foaf.rdf#me"/>
+      <sdo:affiliation rdf:resource="http://www.w3.org/data#W3C"/>
+    </dct:contributor>
     <dct:contributor rdf:parseType="Resource">
       <foaf:name>Shuji Kamitsuna</foaf:name>
       <foaf:homepage rdf:resource="http://www.asahi-net.or.jp/~ax2s-kmtn/"/>
+    </dct:contributor>
+    <rdfs:label xml:lang="da">Datakatalogvokabular</rdfs:label>
+    <dct:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#date"
+    >2017-12-19</dct:modified>
+    <dct:contributor rdf:parseType="Resource">
+      <foaf:name>Martin Alvarez-Espinar</foaf:name>
+    </dct:contributor>
+    <foaf:maker rdf:parseType="Resource">
+      <foaf:name>Government Linked Data WG</foaf:name>
+      <foaf:homepage rdf:resource="http://www.w3.org/2011/gld/"/>
+    </foaf:maker>
+    <dct:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#date"
+    >2013-09-20</dct:modified>
+    <dct:contributor rdf:parseType="Resource">
+      <foaf:name>Vassilios Peristeras</foaf:name>
+      <sdo:affiliation rdf:parseType="Resource">
+        <foaf:name>European Commission, DG DIGIT</foaf:name>
+        <foaf:homepage rdf:resource="http://ec.europa.eu/dgs/informatics/"/>
+      </sdo:affiliation>
     </dct:contributor>
     <owl:imports rdf:resource="http://www.w3.org/ns/prov-o#"/>
     <rdfs:comment xml:lang="ja">DCATは、ウェブ上で公開されたデータ・カタログ間の相互運用性の促進を目的とするRDFの語彙です。このドキュメントでは、その利用のために、スキーマを定義し、例を提供します。データ・カタログ内のデータセットを記述するためにDCATを用いると、公開者が、発見可能性を増加させ、アプリケーションが複数のカタログのメタデータを容易に利用できるようになります。さらに、カタログの分散公開を可能にし、複数のサイトにまたがるデータセットの統合検索を促進します。集約されたDCATメタデータは、ディジタル保存を促進するためのマニフェスト・ファイルとして使用できます。</rdfs:comment>
     <rdfs:comment xml:lang="en">DCAT is an RDF vocabulary designed to facilitate interoperability between data catalogs published on the Web. By using DCAT to describe datasets in data catalogs, publishers increase discoverability and enable applications easily to consume metadata from multiple catalogs. It further enables decentralized publishing of catalogs and facilitates federated dataset search across sites. Aggregated DCAT metadata can serve as a manifest file to facilitate digital preservation. DCAT is defined at http://www.w3.org/TR/vocab-dcat/. Any variance between that normative document and this schema is an error in this schema.</rdfs:comment>
     <owl:versionInfo xml:lang="da">Dette er en opdateret kopi af DCAT v. 2.0 som er tilgænglig på https://www.w3.org/ns/dcat.ttl</owl:versionInfo>
-    <dct:contributor rdf:parseType="Resource">
-      <foaf:name>Martin Alvarez-Espinar</foaf:name>
-    </dct:contributor>
     <dct:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#date"
     >2013-11-28</dct:modified>
-    <dct:creator rdf:parseType="Resource">
-      <foaf:name>John Erickson</foaf:name>
-    </dct:creator>
     <dct:modified>2019</dct:modified>
-    <dct:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#date"
-    >2020-11-30</dct:modified>
+    <dct:contributor rdf:parseType="Resource">
+      <foaf:name>Ghislain Auguste Atemezing</foaf:name>
+      <rdfs:seeAlso rdf:resource="http://www.eurecom.fr/~atemezin/gatemezing-foaf.rdf"/>
+    </dct:contributor>
     <dct:license rdf:resource="https://creativecommons.org/licenses/by/4.0/"/>
     <owl:imports rdf:resource="http://purl.org/dc/terms/"/>
     <dct:contributor>
@@ -114,9 +100,27 @@
         </sdo:affiliation>
       </foaf:Person>
     </dct:contributor>
+    <dct:creator rdf:parseType="Resource">
+      <foaf:name>Fadi Maali</foaf:name>
+      <rdfs:seeAlso rdf:resource="http://fadmaa.me/foaf.ttl"/>
+    </dct:creator>
+    <dct:contributor rdf:parseType="Resource">
+      <foaf:name>Andrea Perego</foaf:name>
+      <foaf:homepage rdf:resource="http://www.andrea-perego.name/foaf/#me"/>
+      <rdfs:seeAlso rdf:resource="https://orcid.org/0000-0001-9300-2694"/>
+    </dct:contributor>
     <rdfs:comment xml:lang="es">DCAT es un vocabulario RDF diseñado para facilitar la interoperabilidad entre catálogos de datos publicados en la Web. Utilizando DCAT para describir datos disponibles en catálogos se aumenta la posibilidad de que sean descubiertos y se permite que las aplicaciones consuman fácilmente los metadatos de varios catálogos.</rdfs:comment>
+    <dct:contributor rdf:parseType="Resource">
+      <foaf:name>Richard Cyganiak</foaf:name>
+    </dct:contributor>
     <rdfs:label xml:lang="ar">أنطولوجية فهارس قوائم البيانات</rdfs:label>
     <rdfs:label xml:lang="el">Το λεξιλόγιο των καταλόγων δεδομένων</rdfs:label>
+    <dct:contributor rdf:parseType="Resource">
+      <foaf:name>Riccardo Albertoni</foaf:name>
+      <foaf:homepage rdf:resource="https://w3id.org/people/ralbertoni/"/>
+      <foaf:homepage rdf:resource="http://www.imati.cnr.it/index.php/people/8-curricula/178-riccardo-albertoni"/>
+      <rdfs:seeAlso rdf:resource="https://orcid.org/0000-0001-5648-2713"/>
+    </dct:contributor>
     <dct:contributor rdf:parseType="Resource">
       <foaf:name>Jakub Klímek</foaf:name>
       <foaf:homepage rdf:resource="https://jakub.klímek.com/"/>
@@ -124,16 +128,6 @@
     </dct:contributor>
     <owl:versionInfo xml:lang="cs">Toto je aktualizovaná kopie slovníku DCAT verze 2.0, převzatá z https://www.w3.org/ns/dcat.ttl</owl:versionInfo>
     <rdfs:comment xml:lang="el">Το DCAT είναι ένα RDF λεξιλόγιο που σχεδιάσθηκε για να κάνει εφικτή τη διαλειτουργικότητα μεταξύ καταλόγων δεδομένων στον Παγκόσμιο Ιστό. Χρησιμοποιώντας το DCAT για την περιγραφή συνόλων δεδομένων, οι εκδότες αυτών αυξάνουν την ανακαλυψιμότητα και επιτρέπουν στις εφαρμογές την εύκολη κατανάλωση μεταδεδομένων από πολλαπλούς καταλόγους. Επιπλέον, δίνει τη δυνατότητα για αποκεντρωμένη έκδοση και διάθεση καταλόγων και επιτρέπει δυνατότητες ενοποιημένης αναζήτησης μεταξύ διαφορετικών πηγών. Συγκεντρωτικά μεταδεδομένα που έχουν περιγραφεί με το DCAT μπορούν να χρησιμοποιηθούν σαν ένα δηλωτικό αρχείο (manifest file) ώστε να διευκολύνουν την ψηφιακή συντήρηση.</rdfs:comment>
-    <rdfs:label xml:lang="ja">データ・カタログ語彙（DCAT）</rdfs:label>
-    <dct:contributor rdf:parseType="Resource">
-      <foaf:name>Richard Cyganiak</foaf:name>
-    </dct:contributor>
-    <dct:contributor rdf:parseType="Resource">
-      <foaf:name>Phil Archer</foaf:name>
-      <foaf:homepage rdf:resource="http://www.w3.org/People/all#phila"/>
-      <rdfs:seeAlso rdf:resource="http://philarcher.org/foaf.rdf#me"/>
-      <sdo:affiliation rdf:resource="http://www.w3.org/data#W3C"/>
-    </dct:contributor>
     <dct:contributor rdf:parseType="Resource">
       <foaf:name>Rufus Pollock</foaf:name>
       <sdo:affiliation rdf:parseType="Resource">
@@ -141,14 +135,22 @@
         <foaf:homepage rdf:resource="http://okfn.org"/>
       </sdo:affiliation>
     </dct:contributor>
-    <rdfs:comment xml:lang="it">DCAT è un vocabolario RDF progettato per facilitare l'interoperabilità tra i cataloghi di dati pubblicati nel Web. Utilizzando DCAT per descrivere i dataset nei cataloghi di dati, i fornitori migliorano la capacità di individuazione dei dati e abilitano le  applicazioni al consumo di dati provenienti da cataloghi differenti. DCAT permette di decentralizzare la pubblicazione di cataloghi e facilita la ricerca federata dei dataset. L'aggregazione dei metadati federati può fungere da file manifesto per facilitare la conservazione digitale. DCAT è definito all'indirizzo http://www.w3.org/TR/vocab-dcat/. Qualsiasi scostamento tra tale definizione normativa e questo schema è da considerarsi un errore di questo schema.</rdfs:comment>
+    <rdfs:label xml:lang="ja">データ・カタログ語彙（DCAT）</rdfs:label>
     <dct:contributor rdf:parseType="Resource">
       <foaf:name>Boris Villazón-Terrazas</foaf:name>
     </dct:contributor>
+    <rdfs:comment xml:lang="it">DCAT è un vocabolario RDF progettato per facilitare l'interoperabilità tra i cataloghi di dati pubblicati nel Web. Utilizzando DCAT per descrivere i dataset nei cataloghi di dati, i fornitori migliorano la capacità di individuazione dei dati e abilitano le  applicazioni al consumo di dati provenienti da cataloghi differenti. DCAT permette di decentralizzare la pubblicazione di cataloghi e facilita la ricerca federata dei dataset. L'aggregazione dei metadati federati può fungere da file manifesto per facilitare la conservazione digitale. DCAT è definito all'indirizzo http://www.w3.org/TR/vocab-dcat/. Qualsiasi scostamento tra tale definizione normativa e questo schema è da considerarsi un errore di questo schema.</rdfs:comment>
     <dct:contributor rdf:parseType="Resource">
-      <foaf:name>Ghislain Auguste Atemezing</foaf:name>
-      <rdfs:seeAlso rdf:resource="http://www.eurecom.fr/~atemezin/gatemezing-foaf.rdf"/>
+      <foaf:name>Alejandra Gonzalez-Beltran</foaf:name>
+      <foaf:homepage rdf:resource="https://agbeltran.github.io"/>
+      <rdfs:seeAlso rdf:resource="https://orcid.org/0000-0003-3499-8262"/>
+      <sdo:affiliation rdf:parseType="Resource">
+        <foaf:name>Science and Technology Facilities Council, UK</foaf:name>
+        <foaf:homepage rdf:resource="http://stfc.ac.uk"/>
+      </sdo:affiliation>
     </dct:contributor>
+    <dct:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#date"
+    >2021-09-14</dct:modified>
     <rdfs:label xml:lang="en">The data catalog vocabulary</rdfs:label>
   </owl:Ontology>
   <rdfs:Class rdf:about="http://www.w3.org/ns/dcat#Dataset">
@@ -204,6 +206,46 @@
     <rdfs:comment xml:lang="da">En samling af data, udgivet eller udvalgt og arrangeret af en enkelt kilde og som er til råde for adgang til eller download af i en eller flere repræsentationer.</rdfs:comment>
     <skos:altLabel xml:lang="da">Datasamling</skos:altLabel>
   </rdfs:Class>
+  <rdfs:Class rdf:about="http://www.w3.org/ns/dcat#Catalog">
+    <skos:definition xml:lang="ja">データ・カタログは、データセットに関するキュレートされたメタデータの集合です。</skos:definition>
+    <skos:scopeNote xml:lang="es">Normalmente, un catálogo de datos disponible en la web se representa como una única instancia de esta clase.</skos:scopeNote>
+    <skos:definition xml:lang="cs">Řízená kolekce metadat o datových sadách a datových službách.</skos:definition>
+    <skos:definition xml:lang="it">Una raccolta curata di metadati sulle risorse (ad es. sui dataset e relativi servizi nel contesto di cataloghi di dati).</skos:definition>
+    <rdfs:label xml:lang="da">Katalog</rdfs:label>
+    <rdfs:label xml:lang="cs">Katalog</rdfs:label>
+    <rdfs:label xml:lang="el">Κατάλογος</rdfs:label>
+    <rdfs:label xml:lang="it">Catalogo</rdfs:label>
+    <rdfs:isDefinedBy rdf:resource="http://www.w3.org/TR/vocab-dcat/"/>
+    <rdfs:comment xml:lang="en">A curated collection of metadata about resources (e.g., datasets and data services in the context of a data catalog).</rdfs:comment>
+    <skos:definition xml:lang="ar">مجموعة من توصيفات قوائم البيانات</skos:definition>
+    <skos:editorialNote xml:lang="en">English, Italian, Spanish definitions updated in this revision. Multilingual text not yet updated.</skos:editorialNote>
+    <skos:definition xml:lang="es">Una colección curada de metadatos sobre recursos (por ejemplo, conjuntos de datos y servicios de datos en el contexto de un catálogo de datos).</skos:definition>
+    <rdfs:comment xml:lang="it">Una raccolta curata di metadati sulle risorse (ad es. sui dataset e relativi servizi nel contesto di cataloghi di dati).</rdfs:comment>
+    <skos:scopeNote xml:lang="da">Et webbaseret datakatalog repræsenteres typisk ved en enkelt instans af denne klasse.</skos:scopeNote>
+    <skos:definition xml:lang="el">Μια επιμελημένη συλλογή μεταδεδομένων περί συνόλων δεδομένων.</skos:definition>
+    <skos:definition xml:lang="fr">Une collection élaborée de métadonnées sur les jeux de données.</skos:definition>
+    <rdfs:comment xml:lang="cs">Řízená kolekce metadat o datových sadách a datových službách</rdfs:comment>
+    <skos:scopeNote xml:lang="el">Συνήθως, ένας κατάλογος δεδομένων στον Παγκόσμιο Ιστό αναπαρίσταται ως ένα στιγμιότυπο αυτής της κλάσης.</skos:scopeNote>
+    <rdfs:subClassOf rdf:resource="http://www.w3.org/ns/dcat#Dataset"/>
+    <rdfs:comment xml:lang="es">Una colección curada de metadatos sobre recursos (por ejemplo, conjuntos de datos y servicios de datos en el contexto de un catálogo de datos).</rdfs:comment>
+    <skos:scopeNote xml:lang="cs">Webový datový katalog je typicky reprezentován jako jedna instance této třídy.</skos:scopeNote>
+    <skos:definition xml:lang="da">En samling af metadata om ressourcer (fx datasæt og datatjenester i kontekst af et datakatalog).</skos:definition>
+    <rdfs:label xml:lang="ar">فهرس قوائم البيانات</rdfs:label>
+    <rdfs:label xml:lang="ja">カタログ</rdfs:label>
+    <rdfs:label xml:lang="es">Catálogo</rdfs:label>
+    <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
+    <skos:scopeNote xml:lang="en">A web-based data catalog is typically represented as a single instance of this class.</skos:scopeNote>
+    <skos:definition xml:lang="en">A curated collection of metadata about resources (e.g., datasets and data services in the context of a data catalog).</skos:definition>
+    <rdfs:label xml:lang="en">Catalog</rdfs:label>
+    <rdfs:comment xml:lang="el">Μια επιμελημένη συλλογή μεταδεδομένων περί συνόλων δεδομένων</rdfs:comment>
+    <rdfs:comment xml:lang="fr">Une collection élaborée de métadonnées sur les jeux de données</rdfs:comment>
+    <skos:scopeNote xml:lang="it">Normalmente, un catalogo di dati nel web viene rappresentato come una singola istanza di questa classe.</skos:scopeNote>
+    <rdfs:label xml:lang="fr">Catalogue</rdfs:label>
+    <rdfs:comment xml:lang="ar">مجموعة من توصيفات قوائم البيانات</rdfs:comment>
+    <rdfs:comment xml:lang="da">En udvalgt og arrangeret samling af metadata om ressourcer (fx datasæt og datatjenester i kontekst af et datakatalog). </rdfs:comment>
+    <rdfs:comment xml:lang="ja">データ・カタログは、データセットに関するキュレートされたメタデータの集合です。</rdfs:comment>
+    <skos:scopeNote xml:lang="ja">通常、ウェブ・ベースのデータ・カタログは、このクラスの1つのインスタンスとして表わされます。</skos:scopeNote>
+  </rdfs:Class>
   <owl:Class rdf:about="http://www.w3.org/ns/dcat#DataService">
     <skos:scopeNote xml:lang="cs">Pokud je dcat:DataService navázána na jednu či více Datových sad, jsou tyto indikovány vlstností dcat:servesDataset.</skos:scopeNote>
     <skos:definition xml:lang="es">Un sitio o end-point que provee operaciones relacionadas a funciones de descubrimiento, acceso, o procesamiento de datos o recursos relacionados.</skos:definition>
@@ -223,6 +265,11 @@
     <rdfs:label xml:lang="en">Data service</rdfs:label>
     <rdfs:comment xml:lang="da">Et websted eller endpoint der udstiller operationer relateret til opdagelse af, adgang til eller behandlende funktioner på data eller relaterede ressourcer.</rdfs:comment>
     <skos:changeNote xml:lang="da">Ny klasse tilføjet i DCAT 2.0.</skos:changeNote>
+    <skos:scopeNote xml:lang="en">If a dcat:DataService is bound to one or more specified Datasets, they are indicated by the dcat:servesDataset property.</skos:scopeNote>
+    <skos:scopeNote xml:lang="es">Si un dcat:DataService está asociado con uno o más conjuntos de datos especificados, dichos conjuntos de datos pueden indicarse con la propiedad dcat:servesDataset.</skos:scopeNote>
+    <rdfs:comment xml:lang="es">Un sitio o end-point que provee operaciones relacionadas a funciones de descubrimiento, acceso, o procesamiento de datos o recursos relacionados.</rdfs:comment>
+    <rdfs:label xml:lang="es">Servicio de datos</rdfs:label>
+    <skos:changeNote xml:lang="es">Nueva clase añadida en DCAT 2.0.</skos:changeNote>
     <rdfs:subClassOf>
       <owl:Restriction>
         <owl:onProperty>
@@ -232,11 +279,6 @@
         >1</owl:maxCardinality>
       </owl:Restriction>
     </rdfs:subClassOf>
-    <skos:scopeNote xml:lang="en">If a dcat:DataService is bound to one or more specified Datasets, they are indicated by the dcat:servesDataset property.</skos:scopeNote>
-    <skos:scopeNote xml:lang="es">Si un dcat:DataService está asociado con uno o más conjuntos de datos especificados, dichos conjuntos de datos pueden indicarse con la propiedad dcat:servesDataset.</skos:scopeNote>
-    <rdfs:comment xml:lang="es">Un sitio o end-point que provee operaciones relacionadas a funciones de descubrimiento, acceso, o procesamiento de datos o recursos relacionados.</rdfs:comment>
-    <rdfs:label xml:lang="es">Servicio de datos</rdfs:label>
-    <skos:changeNote xml:lang="es">Nueva clase añadida en DCAT 2.0.</skos:changeNote>
     <skos:definition xml:lang="it">Un sito o end-point che fornisce operazioni relative alla scoperta, all'accesso o all'elaborazione di funzioni su dati o risorse correlate.</skos:definition>
     <skos:scopeNote xml:lang="it">Il tipo di servizio può essere indicato usando la proprietà dct:type. Il suo valore può essere preso da un vocabolario controllato come il vocabolario dei tipi di servizi per dati spaziali di INSPIRE.</skos:scopeNote>
     <rdfs:label xml:lang="da">Datatjeneste</rdfs:label>
@@ -253,6 +295,14 @@
     <skos:scopeNote xml:lang="ja">このクラスはオプションで、すべてのカタログがそれを用いるとは限りません。これは、データセットに関するメタデータとカタログ内のデータセットのエントリーに関するメタデータとで区別が行われるカタログのために存在しています。例えば、データセットの公開日プロパティーは、公開機関が情報を最初に利用可能とした日付を示しますが、カタログ・レコードの公開日は、データセットがカタログに追加された日付です。両方の日付が異っていたり、後者だけが分かっている場合は、カタログ・レコードに対してのみ公開日を指定すべきです。W3CのPROVオントロジー[prov-o]を用いれば、データセットに対する特定の変更に関連するプロセスやエージェントの詳細などの、さらに詳しい来歴情報の記述が可能となることに注意してください。</skos:scopeNote>
     <rdfs:label xml:lang="ja">カタログ・レコード</rdfs:label>
     <rdfs:label xml:lang="el">Καταγραφή καταλόγου</rdfs:label>
+    <skos:definition xml:lang="it">Un record in un catalogo di dati che descrive un singolo dataset o servizio di dati.</skos:definition>
+    <rdfs:comment xml:lang="en">A record in a data catalog, describing the registration of a single dataset or data service.</rdfs:comment>
+    <rdfs:comment xml:lang="ja">1つのデータセットを記述したデータ・カタログ内のレコード。</rdfs:comment>
+    <rdfs:label xml:lang="ar">سجل</rdfs:label>
+    <skos:definition xml:lang="cs">Záznam v datovém katalogu popisující jednu datovou sadu či datovou službu.</skos:definition>
+    <rdfs:label xml:lang="es">Registro del catálogo</rdfs:label>
+    <rdfs:label xml:lang="it">Record di catalogo</rdfs:label>
+    <skos:scopeNote xml:lang="it">Questa classe è opzionale e non tutti i cataloghi la utilizzeranno. Esiste per cataloghi in cui si opera una distinzione tra i metadati relativi al dataset ed i metadati relativi alla gestione del dataset nel catalogo. Ad esempio, la  proprietà per indicare la data di pubblicazione del dataset rifletterà la data in cui l'informazione è stata originariamente messa a disposizione dalla casa editrice, mentre la data di pubblicazione per il record nel catalogo rifletterà la data in cui il dataset è stato aggiunto al catalogo. Nei casi dove solo quest'ultima sia nota, si utilizzerà esclusivamente la data di  pubblicazione relativa al record del catalogo. Si noti che l'Ontologia W3C PROV permette di descrivere ulteriori informazioni sulla provenienza, quali i dettagli del processo, la procedura e l'agente coinvolto in una particolare modifica di un dataset.</skos:scopeNote>
     <rdfs:subClassOf>
       <owl:Restriction>
         <owl:onProperty>
@@ -262,14 +312,6 @@
         >1</owl:cardinality>
       </owl:Restriction>
     </rdfs:subClassOf>
-    <skos:definition xml:lang="it">Un record in un catalogo di dati che descrive un singolo dataset o servizio di dati.</skos:definition>
-    <rdfs:comment xml:lang="en">A record in a data catalog, describing the registration of a single dataset or data service.</rdfs:comment>
-    <rdfs:comment xml:lang="ja">1つのデータセットを記述したデータ・カタログ内のレコード。</rdfs:comment>
-    <rdfs:label xml:lang="ar">سجل</rdfs:label>
-    <skos:definition xml:lang="cs">Záznam v datovém katalogu popisující jednu datovou sadu či datovou službu.</skos:definition>
-    <rdfs:label xml:lang="es">Registro del catálogo</rdfs:label>
-    <rdfs:label xml:lang="it">Record di catalogo</rdfs:label>
-    <skos:scopeNote xml:lang="it">Questa classe è opzionale e non tutti i cataloghi la utilizzeranno. Esiste per cataloghi in cui si opera una distinzione tra i metadati relativi al dataset ed i metadati relativi alla gestione del dataset nel catalogo. Ad esempio, la  proprietà per indicare la data di pubblicazione del dataset rifletterà la data in cui l'informazione è stata originariamente messa a disposizione dalla casa editrice, mentre la data di pubblicazione per il record nel catalogo rifletterà la data in cui il dataset è stato aggiunto al catalogo. Nei casi dove solo quest'ultima sia nota, si utilizzerà esclusivamente la data di  pubblicazione relativa al record del catalogo. Si noti che l'Ontologia W3C PROV permette di descrivere ulteriori informazioni sulla provenienza, quali i dettagli del processo, la procedura e l'agente coinvolto in una particolare modifica di un dataset.</skos:scopeNote>
     <skos:scopeNote xml:lang="cs">Tato třída je volitelná a ne všechny katalogy ji využijí. Existuje pro katalogy, ve kterých se rozlišují metadata datové sady či datové služby a metadata o záznamu o datové sadě či datové službě v katalogu. Například datum publikace datové sady odráží datum, kdy byla datová sada původně zveřejněna poskytovatelem dat, zatímco datum publikace katalogizačního záznamu je datum zanesení datové sady do katalogu. V případech kdy se obě data liší, nebo je známo jen to druhé, by mělo být specifikováno jen datum publikace katalogizačního záznamu. Všimněte si, že ontologie W3C PROV umožňuje popsat další informace o původu jako například podrobnosti o procesu konkrétní změny datové sady a jeho účastnících.</skos:scopeNote>
     <rdfs:subClassOf>
       <owl:Restriction>
@@ -348,13 +390,7 @@
     <rdfs:comment xml:lang="it">Un ruolo è la funzione di una risorsa o di un agente rispetto ad un'altra risorsa, nel contesto dell'attribuzione delle risorse o delle relazioni tra risorse.</rdfs:comment>
   </owl:Class>
   <owl:Class rdf:about="http://www.w3.org/ns/dcat#Relationship">
-    <rdfs:subClassOf>
-      <owl:Restriction>
-        <owl:onProperty rdf:resource="http://purl.org/dc/terms/relation"/>
-        <owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger"
-        >1</owl:minCardinality>
-      </owl:Restriction>
-    </rdfs:subClassOf>
+    <skos:definition xml:lang="en">An association class for attaching additional information to a relationship between DCAT Resources.</skos:definition>
     <skos:changeNote xml:lang="it">Nuova classe aggiunta in DCAT 2.0.</skos:changeNote>
     <rdfs:comment xml:lang="es">Una clase de asociación para adjuntar información adicional a una relación entre recursos DCAT.</rdfs:comment>
     <skos:changeNote xml:lang="es">Nueva clase añadida en DCAT 2.0.</skos:changeNote>
@@ -362,6 +398,13 @@
     <skos:scopeNote xml:lang="es">Se usa para caracterizar la relación entre conjuntos de datos, y potencialmente otros recursos, donde la naturaleza de la relación se conoce pero no está caracterizada adecuadamente con propiedades del estándar 'Dublin Core' (dct:hasPart, dct:isPartOf, dct:conformsTo, dct:isFormatOf, dct:hasFormat, dct:isVersionOf, dct:hasVersion, dct:replaces, dct:isReplacedBy, dct:references, dct:isReferencedBy, dct:requires, dct:isRequiredBy) or PROV-O properties (prov:wasDerivedFrom, prov:wasInfluencedBy, prov:wasQuotedFrom, prov:wasRevisionOf, prov:hadPrimarySource, prov:alternateOf, prov:specializationOf).</skos:scopeNote>
     <rdfs:label xml:lang="it">Relazione</rdfs:label>
     <skos:definition xml:lang="da">En associationsklasse til brug for tilknytning af yderligere information til en relation mellem DCAT-ressourcer.</skos:definition>
+    <rdfs:subClassOf>
+      <owl:Restriction>
+        <owl:onProperty rdf:resource="http://purl.org/dc/terms/relation"/>
+        <owl:minCardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger"
+        >1</owl:minCardinality>
+      </owl:Restriction>
+    </rdfs:subClassOf>
     <skos:changeNote xml:lang="cs">Nová třída přidaná ve verzi DCAT 2.0.</skos:changeNote>
     <rdfs:comment xml:lang="cs">Asociační třída pro připojení dodatečných informací ke vztahu mezi zdroji DCAT.</rdfs:comment>
     <rdfs:comment xml:lang="en">An association class for attaching additional information to a relationship between DCAT Resources.</rdfs:comment>
@@ -379,7 +422,6 @@
     <rdfs:comment xml:lang="it">Una classe di associazione per il collegamento di informazioni aggiuntive a una relazione tra le risorse DCAT.</rdfs:comment>
     <skos:scopeNote xml:lang="it">Viene utilizzato per caratterizzare la relazione tra insiemi di dati, e potenzialmente altri tipi di risorse, nei casi in cui la natura della relazione è nota ma non adeguatamente caratterizzata dalle proprietà dello standard 'Dublin Core' (dct:hasPart, dct:isPartOf, dct:conformsTo, dct:isFormatOf, dct:hasFormat, dct:isVersionOf, dct:hasVersion, dct:replaces, dct:isReplacedBy, dct:references, dct:isReferencedBy, dct:require, dct:isRequiredBy) o dalle propietà fornite da PROV-O  (prov:wasDerivedFrom, prov:wasInfluencedBy, prov:wasQuotedFrom, prov:wasRevisionOf, prov: hadPrimarySource, prov:alternateOf, prov:specializationOf).</skos:scopeNote>
     <rdfs:label xml:lang="en">Relationship</rdfs:label>
-    <skos:definition xml:lang="en">An association class for attaching additional information to a relationship between DCAT Resources.</skos:definition>
   </owl:Class>
   <owl:Class rdf:about="http://www.w3.org/ns/dcat#Resource">
     <rdfs:label xml:lang="cs">Katalogizovaný zdroj</rdfs:label>
@@ -412,52 +454,6 @@
     <skos:changeNote xml:lang="es">Nueva clase agregada en DCAT 2.0.</skos:changeNote>
     <rdfs:comment xml:lang="cs">Zdroj publikovaný či řízený jediným činitelem.</rdfs:comment>
     <rdfs:comment xml:lang="en">Resource published or curated by a single agent.</rdfs:comment>
-  </owl:Class>
-  <owl:Class rdf:about="http://www.w3.org/ns/dcat#Catalog">
-    <rdfs:isDefinedBy rdf:resource="http://www.w3.org/TR/vocab-dcat/"/>
-    <rdfs:subClassOf rdf:resource="http://www.w3.org/ns/dcat#Dataset"/>
-    <rdfs:comment xml:lang="it">Una raccolta curata di metadati sulle risorse (ad es. sui dataset e relativi servizi nel contesto di cataloghi di dati).</rdfs:comment>
-    <rdfs:label xml:lang="es">Catálogo</rdfs:label>
-    <rdfs:label xml:lang="ar">فهرس قوائم البيانات</rdfs:label>
-    <rdfs:comment xml:lang="da">En udvalgt og arrangeret samling af metadata om ressourcer (fx datasæt og datatjenester i kontekst af et datakatalog). </rdfs:comment>
-    <skos:definition xml:lang="el">Μια επιμελημένη συλλογή μεταδεδομένων περί συνόλων δεδομένων.</skos:definition>
-    <rdfs:label xml:lang="it">Catalogo</rdfs:label>
-    <rdfs:label xml:lang="cs">Katalog</rdfs:label>
-    <rdfs:label xml:lang="da">Katalog</rdfs:label>
-    <skos:definition xml:lang="fr">Une collection élaborée de métadonnées sur les jeux de données.</skos:definition>
-    <rdfs:comment xml:lang="ja">データ・カタログは、データセットに関するキュレートされたメタデータの集合です。</rdfs:comment>
-    <rdfs:label xml:lang="el">Κατάλογος</rdfs:label>
-    <skos:definition xml:lang="ja">データ・カタログは、データセットに関するキュレートされたメタデータの集合です。</skos:definition>
-    <skos:scopeNote xml:lang="es">Normalmente, un catálogo de datos disponible en la web se representa como una única instancia de esta clase.</skos:scopeNote>
-    <rdfs:comment xml:lang="es">Una colección curada de metadatos sobre recursos (por ejemplo, conjuntos de datos y servicios de datos en el contexto de un catálogo de datos).</rdfs:comment>
-    <skos:scopeNote xml:lang="cs">Webový datový katalog je typicky reprezentován jako jedna instance této třídy.</skos:scopeNote>
-    <skos:definition xml:lang="it">Una raccolta curata di metadati sulle risorse (ad es. sui dataset e relativi servizi nel contesto di cataloghi di dati).</skos:definition>
-    <skos:scopeNote xml:lang="it">Normalmente, un catalogo di dati nel web viene rappresentato come una singola istanza di questa classe.</skos:scopeNote>
-    <rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Class"/>
-    <skos:definition xml:lang="es">Una colección curada de metadatos sobre recursos (por ejemplo, conjuntos de datos y servicios de datos en el contexto de un catálogo de datos).</skos:definition>
-    <skos:definition xml:lang="cs">Řízená kolekce metadat o datových sadách a datových službách.</skos:definition>
-    <rdfs:comment xml:lang="fr">Une collection élaborée de métadonnées sur les jeux de données</rdfs:comment>
-    <skos:scopeNote xml:lang="da">Et webbaseret datakatalog repræsenteres typisk ved en enkelt instans af denne klasse.</skos:scopeNote>
-    <skos:scopeNote xml:lang="en">A web-based data catalog is typically represented as a single instance of this class.</skos:scopeNote>
-    <rdfs:label xml:lang="ja">カタログ</rdfs:label>
-    <rdfs:label xml:lang="en">Catalog</rdfs:label>
-    <skos:editorialNote xml:lang="en">English, Italian, Spanish definitions updated in this revision. Multilingual text not yet updated.</skos:editorialNote>
-    <skos:scopeNote xml:lang="ja">通常、ウェブ・ベースのデータ・カタログは、このクラスの1つのインスタンスとして表わされます。</skos:scopeNote>
-    <rdfs:label xml:lang="fr">Catalogue</rdfs:label>
-    <skos:definition xml:lang="da">En samling af metadata om ressourcer (fx datasæt og datatjenester i kontekst af et datakatalog).</skos:definition>
-    <skos:definition xml:lang="en">A curated collection of metadata about resources (e.g., datasets and data services in the context of a data catalog).</skos:definition>
-    <skos:definition xml:lang="ar">مجموعة من توصيفات قوائم البيانات</skos:definition>
-    <skos:scopeNote xml:lang="el">Συνήθως, ένας κατάλογος δεδομένων στον Παγκόσμιο Ιστό αναπαρίσταται ως ένα στιγμιότυπο αυτής της κλάσης.</skos:scopeNote>
-    <rdfs:comment xml:lang="el">Μια επιμελημένη συλλογή μεταδεδομένων περί συνόλων δεδομένων</rdfs:comment>
-    <rdfs:comment xml:lang="en">A curated collection of metadata about resources (e.g., datasets and data services in the context of a data catalog).</rdfs:comment>
-    <rdfs:comment xml:lang="ar">مجموعة من توصيفات قوائم البيانات</rdfs:comment>
-    <rdfs:subClassOf>
-      <owl:Restriction>
-        <owl:onProperty rdf:resource="http://purl.org/dc/terms/hasPart"/>
-        <owl:allValuesFrom rdf:resource="http://www.w3.org/ns/dcat#Resource"/>
-      </owl:Restriction>
-    </rdfs:subClassOf>
-    <rdfs:comment xml:lang="cs">Řízená kolekce metadat o datových sadách a datových službách</rdfs:comment>
   </owl:Class>
   <owl:Class rdf:about="http://www.w3.org/ns/dcat#Distribution">
     <rdfs:label xml:lang="ar">التوزيع</rdfs:label>
@@ -893,11 +889,6 @@
     <skos:changeNote xml:lang="es">Nueva propiedad agregada en DCAT 2.0.</skos:changeNote>
     <rdfs:label xml:lang="en">hadRole</rdfs:label>
     <skos:definition xml:lang="es">La función de una entidad o agente con respecto a otra entidad o recurso.</skos:definition>
-    <skos:definition xml:lang="cs">Funkce entity či agenta ve vztahu k jiné entitě či zdroji.</skos:definition>
-    <skos:scopeNote xml:lang="en">May be used in a qualified-relation to specify the role of an Entity with respect to another Entity.  It is recommended that the value be taken from a controlled vocabulary of entity roles such as: ISO 19115 DS_AssociationTypeCode http://registry.it.csiro.au/def/isotc211/DS_AssociationTypeCode; IANA Registry of Link Relations https://www.iana.org/assignments/link-relation; DataCite metadata schema; MARC relators https://id.loc.gov/vocabulary/relators.</skos:scopeNote>
-    <skos:editorialNote xml:lang="en">Introduced into DCAT to complement prov:hadRole (whose use is limited to roles in the context of an activity, with the domain of prov:Association.</skos:editorialNote>
-    <skos:scopeNote xml:lang="en">May be used in a qualified-attribution to specify the role of an Agent with respect to an Entity. It is recommended that the value be taken from a controlled vocabulary of agent roles, such as http://registry.it.csiro.au/def/isotc211/CI_RoleCode.</skos:scopeNote>
-    <rdfs:comment xml:lang="cs">Funkce entity či agenta ve vztahu k jiné entitě či zdroji.</rdfs:comment>
     <rdfs:domain>
       <owl:Class>
         <owl:unionOf rdf:parseType="Collection">
@@ -906,6 +897,11 @@
         </owl:unionOf>
       </owl:Class>
     </rdfs:domain>
+    <skos:definition xml:lang="cs">Funkce entity či agenta ve vztahu k jiné entitě či zdroji.</skos:definition>
+    <skos:scopeNote xml:lang="en">May be used in a qualified-relation to specify the role of an Entity with respect to another Entity.  It is recommended that the value be taken from a controlled vocabulary of entity roles such as: ISO 19115 DS_AssociationTypeCode http://registry.it.csiro.au/def/isotc211/DS_AssociationTypeCode; IANA Registry of Link Relations https://www.iana.org/assignments/link-relation; DataCite metadata schema; MARC relators https://id.loc.gov/vocabulary/relators.</skos:scopeNote>
+    <skos:editorialNote xml:lang="en">Introduced into DCAT to complement prov:hadRole (whose use is limited to roles in the context of an activity, with the domain of prov:Association.</skos:editorialNote>
+    <skos:scopeNote xml:lang="en">May be used in a qualified-attribution to specify the role of an Agent with respect to an Entity. It is recommended that the value be taken from a controlled vocabulary of agent roles, such as http://registry.it.csiro.au/def/isotc211/CI_RoleCode.</skos:scopeNote>
+    <rdfs:comment xml:lang="cs">Funkce entity či agenta ve vztahu k jiné entitě či zdroji.</rdfs:comment>
     <skos:scopeNote xml:lang="cs">Může být použito v kvalifikovaném přiřazení pro specifikaci role Agenta ve vztahu k Entitě. Je doporučeno hodnotu vybrat z řízeného slovníku rolí agentů, jako například http://registry.it.csiro.au/def/isotc211/CI_RoleCode.</skos:scopeNote>
     <skos:scopeNote xml:lang="it">Può essere utilizzato in un'attribuzione qualificata per specificare il ruolo di un agente rispetto a un'entità. Si raccomanda che il valore sia preso da un vocabolario controllato di ruoli di agente, come ad esempio http://registry.it.csiro.au/def/isotc211/CI_RoleCode.</skos:scopeNote>
     <rdfs:label xml:lang="da">havde rolle</rdfs:label>
@@ -1152,6 +1148,10 @@
     <rdfs:domain rdf:resource="http://www.w3.org/ns/dcat#Distribution"/>
     <skos:editorialNote xml:lang="en">rdfs:label, rdfs:comment and skos:scopeNote have been modified. Non-english versions except for Italian must be updated.</skos:editorialNote>
     <skos:scopeNote xml:lang="da">Hvis en eller flere distributioner kun er tilgængelige via en destinationsside (dvs. en URL til direkte download er ikke kendt), så bør destinationssidelinket gentages som adgangsadresse for distributionen.</skos:scopeNote>
+    <owl:propertyChainAxiom rdf:parseType="Collection">
+      <owl:ObjectProperty rdf:about="http://www.w3.org/ns/dcat#accessService"/>
+      <owl:ObjectProperty rdf:about="http://www.w3.org/ns/dcat#endpointURL"/>
+    </owl:propertyChainAxiom>
     <rdfs:comment xml:lang="es">Puede ser cualquier tipo de URL que de acceso a una distribución del conjunto de datos, e.g., página de destino, descarga, URL feed, punto de acceso SPARQL. Esta propriedad se debe usar cuando su catálogo de datos no tiene información sobre donde está o cuando no se puede descargar.</rdfs:comment>
     <rdfs:label xml:lang="fr">URL d'accès</rdfs:label>
     <skos:definition xml:lang="it">Un URL di una risorsa che consente di accedere a una distribuzione del set di dati. Per esempio, pagina di destinazione, feed, endpoint SPARQL. Da utilizzare per tutti i casi, tranne  quando  si tratta di un semplice link per il download nel qual caso è preferito downloadURL.</skos:definition>
@@ -1160,10 +1160,6 @@
     <skos:scopeNote xml:lang="es">El rango es una URL. Si la distribución es accesible solamente través de una página de destino (es decir, si no se conoce una URL de descarga directa), entonces el enlance a la página de destino debe ser duplicado como accessURL en la distribución.</skos:scopeNote>
     <rdfs:label xml:lang="ja">アクセスURL</rdfs:label>
     <rdfs:comment xml:lang="cs">URL zdroje, přes které je přístupná distribuce datové sady. Příkladem může být vstupní stránka, RSS kanál či SPARQL endpoint. Použijte ve všech případech kromě URL souboru ke stažení, pro které je lepší použít dcat:downloadURL.</rdfs:comment>
-    <owl:propertyChainAxiom rdf:parseType="Collection">
-      <owl:ObjectProperty rdf:about="http://www.w3.org/ns/dcat#accessService"/>
-      <owl:ObjectProperty rdf:about="http://www.w3.org/ns/dcat#endpointURL"/>
-    </owl:propertyChainAxiom>
     <rdfs:comment xml:lang="el">Μπορεί να είναι οποιουδήποτε είδους URL που δίνει πρόσβαση στη διανομή ενός συνόλου δεδομένων. Π.χ. ιστοσελίδα αρχικής πρόσβασης, μεταφόρτωση, feed URL, σημείο διάθεσης SPARQL. Να χρησιμοποιείται όταν ο κατάλογος δεν περιέχει πληροφορίες εαν πρόκειται ή όχι για μεταφορτώσιμο αρχείο.</rdfs:comment>
     <rdfs:comment xml:lang="it">Un URL di una risorsa che consente di accedere a una distribuzione del set di dati. Per esempio, pagina di destinazione, feed, endpoint SPARQL. Da utilizzare per tutti i casi, tranne  quando  si tratta di un semplice link per il download nel qual caso è preferito downloadURL.</rdfs:comment>
     <skos:scopeNote xml:lang="el">Η τιμή είναι ένα URL. Αν η/οι διανομή/ές είναι προσβάσιμη/ες μόνο μέσω μίας ιστοσελίδας αρχικής πρόσβασης (δηλαδή αν δεν υπάρχουν γνωστές διευθύνσεις άμεσης μεταφόρτωσης), τότε ο σύνδεσμος της ιστοσελίδας αρχικής πρόσβασης πρέπει να αναπαραχθεί ως accessURL σε μία διανομή.</skos:scopeNote>

--- a/dcat/rdf/dcat2.ttl
+++ b/dcat/rdf/dcat2.ttl
@@ -120,6 +120,7 @@
   dct:modified "2017-12-19"^^xsd:date ;
   dct:modified "2019" ;
   dct:modified "2020-11-30"^^xsd:date ;
+  dct:modified "2021-09-14"^^xsd:date ;
   rdfs:comment "DCAT es un vocabulario RDF diseñado para facilitar la interoperabilidad entre catálogos de datos publicados en la Web. Utilizando DCAT para describir datos disponibles en catálogos se aumenta la posibilidad de que sean descubiertos y se permite que las aplicaciones consuman fácilmente los metadatos de varios catálogos."@es ;
   rdfs:comment "DCAT est un vocabulaire développé pour faciliter l'interopérabilité entre les jeux de données publiées sur le Web. En utilisant DCAT pour décrire les jeux de données dans les catalogues de données, les fournisseurs de données augmentent leur découverte et permettent que les applications facilement les métadonnées de plusieurs catalogues. Il permet en plus la publication décentralisée des catalogues et facilitent la recherche fédérée des données entre plusieurs sites. Les métadonnées DCAT aggrégées peuvent servir comme un manifeste pour faciliter la préservation digitale des ressources. DCAT est définie à l'adresse http://www.w3.org/TR/vocab-dcat/. Une quelconque version de ce document normatif et ce vocabulaire est une erreur dans ce vocabulaire."@fr ;
   rdfs:comment "DCAT is an RDF vocabulary designed to facilitate interoperability between data catalogs published on the Web. By using DCAT to describe datasets in data catalogs, publishers increase discoverability and enable applications easily to consume metadata from multiple catalogs. It further enables decentralized publishing of catalogs and facilitates federated dataset search across sites. Aggregated DCAT metadata can serve as a manifest file to facilitate digital preservation. DCAT is defined at http://www.w3.org/TR/vocab-dcat/. Any variance between that normative document and this schema is an error in this schema."@en ;
@@ -175,11 +176,6 @@ dcat:Catalog
   rdfs:label "カタログ"@ja ;
   rdfs:label "Katalog"@da ;
   rdfs:subClassOf dcat:Dataset ;
-  rdfs:subClassOf [
-      a owl:Restriction ;
-      owl:allValuesFrom dcat:Resource ;
-      owl:onProperty dct:hasPart ;
-    ] ;
   skos:definition "A curated collection of metadata about resources (e.g., datasets and data services in the context of a data catalog)."@en ;
   skos:definition "Una colección curada de metadatos sobre recursos (por ejemplo, conjuntos de datos y servicios de datos en el contexto de un catálogo de datos)."@es ;
   skos:definition "Una raccolta curata di metadati sulle risorse (ad es. sui dataset e relativi servizi nel contesto di cataloghi di dati)."@it ;

--- a/dcat/rdf/dcat2.ttl
+++ b/dcat/rdf/dcat2.ttl
@@ -257,11 +257,6 @@ dcat:DataService
   skos:altLabel "Dataservice"@da ;
   rdfs:subClassOf dctype:Service ;
   rdfs:subClassOf dcat:Resource ;
-  rdfs:subClassOf [
-      a owl:Restriction ;
-      owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
-      owl:onProperty dcat:endpointURL ;
-    ] ;
   skos:changeNote "New class added in DCAT 2.0."@en ;
   skos:changeNote "Nová třída přidaná ve verzi DCAT 2.0."@cs ;
   skos:changeNote "Nueva clase añadida en DCAT 2.0."@es ;
@@ -391,11 +386,6 @@ dcat:Relationship
   rdfs:label "Relazione"@it ;
   rdfs:label "Vztah"@cs ;
   rdfs:label "Relation"@da ;
-  rdfs:subClassOf [
-      a owl:Restriction ;
-      owl:minCardinality "1"^^xsd:nonNegativeInteger ;
-      owl:onProperty dct:relation ;
-    ] ;
   skos:changeNote "New class added in DCAT 2.0."@en ;
   skos:changeNote "Nová třída přidaná ve verzi DCAT 2.0."@cs ;
   skos:changeNote "Nueva clase añadida en DCAT 2.0."@es ;


### PR DESCRIPTION


As suggested in issue #1394, and in the resolution https://github.com/w3c/dxwg/issues/105
This PR deletes from DCAT 2 serialization the axioms not explicitly mentioned in the DCAT 2 HTML REC.

 I tried to track back where we decided to add these axioms ss suggested by Alejandra, issue #105 seems to play a role in many of them; perhaps @dr-shorthair or other editors have some more vivid memory about the discussion at the time.
 
Anyway, the PR deletes Axiom 1: all the dcterms:hasPart of dcat:Catalog to range in dcat:Resource 
```
dcat:Catalog rdfs:subClassOf [
      a owl:Restriction ;
      owl:allValuesFrom dcat:Resource ;
      owl:onProperty dct:hasPart ;
    ] ;
```
This axiom could be implied by the range in https://www.w3.org/TR/vocab-dcat-2/#Property:catalog_has_part, but I am afraid we should have been more explicit on this to keep the axiom. I have not found a specific discussion on this in the DCAT 2 issue. 

The PR deletes deletes Axiom 2:  max one dcat:endpointURL is allowed in DataService
```
dcat:DataService rdfs:subClassOf [
      a owl:Restriction ;
      owl:maxCardinality "1"^^xsd:nonNegativeInteger ;
      owl:onProperty dcat:endpointURL ;
 ] 
```
it is probably implied by the  dcat:endpointURL definition "The root location or primary endpoint of the service (a Web-resolvable IRI) but not explicitly mentioned as axiom in the rec.


The PR deletes Axiom 3: at least one target should be specified for dcat:Relationship

```
dcat:Relationship
rdfs:subClassOf [
      a owl:Restriction ;
      owl:minCardinality "1"^^xsd:nonNegativeInteger ;
      owl:onProperty dct:relation ;
    ] ;
```

As we discussed, we keep axioms that are reflected in the REC, 

Axiom 4:
```
dcat:accessURL owl:propertyChainAxiom (
      dcat:accessService
      dcat:endpointURL
    ) ;
```
see rec  at https://www.w3.org/TR/vocab-dcat-2/#Property:distribution_access_url
 
axiom 5 
```
dcat:hadRole
  a owl:ObjectProperty ;
 rdfs:domain [
      a owl:Class ;
      owl:unionOf (
          prov:Attribution
          dcat:Relationship
        ) ;
    ] ;
```
see the domain defined at https://www.w3.org/TR/vocab-dcat-2/#Property:relationship_hadRole

Axiom 6: 

```
dcat:CatalogRecord rdfs:subClassOf [
      a owl:Restriction ;
      owl:allValuesFrom dcat:Resource ;
      owl:onProperty foaf:primaryTopic ;
    ] ;
  rdfs:subClassOf [
      a owl:Restriction ;
      owl:cardinality "1"^^xsd:nonNegativeInteger ;
      owl:onProperty foaf:primaryTopic ;
    ] ;
```
 as it implements what is written in words in https://www.w3.org/TR/vocab-dcat-2/#Property:record_primary_topic

For discussion about what we are going to do with these axioms in DCAT 3, please refer to issue  #1402 