### PR TITLE
DCAT removing inverse properties from Vocabulary Specification

### DIFF
--- a/dcat/index.html
+++ b/dcat/index.html
@@ -852,7 +852,7 @@ table.simple {width:100%;}
 
 <li><a href="#Property:resource_first">first</a></li>
 <li><a href="#Property:resource_last">last</a></li>
-<li><a href="#Property:resource_next">next</a></li>
+<!-- <li><a href="#Property:resource_next">next</a></li> -->
 <li><a href="#Property:resource_previous">previous</a></li>
 
 </ul>
@@ -1028,7 +1028,7 @@ table.simple {width:100%;}
 <!-- Series properties -->			
             <li><a href="#Property:resource_first">first</a></li>
             <li><a href="#Property:resource_last">last</a></li>
-            <li><a href="#Property:resource_next">next</a></li>
+            <!-- <li><a href="#Property:resource_next">next</a></li> -->
             <li><a href="#Property:resource_previous">previous</a></li>
 			
         </ul>
@@ -2064,7 +2064,7 @@ table.simple {width:100%;}
 <th class="prop">See also:</th>
 <td>
 <a href="#Property:resource_last"></a>,
-<a href="#Property:resource_next"></a>,
+<!--<a href="#Property:resource_next"></a>, -->
 <a href="#Property:resource_previous"></a>.
 </td>
 </tr>
@@ -2108,7 +2108,7 @@ table.simple {width:100%;}
 <th class="prop">See also:</th>
 <td>
 <a href="#Property:resource_first"></a>,
-<a href="#Property:resource_next"></a>,
+<!-- <a href="#Property:resource_next"></a>, -->
 <a href="#Property:resource_previous"></a>.
 </td>
 </tr>
@@ -2118,6 +2118,7 @@ table.simple {width:100%;}
 
 </section>
 
+<!--    
 <section id="Property:resource_next">
 
 <h4>Property: next</h4>
@@ -2134,12 +2135,6 @@ table.simple {width:100%;}
 <th class="prop">Definition:</th>
 <td>The next resource (after the current one) in an ordered collection or series of resources.</td>
 </tr>
-<!--
-<tr>
-<th class="prop">Equivalent property:</th>
-<td><a data-cite="?XHTML-VOCAB#prev"><code title="http://www.w3.org/1999/xhtml/vocab#prev">xhv:prev</code></a></td>
-</tr>
--->
 <tr>
 <th class="prop">Sub-property of:</th>
 <td><a data-cite="?XHTML-VOCAB#next"><code title="http://www.w3.org/1999/xhtml/vocab#next">xhv:next</code></a></td>
@@ -2163,6 +2158,7 @@ table.simple {width:100%;}
 <p>For guidance on the use of this property, see <a href="#dataset-series"></a>.</p>
 
 </section>
+-->
 
 <section id="Property:resource_previous">
 
@@ -2199,8 +2195,8 @@ table.simple {width:100%;}
 <th class="prop">See also:</th>
 <td>
 <a href="#Property:resource_first"></a>,
-<a href="#Property:resource_last"></a>,
-<a href="#Property:resource_next"></a>.
+<a href="#Property:resource_last"></a><!--,
+<!-- <a href="#Property:resource_next"></a> -->.
 </td>
 </tr>
 </table>
@@ -2398,7 +2394,7 @@ table.simple {width:100%;}
 
 <li><a href="#Property:resource_first">first</a></li>
 <li><a href="#Property:resource_last">last</a></li>
-<li><a href="#Property:resource_next">next</a></li>
+<!-- <li><a href="#Property:resource_next">next</a></li> -->
 <li><a href="#Property:resource_previous">previous</a></li>
 
         </ul>
@@ -2683,7 +2679,7 @@ table.simple {width:100%;}
 
 <li><a href="#Property:resource_first">first</a></li>
 <li><a href="#Property:resource_last">last</a></li>
-<li><a href="#Property:resource_next">next</a></li>
+<!-- <li><a href="#Property:resource_next">next</a></li> -->
 <li><a href="#Property:resource_previous">previous</a></li>
 
         </ul>
@@ -3200,7 +3196,7 @@ table.simple {width:100%;}
 
 <li><a href="#Property:resource_first">first</a></li>
 <li><a href="#Property:resource_last">last</a></li>
-<li><a href="#Property:resource_next">next</a></li>
+<!-- <li><a href="#Property:resource_next">next</a></li> -->
 <li><a href="#Property:resource_previous">previous</a></li>
 
         </ul>
@@ -4942,7 +4938,7 @@ ex:budget-2020 a dcat:Dataset ;
 </aside>
 
 
-<p>Dataset series may evolve over time, by acquiring new datasets. E.g., a dataset series about yearly budget data will acquire a new child dataset every year. In such cases, it might be important to link the yearly releases with relationships specifying the first, previous, next, and latest ones. In such scenario, DCAT makes use of properties <a href="#Property:resource_first"><code>dcat:first</code></a>, <a href="#Property:resource_previous"><code>dcat:prev</code></a>, <a href="#Property:resource_next"><code>dcat:next</code></a>, and <a href="#Property:resource_last"><code>dcat:last</code></a>, respectively.</p>
+<p>Dataset series may evolve over time, by acquiring new datasets. E.g., a dataset series about yearly budget data will acquire a new child dataset every year. In such cases, it might be important to link the yearly releases with relationships specifying the first, previous, next, and latest ones. In such scenario, DCAT makes use of properties <a href="#Property:resource_first"><code>dcat:first</code></a>, <a href="#Property:resource_previous"><code>dcat:prev</code></a>, and <a href="#Property:resource_last"><code>dcat:last</code></a>, respectively. See <a href="#inverse-properties"> </a> for <code>dcat:next</code>. </p>
 
 <aside class="example" id="ex-dataset-series-releases" title="Linking datasets in a series">
 <p>The following example extends <a href="#ex-dataset-series-containment"></a> by specifying the publication date (<code>dcterms:issued</code>) of each child dataset, and the previous (<code>dcat:prev</code>) and next release (<code>dcat:next</code>).</p>
@@ -6572,6 +6568,8 @@ ga-courts:jc-wms
 <p>The document has undergone the following changes since the DCAT 3 second public working draft of 4 May 2021 [[?VOCAB-DCAT-3-20210504]]:</p>
 
 <ul>
+    <li><p> Added new section <a href="#inverse-properties"></a> and removed   <code>dcat:next</code> from <a href="#vocabulary-specification"></a>.</p></li> 
+    
     <li><p><a href="#basic-example"></a> has been updated to tell a more coherent story (see  issue <a href="https://github.com/w3c/dxwg/issues/1155">#1155</a>) and express temporal coverage by using <a href="#Class:Period_of_Time"><code>dcterms:PeriodOfTime</code></a>, <a href="#Property:period_start_date"><code>dcat:startDate</code></a>, and <a href="#Property:period_end_date"><code>dcat:endDate</code></a>.</p></li> 
 <li>The usage notes of properties <a href="#Property:location_bbox"><code title="http://www.w3.org/ns/dcat#bbox">dcat:bbox</code></a> and <a href="#Property:location_centroid"><code title="http://www.w3.org/ns/dcat#centroid">dcat:centroid</code></a> have been revised to make it clearer that they are supposed to be used only with geometry literals - see Issue <a href="https://github.com/w3c/dxwg/issues/1359">#1359</a>.</li>
 <li>The property <a href="#Property:resource_theme"><code title="http://www.w3.org/ns/dcat#theme">dcat:theme</code></a>  have been explicitly defined as an OWL object property and its range is dropped, see Issue <a href="https://github.com/w3c/dxwg/issues/1364">#1364</a>.</li>
@@ -6607,7 +6605,7 @@ ga-courts:jc-wms
 <ul>
 <li>A new class <code>dcat:DatasetSeries</code> has been defined (see <a href="#Class:Dataset_Series"></a>) - see Issue <a href="https://github.com/w3c/dxwg/issues/1272">#1272</a>.</li>
 <li>Property <a href="#Property:dataset_in_series"><code>dcat:inSeries</code></a> has been added to <a href="#Class:Dataset"></a> - see Issue <a href="https://github.com/w3c/dxwg/issues/1307">#1307</a>.</li>
-<li>Properties <a href="#Property:resource_first"><code>dcat:first</code></a>, <a href="#Property:resource_previous"><code>dcat:prev</code></a>, <a href="#Property:resource_next"><code>dcat:next</code></a>, and <a href="#Property:resource_last"><code>dcat:last</code></a> have been added to <a href="#Class:Resource"></a> - see Issue <a href="https://github.com/w3c/dxwg/issues/1308">#1308</a>.</li>
+<li>Properties <a href="#Property:resource_first"><code>dcat:first</code></a>, <a href="#Property:resource_previous"><code>dcat:prev</code></a>, <code>dcat:next</code>, and <a href="#Property:resource_last"><code>dcat:last</code></a> have been added to <a href="#Class:Resource"></a> - see Issue <a href="https://github.com/w3c/dxwg/issues/1308">#1308</a>.</li>
 </ul>
 </li>
 <li>Added property <a href="#Property:distribution_checksum"><code>spdx:checksum</code></a> to <a href="#Class:Distribution"></a>; added class <code>spdx:Checksum</code> (see <a href="#Class:Checksum"></a>), and its properties <a href="#Property:checksum_algorithm"><code>spdx:algorithm</code></a> and <a href="#Property:checksum_checksum_value"><code>spdx:checksumValue</code></a> - see Issue <a href="https://github.com/w3c/dxwg/issues/1287">#1287</a>.</li>

--- a/dcat/index.html
+++ b/dcat/index.html
@@ -843,7 +843,9 @@ table.simple {width:100%;}
 -->			
             <li><a href="#Property:resource_has_version">has version</a></li>
             <!-- <li><a href="#Property:resource_is_replaced_by">is replaced by</a></li> -->
+<!--			
             <li><a href="#Property:resource_is_version_of">is version of</a></li>
+-->			
             <li><a href="#Property:resource_previous_version">previous version</a></li>
             <li><a href="#Property:resource_replaces">replaces</a></li>
             <li><a href="#Property:resource_status">status</a></li>
@@ -1019,7 +1021,9 @@ table.simple {width:100%;}
 -->			
             <li><a href="#Property:resource_has_version">has version</a></li>
             <!--<li><a href="#Property:resource_is_replaced_by">is replaced by</a></li> -->
+<!--			
             <li><a href="#Property:resource_is_version_of">is version of</a></li>
+-->			
             <li><a href="#Property:resource_previous_version">previous version</a></li>
             <li><a href="#Property:resource_replaces">replaces</a></li>
             <li><a href="#Property:resource_status">status</a></li>
@@ -1576,7 +1580,9 @@ table.simple {width:100%;}
 <a href="#Property:resource_has_current_version"></a>,
 <a href="#Property:resource_has_version"></a>,
 <!--<a href="#Property:resource_is_replaced_by"></a>, -->
+<!--
 <a href="#Property:resource_is_version_of"></a>,
+-->
 <a href="#Property:resource_release_date"></a>,
 <a href="#Property:resource_replaces"></a>,
 <a href="#Property:resource_status"></a>,
@@ -1627,7 +1633,9 @@ table.simple {width:100%;}
 <td>
 <a href="#Property:resource_has_current_version"></a>,
 <!-- <a href="#Property:resource_is_replaced_by"></a>, -->
+<!--
 <a href="#Property:resource_is_version_of"></a>,
+-->
 <a href="#Property:resource_previous_version"></a>,
 <a href="#Property:resource_release_date"></a>,
 <a href="#Property:resource_replaces"></a>,
@@ -1733,7 +1741,9 @@ table.simple {width:100%;}
 <td>
 <a href="#Property:resource_has_version"></a>,
 <!-- <a href="#Property:resource_is_replaced_by"></a>, -->
+<!--
 <a href="#Property:resource_is_version_of"></a>,
+-->
 <a href="#Property:resource_previous_version"></a>,
 <a href="#Property:resource_release_date"></a>,
 <a href="#Property:resource_replaces"></a>,
@@ -1780,7 +1790,9 @@ table.simple {width:100%;}
 <a href="#Property:resource_has_current_version"></a>,
 <a href="#Property:resource_has_version"></a>,
 <a href="#Property:resource_is_replaced_by"></a>,
+<!--
 <a href="#Property:resource_is_version_of"></a>,
+-->
 <a href="#Property:resource_previous_version"></a>,
 <a href="#Property:resource_release_date"></a>,
 <a href="#Property:resource_replaces"></a>,
@@ -1829,7 +1841,9 @@ table.simple {width:100%;}
 <a href="#Property:resource_has_current_version"></a>,
 <a href="#Property:resource_has_version"></a>,
 <!-- <a href="#Property:resource_is_replaced_by"></a>, --> <a href="#inverse-properties"></a>,
+<!--
 <a href="#Property:resource_is_version_of"></a>,
+-->
 <a href="#Property:resource_previous_version"></a>,
 <a href="#Property:resource_release_date"></a>,
 <a href="#Property:resource_status"></a>,
@@ -1871,7 +1885,9 @@ table.simple {width:100%;}
 <td>
 <a href="#Property:resource_has_current_version"></a>,
 <a href="#Property:resource_has_version"></a>,
+<!--
 <a href="#Property:resource_is_version_of"></a>,
+-->
 <a href="#Property:resource_previous_version"></a>,
 <a href="#Property:resource_release_date"></a>,
 <a href="#Property:resource_replaces"></a>,
@@ -1920,7 +1936,9 @@ table.simple {width:100%;}
 <a href="#Property:resource_has_current_version"></a>,
 <a href="#Property:resource_has_version"></a>,
 <!-- <a href="#Property:resource_is_replaced_by"></a>, -->
+<!--
 <a href="#Property:resource_is_version_of"></a>,
+-->
 <a href="#Property:resource_previous_version"></a>,
 <a href="#Property:resource_release_date"></a>,
 <a href="#Property:resource_replaces"></a>,
@@ -1964,7 +1982,9 @@ table.simple {width:100%;}
 <a href="#Property:resource_has_current_version"></a>,
 <a href="#Property:resource_has_version"></a>,
 <!-- <a href="#Property:resource_is_replaced_by"></a>, -->
+<!--
 <a href="#Property:resource_is_version_of"></a>,
+-->
 <a href="#Property:resource_previous_version"></a>,
 <a href="#Property:resource_release_date"></a>,
 <a href="#Property:resource_replaces"></a>,
@@ -2008,7 +2028,9 @@ table.simple {width:100%;}
 <a href="#Property:resource_has_current_version"></a>,
 <a href="#Property:resource_has_version"></a>,
 <!-- <a href="#Property:resource_is_replaced_by"></a>, -->
+<!--
 <a href="#Property:resource_is_version_of"></a>,
+-->
 <a href="#Property:resource_previous_version"></a>,
 <a href="#Property:resource_release_date"></a>,
 <a href="#Property:resource_replaces"></a>,
@@ -2381,7 +2403,9 @@ table.simple {width:100%;}
 <!-- 
             <li><a href="#Property:resource_is_replaced_by">is replaced by</a></li> 
 -->
+<!--
             <li><a href="#Property:resource_is_version_of">is version of</a></li>
+-->
             <li><a href="#Property:resource_previous_version">previous version</a></li>
             <li><a href="#Property:resource_replaces">replaces</a></li>
             <li><a href="#Property:resource_status">status</a></li>
@@ -2668,7 +2692,9 @@ table.simple {width:100%;}
             <!-- 
             <li><a href="#Property:resource_is_replaced_by">is replaced by</a></li> 
 -->
+<!--
             <li><a href="#Property:resource_is_version_of">is version of</a></li>
+-->
             <li><a href="#Property:resource_previous_version">previous version</a></li>
             <li><a href="#Property:resource_replaces">replaces</a></li>
             <li><a href="#Property:resource_status">status</a></li>
@@ -3187,7 +3213,9 @@ table.simple {width:100%;}
 <!-- 
             <li><a href="#Property:resource_is_replaced_by">is replaced by</a></li> 
 -->
+<!--
             <li><a href="#Property:resource_is_version_of">is version of</a></li>
+-->
             <li><a href="#Property:resource_previous_version">previous version</a></li>
             <li><a href="#Property:resource_replaces">replaces</a></li>
             <li><a href="#Property:resource_status">status</a></li>

--- a/dcat/index.html
+++ b/dcat/index.html
@@ -842,7 +842,7 @@ table.simple {width:100%;}
             <li><a href="#Property:resource_has_last_version">has last version</a></li>
 -->			
             <li><a href="#Property:resource_has_version">has version</a></li>
-            <li><a href="#Property:resource_is_replaced_by">is replaced by</a></li>
+            <!-- <li><a href="#Property:resource_is_replaced_by">is replaced by</a></li> -->
             <li><a href="#Property:resource_is_version_of">is version of</a></li>
             <li><a href="#Property:resource_previous_version">previous version</a></li>
             <li><a href="#Property:resource_replaces">replaces</a></li>
@@ -1018,7 +1018,7 @@ table.simple {width:100%;}
             <li><a href="#Property:resource_has_last_version">has last version</a></li>
 -->			
             <li><a href="#Property:resource_has_version">has version</a></li>
-            <li><a href="#Property:resource_is_replaced_by">is replaced by</a></li>
+            <!--<li><a href="#Property:resource_is_replaced_by">is replaced by</a></li> -->
             <li><a href="#Property:resource_is_version_of">is version of</a></li>
             <li><a href="#Property:resource_previous_version">previous version</a></li>
             <li><a href="#Property:resource_replaces">replaces</a></li>
@@ -1575,7 +1575,7 @@ table.simple {width:100%;}
 <td>
 <a href="#Property:resource_has_current_version"></a>,
 <a href="#Property:resource_has_version"></a>,
-<a href="#Property:resource_is_replaced_by"></a>,
+<!--<a href="#Property:resource_is_replaced_by"></a>, -->
 <a href="#Property:resource_is_version_of"></a>,
 <a href="#Property:resource_release_date"></a>,
 <a href="#Property:resource_replaces"></a>,
@@ -1626,7 +1626,7 @@ table.simple {width:100%;}
 <th class="prop">See also:</th>
 <td>
 <a href="#Property:resource_has_current_version"></a>,
-<a href="#Property:resource_is_replaced_by"></a>,
+<!-- <a href="#Property:resource_is_replaced_by"></a>, -->
 <a href="#Property:resource_is_version_of"></a>,
 <a href="#Property:resource_previous_version"></a>,
 <a href="#Property:resource_release_date"></a>,
@@ -1679,7 +1679,7 @@ table.simple {width:100%;}
 <td>
 <a href="#Property:resource_has_current_version"></a>,
 <a href="#Property:resource_has_version"></a>,
-<a href="#Property:resource_is_replaced_by"></a>,
+<!-- <a href="#Property:resource_is_replaced_by"></a>, -->
 <a href="#Property:resource_previous_version"></a>,
 <a href="#Property:resource_release_date"></a>,
 <a href="#Property:resource_replaces"></a>,
@@ -1730,7 +1730,7 @@ table.simple {width:100%;}
 <th class="prop">See also:</th>
 <td>
 <a href="#Property:resource_has_version"></a>,
-<a href="#Property:resource_is_replaced_by"></a>,
+<!-- <a href="#Property:resource_is_replaced_by"></a>, -->
 <a href="#Property:resource_is_version_of"></a>,
 <a href="#Property:resource_previous_version"></a>,
 <a href="#Property:resource_release_date"></a>,
@@ -1826,7 +1826,7 @@ table.simple {width:100%;}
 <td>
 <a href="#Property:resource_has_current_version"></a>,
 <a href="#Property:resource_has_version"></a>,
-<a href="#Property:resource_is_replaced_by"></a>,
+<!-- <a href="#Property:resource_is_replaced_by"></a>, --> <a href="#inverse-properties"></a>,
 <a href="#Property:resource_is_version_of"></a>,
 <a href="#Property:resource_previous_version"></a>,
 <a href="#Property:resource_release_date"></a>,
@@ -1841,6 +1841,7 @@ table.simple {width:100%;}
 
 </section>
 
+<!--
 <section id="Property:resource_is_replaced_by">
 
 <h4>Property: is replaced by</h4>
@@ -1862,16 +1863,7 @@ table.simple {width:100%;}
 <tr>
 <th class="prop">Sub-property of:</th>
 <td><a href="https://www.dublincore.org/specifications/dublin-core/dcmi-terms/#http://purl.org/dc/terms/relation"><code title="http://purl.org/dc/terms/relation">dcterms:relation</code></a></td>
-</tr>
-<!--
-<tr>
-<th class="prop">Usage note:</th>
-<td>
-<p>This property is intended for relating a non-versioned or abstract resource to the most recent versioned resource, irrespective of its status (stable vs draft) to a non-versioned or abstract resource. To point instead to the latest <em>stable</em> version of a resource, property <a href="#Property:resource_has_current_version"><code>dcat:hasCurrentVersion</code></a> SHOULD be used.</p>
-<p>The notion of version used by this property is limited to versions resulting from revisions occurring to a resource as part of its life-cycle.</p>
-</td>
-</tr>
--->
+</tr>    
 <tr>
 <th class="prop">See also:</th>
 <td>
@@ -1890,7 +1882,7 @@ table.simple {width:100%;}
 
 <p>For guidance on the use of this property, see <a href="#version-replace"></a>.</p>
 
-</section>
+</section> -->
 
 <section id="Property:resource_version">
 
@@ -1925,7 +1917,7 @@ table.simple {width:100%;}
 <td>
 <a href="#Property:resource_has_current_version"></a>,
 <a href="#Property:resource_has_version"></a>,
-<a href="#Property:resource_is_replaced_by"></a>,
+<!-- <a href="#Property:resource_is_replaced_by"></a>, -->
 <a href="#Property:resource_is_version_of"></a>,
 <a href="#Property:resource_previous_version"></a>,
 <a href="#Property:resource_release_date"></a>,
@@ -1969,7 +1961,7 @@ table.simple {width:100%;}
 <td>
 <a href="#Property:resource_has_current_version"></a>,
 <a href="#Property:resource_has_version"></a>,
-<a href="#Property:resource_is_replaced_by"></a>,
+<!-- <a href="#Property:resource_is_replaced_by"></a>, -->
 <a href="#Property:resource_is_version_of"></a>,
 <a href="#Property:resource_previous_version"></a>,
 <a href="#Property:resource_release_date"></a>,
@@ -2013,7 +2005,7 @@ table.simple {width:100%;}
 <td>
 <a href="#Property:resource_has_current_version"></a>,
 <a href="#Property:resource_has_version"></a>,
-<a href="#Property:resource_is_replaced_by"></a>,
+<!-- <a href="#Property:resource_is_replaced_by"></a>, -->
 <a href="#Property:resource_is_version_of"></a>,
 <a href="#Property:resource_previous_version"></a>,
 <a href="#Property:resource_release_date"></a>,
@@ -2064,7 +2056,7 @@ table.simple {width:100%;}
 <th class="prop">See also:</th>
 <td>
 <a href="#Property:resource_last"></a>,
-<!--<a href="#Property:resource_next"></a>, -->
+<!-- <a href="#Property:resource_next"></a> --> <a href="#inverse-properties"></a>,
 <a href="#Property:resource_previous"></a>.
 </td>
 </tr>
@@ -2108,7 +2100,7 @@ table.simple {width:100%;}
 <th class="prop">See also:</th>
 <td>
 <a href="#Property:resource_first"></a>,
-<!-- <a href="#Property:resource_next"></a>, -->
+<!-- <a href="#Property:resource_next"></a> --> <a href="#inverse-properties"></a>,
 <a href="#Property:resource_previous"></a>.
 </td>
 </tr>
@@ -2195,8 +2187,8 @@ table.simple {width:100%;}
 <th class="prop">See also:</th>
 <td>
 <a href="#Property:resource_first"></a>,
-<a href="#Property:resource_last"></a><!--,
-<!-- <a href="#Property:resource_next"></a> -->.
+<a href="#Property:resource_last"></a>,
+<!-- <a href="#Property:resource_next"></a> --> <a href="#inverse-properties"></a>.
 </td>
 </tr>
 </table>
@@ -2384,7 +2376,9 @@ table.simple {width:100%;}
             <li><a href="#Property:resource_has_last_version">has last version</a></li>
 -->			
             <li><a href="#Property:resource_has_version">has version</a></li>
-            <li><a href="#Property:resource_is_replaced_by">is replaced by</a></li>
+<!-- 
+            <li><a href="#Property:resource_is_replaced_by">is replaced by</a></li> 
+-->
             <li><a href="#Property:resource_is_version_of">is version of</a></li>
             <li><a href="#Property:resource_previous_version">previous version</a></li>
             <li><a href="#Property:resource_replaces">replaces</a></li>
@@ -2669,7 +2663,9 @@ table.simple {width:100%;}
             <li><a href="#Property:resource_has_last_version">has last version</a></li>
 -->			
             <li><a href="#Property:resource_has_version">has version</a></li>
-            <li><a href="#Property:resource_is_replaced_by">is replaced by</a></li>
+            <!-- 
+            <li><a href="#Property:resource_is_replaced_by">is replaced by</a></li> 
+-->
             <li><a href="#Property:resource_is_version_of">is version of</a></li>
             <li><a href="#Property:resource_previous_version">previous version</a></li>
             <li><a href="#Property:resource_replaces">replaces</a></li>
@@ -3186,7 +3182,9 @@ table.simple {width:100%;}
             <li><a href="#Property:resource_has_last_version">has last version</a></li>
 -->			
             <li><a href="#Property:resource_has_version">has version</a></li>
-            <li><a href="#Property:resource_is_replaced_by">is replaced by</a></li>
+<!-- 
+            <li><a href="#Property:resource_is_replaced_by">is replaced by</a></li> 
+-->
             <li><a href="#Property:resource_is_version_of">is version of</a></li>
             <li><a href="#Property:resource_previous_version">previous version</a></li>
             <li><a href="#Property:resource_replaces">replaces</a></li>
@@ -4638,7 +4636,7 @@ mycity-bus:stops-2015-12-07 a dcat:Dataset ;
 
 <h2>Versions replaced by other ones</h2>
 
-<p>Another type of relationship concerns whether a given version replaces/supersedes another one. For this purpose, DCAT reuses the relevant [[DCTERMS]] property, namely, <a href="#Property:resource_replaces"><code title="http://purl.org/dc/terms/replaces">dcterms:replaces</code></a>, plus its inverse <a href="#Property:resource_is_replaced_by"><code title="http://purl.org/dc/terms/isReplacedBy">dcterms:isReplacedBy</code></a>, in case a back link needs to be provided.</p>
+<p>Another type of relationship concerns whether a given version replaces/supersedes another one. For this purpose, DCAT reuses the relevant [[DCTERMS]] property, namely, <a href="#Property:resource_replaces"><code title="http://purl.org/dc/terms/replaces">dcterms:replaces</code></a>, plus its inverse <code title="http://purl.org/dc/terms/isReplacedBy">dcterms:isReplacedBy</code>, in case a back link needs to be provided.</p>
 
 <p>It is worth noting that these properties are not denoting by themselves a version chain - i.e., a version is not necessarily replacing its immediate predecessor.</p>
 
@@ -6568,7 +6566,7 @@ ga-courts:jc-wms
 <p>The document has undergone the following changes since the DCAT 3 second public working draft of 4 May 2021 [[?VOCAB-DCAT-3-20210504]]:</p>
 
 <ul>
-    <li><p> Added new section <a href="#inverse-properties"></a> and removed   <code>dcat:next</code> from <a href="#vocabulary-specification"></a>.</p></li> 
+    <li><p> Added new section <a href="#inverse-properties"></a> and removed   <code>dcat:next</code>, <code>dcterms:isReplacedBy</code> from <a href="#vocabulary-specification"></a>.</p></li> 
     
     <li><p><a href="#basic-example"></a> has been updated to tell a more coherent story (see  issue <a href="https://github.com/w3c/dxwg/issues/1155">#1155</a>) and express temporal coverage by using <a href="#Class:Period_of_Time"><code>dcterms:PeriodOfTime</code></a>, <a href="#Property:period_start_date"><code>dcat:startDate</code></a>, and <a href="#Property:period_end_date"><code>dcat:endDate</code></a>.</p></li> 
 <li>The usage notes of properties <a href="#Property:location_bbox"><code title="http://www.w3.org/ns/dcat#bbox">dcat:bbox</code></a> and <a href="#Property:location_centroid"><code title="http://www.w3.org/ns/dcat#centroid">dcat:centroid</code></a> have been revised to make it clearer that they are supposed to be used only with geometry literals - see Issue <a href="https://github.com/w3c/dxwg/issues/1359">#1359</a>.</li>

--- a/dcat/index.html
+++ b/dcat/index.html
@@ -1790,9 +1790,7 @@ table.simple {width:100%;}
 <a href="#Property:resource_has_current_version"></a>,
 <a href="#Property:resource_has_version"></a>,
 <a href="#Property:resource_is_replaced_by"></a>,
-<!--
 <a href="#Property:resource_is_version_of"></a>,
--->
 <a href="#Property:resource_previous_version"></a>,
 <a href="#Property:resource_release_date"></a>,
 <a href="#Property:resource_replaces"></a>,
@@ -1885,9 +1883,7 @@ table.simple {width:100%;}
 <td>
 <a href="#Property:resource_has_current_version"></a>,
 <a href="#Property:resource_has_version"></a>,
-<!--
 <a href="#Property:resource_is_version_of"></a>,
--->
 <a href="#Property:resource_previous_version"></a>,
 <a href="#Property:resource_release_date"></a>,
 <a href="#Property:resource_replaces"></a>,
@@ -1900,7 +1896,8 @@ table.simple {width:100%;}
 
 <p>For guidance on the use of this property, see <a href="#version-replace"></a>.</p>
 
-</section> -->
+</section> 
+-->
 
 <section id="Property:resource_version">
 

--- a/dcat/index.html
+++ b/dcat/index.html
@@ -5434,6 +5434,7 @@ ex:budget-2018-it a dcat:Dataset ;
 
 # Conformance test result
 :testResult a prov:Entity ;
+  prov:wasGeneratedBy :testingActivity;
   # :notConformant belongs to a SKOS concept scheme about conformance
   dcterms:type :notConformant .
 
@@ -5504,6 +5505,7 @@ a:conformanceTest a earl:TestRequirement, prov:Plan ;
 a:testResult a earl:TestResult ;
   #  results in conformancy .
   dcterms:type  a:conformant ;
+  prov:wasGeneratedBy a:testingActivity;
   #the overall set of tests have been passed
   earl:outcome earl:passed .
 
@@ -5514,7 +5516,7 @@ a:testResult a earl:TestResult ;
 
 #the testing activity
 a:testingActivity a prov:Activity ;
-  prov:generated a:TestAssertion, a:testResult ;
+  prov:generated a:assertion, a:testResult ;
   prov:use a:Dataset ;
   prov:wasAssociatedWith &lt;http://validator.example.org/&gt; .</pre>
 </aside>

--- a/dcat/index.html
+++ b/dcat/index.html
@@ -1642,6 +1642,7 @@ table.simple {width:100%;}
 
 </section>
 
+<!--
 <section id="Property:resource_is_version_of">
 
 <h4>Property: is version of</h4>
@@ -1693,6 +1694,7 @@ table.simple {width:100%;}
 <p>For guidance on the use of this property, see <a href="#version-history"></a>.</p>
 
 </section>
+-->
 
 <section id="Property:resource_has_current_version">
 
@@ -3884,9 +3886,15 @@ The interval can also be open - i.e., it can have just a start or just an end.</
 <td><a href="#Property:resource_is_referenced_by"><code>dcterms:isReferencedBy</code></a></td>
 <td id="inverse-of-resource_is_referenced_by"><a href="https://www.dublincore.org/specifications/dublin-core/dcmi-terms/#http://purl.org/dc/terms/references"><code>dcterms:references</code></a></td>
 </tr>
+<!--
 <tr>
 <td><a href="#Property:resource_is_version_of"><code>dcat:isVersionOf</code></a></td>
 <td id="inverse-of-resource_is_version_of"><code>dcat:hasVersion</code></td>
+</tr>
+-->
+<tr>
+<td><a href="#Property:resource_has_version"><code>dcat:hasVersion</code></a></td>
+<td id="Property:resource_is_version_of"><code>dcat:isVersionOf</code></td>
 </tr>
 <!--
 <tr>
@@ -4535,10 +4543,14 @@ For example:</p>
 
 <ul>
 <li><a href="#Property:resource_previous_version"><code>dcat:previousVersion</code></a> (equivalent to <a data-cite="?PAV#d4e459"><code>pav:previousVersion</code></a>)</li>
+<!--
 <li><p><a href="#Property:resource_has_version"><code>dcat:hasVersion</code></a> (equivalent to <a data-cite="?PAV#d4e395"><code>pav:hasVersion</code></a>), plus the following additional properties:</p>
 <ul>
 <li><a href="#Property:resource_is_version_of"><code>dcat:isVersionOf</code></a> (inverse of <code>dcat:hasVersion</code>);</li>
 <li><a href="#Property:resource_has_current_version"><code>dcat:hasCurrentVersion</code></a> (equivalent to <a data-cite="?PAV#d4e359"><code>pav:hasCurrentVersion</code></a>, and subproperty of <code>dcat:hasVersion</code>)</li>
+-->
+<li><p><a href="#Property:resource_has_version"><code>dcat:hasVersion</code></a> (equivalent to <a data-cite="?PAV#d4e395"><code>pav:hasVersion</code></a>);</p>
+<li><a href="#Property:resource_has_current_version"><code>dcat:hasCurrentVersion</code></a> (equivalent to <a data-cite="?PAV#d4e359"><code>pav:hasCurrentVersion</code></a>, and subproperty of <code>dcat:hasVersion</code>).</li>
 <!--
 <li><a href="#Property:resource_has_last_version"><code>dcat:hasLastVersion</code></a> (subproperty of <code>dcat:hasVersion</code>)</li>
 -->
@@ -4565,7 +4577,11 @@ For example:</p>
 
 <p>In addition to this, property <code>dcat:hasVersion</code> can be used to specify a version hierarchy, by linking an abstract resource to its versions.</p>
 
+<!--
 <p>If needed, the version hierarchy can be further described by specific properties. More precisely, property <code>dcat:isVersionOf</code> (inverse of <code>dcat:hasVersion</code>) gives the possibility of specifying a back link from a version to the abstract resource, whereas property <code>dcat:hasCurrentVersion</code> link an abstract resource to snapshot corresponding to the current version of the content.</p>
+-->
+
+<p>If needed, the version hierarchy can be further described by specific properties. More precisely, property <code>dcat:hasCurrentVersion</code> link an abstract resource to snapshot corresponding to the current version of the content, whereas property <code>dcat:isVersionOf</code> (inverse of <code>dcat:hasVersion</code>) gives the possibility of specifying a back link from a version to the abstract resource (for the use of this property, see <a href="#inverse-properties"></a>).</p>
 
 <!--
 <p>If needed, the version hierarchy can be further described by specific properties. More precisely, property <code>dcat:isVersionOf</code> (inverse of <code>dcat:hasVersion</code>) gives the possibility of specifying a back link from a version to the abstract resource, whereas property <code>dcat:hasCurrentVersion</code> link an abstract resource to snapshot corresponding to the current version of the content. Finally, property <code>dcat:hasLastVersion</code> link the abstract resource to the latest version of the resource in the version chain. Note that the current version of a resource may be different from the last version: e.g., if the last version is still in draft status, the current one may correspond to the latest stable version of the resource.</p>

--- a/dcat/index.html
+++ b/dcat/index.html
@@ -1688,7 +1688,7 @@ table.simple {width:100%;}
 <td>
 <a href="#Property:resource_has_current_version"></a>,
 <a href="#Property:resource_has_version"></a>,
-<!-- <a href="#Property:resource_is_replaced_by"></a>, -->
+<a href="#Property:resource_is_replaced_by"></a>,
 <a href="#Property:resource_previous_version"></a>,
 <a href="#Property:resource_release_date"></a>,
 <a href="#Property:resource_replaces"></a>,


### PR DESCRIPTION
This PR removes the properties  <code>dcat:next</code> and <code>dcterms:isReplacedBy</code> from the Vocabulary specification (section  6).  


Still to decide if other properties mentioned in the inverse property section (e.g.,  <code>dcat:hasVersion</code> and <code>prov:generated</code>) need to be removed as well.
 
Preview: https://raw.githack.com/w3c/dxwg/DCAT-adjustementForInverseProperties/dcat/index.html

Diff: https://services.w3.org/htmldiff?doc1=https%3A%2F%2Fw3c.github.io%2Fdxwg%2Fdcat%2F&doc2=https%3A%2F%2Fraw.githack.com%2Fw3c%2Fdxwg%2FDCAT-adjustementForInverseProperties%2Fdcat%2Findex.html