### PR TITLE
Move dcat:isVersionOf to section on inverse properties

### DIFF
--- a/dcat/index.html
+++ b/dcat/index.html
@@ -843,7 +843,9 @@ table.simple {width:100%;}
 -->			
             <li><a href="#Property:resource_has_version">has version</a></li>
             <!-- <li><a href="#Property:resource_is_replaced_by">is replaced by</a></li> -->
+<!--			
             <li><a href="#Property:resource_is_version_of">is version of</a></li>
+-->			
             <li><a href="#Property:resource_previous_version">previous version</a></li>
             <li><a href="#Property:resource_replaces">replaces</a></li>
             <li><a href="#Property:resource_status">status</a></li>
@@ -1019,7 +1021,9 @@ table.simple {width:100%;}
 -->			
             <li><a href="#Property:resource_has_version">has version</a></li>
             <!--<li><a href="#Property:resource_is_replaced_by">is replaced by</a></li> -->
+<!--			
             <li><a href="#Property:resource_is_version_of">is version of</a></li>
+-->			
             <li><a href="#Property:resource_previous_version">previous version</a></li>
             <li><a href="#Property:resource_replaces">replaces</a></li>
             <li><a href="#Property:resource_status">status</a></li>
@@ -1576,7 +1580,9 @@ table.simple {width:100%;}
 <a href="#Property:resource_has_current_version"></a>,
 <a href="#Property:resource_has_version"></a>,
 <!--<a href="#Property:resource_is_replaced_by"></a>, -->
+<!--
 <a href="#Property:resource_is_version_of"></a>,
+-->
 <a href="#Property:resource_release_date"></a>,
 <a href="#Property:resource_replaces"></a>,
 <a href="#Property:resource_status"></a>,
@@ -1627,7 +1633,9 @@ table.simple {width:100%;}
 <td>
 <a href="#Property:resource_has_current_version"></a>,
 <!-- <a href="#Property:resource_is_replaced_by"></a>, -->
+<!--
 <a href="#Property:resource_is_version_of"></a>,
+-->
 <a href="#Property:resource_previous_version"></a>,
 <a href="#Property:resource_release_date"></a>,
 <a href="#Property:resource_replaces"></a>,
@@ -1733,7 +1741,9 @@ table.simple {width:100%;}
 <td>
 <a href="#Property:resource_has_version"></a>,
 <!-- <a href="#Property:resource_is_replaced_by"></a>, -->
+<!--
 <a href="#Property:resource_is_version_of"></a>,
+-->
 <a href="#Property:resource_previous_version"></a>,
 <a href="#Property:resource_release_date"></a>,
 <a href="#Property:resource_replaces"></a>,
@@ -1780,7 +1790,9 @@ table.simple {width:100%;}
 <a href="#Property:resource_has_current_version"></a>,
 <a href="#Property:resource_has_version"></a>,
 <a href="#Property:resource_is_replaced_by"></a>,
+<!--
 <a href="#Property:resource_is_version_of"></a>,
+-->
 <a href="#Property:resource_previous_version"></a>,
 <a href="#Property:resource_release_date"></a>,
 <a href="#Property:resource_replaces"></a>,
@@ -1829,7 +1841,9 @@ table.simple {width:100%;}
 <a href="#Property:resource_has_current_version"></a>,
 <a href="#Property:resource_has_version"></a>,
 <!-- <a href="#Property:resource_is_replaced_by"></a>, --> <a href="#inverse-properties"></a>,
+<!--
 <a href="#Property:resource_is_version_of"></a>,
+-->
 <a href="#Property:resource_previous_version"></a>,
 <a href="#Property:resource_release_date"></a>,
 <a href="#Property:resource_status"></a>,
@@ -1871,7 +1885,9 @@ table.simple {width:100%;}
 <td>
 <a href="#Property:resource_has_current_version"></a>,
 <a href="#Property:resource_has_version"></a>,
+<!--
 <a href="#Property:resource_is_version_of"></a>,
+-->
 <a href="#Property:resource_previous_version"></a>,
 <a href="#Property:resource_release_date"></a>,
 <a href="#Property:resource_replaces"></a>,
@@ -1920,7 +1936,9 @@ table.simple {width:100%;}
 <a href="#Property:resource_has_current_version"></a>,
 <a href="#Property:resource_has_version"></a>,
 <!-- <a href="#Property:resource_is_replaced_by"></a>, -->
+<!--
 <a href="#Property:resource_is_version_of"></a>,
+-->
 <a href="#Property:resource_previous_version"></a>,
 <a href="#Property:resource_release_date"></a>,
 <a href="#Property:resource_replaces"></a>,
@@ -1964,7 +1982,9 @@ table.simple {width:100%;}
 <a href="#Property:resource_has_current_version"></a>,
 <a href="#Property:resource_has_version"></a>,
 <!-- <a href="#Property:resource_is_replaced_by"></a>, -->
+<!--
 <a href="#Property:resource_is_version_of"></a>,
+-->
 <a href="#Property:resource_previous_version"></a>,
 <a href="#Property:resource_release_date"></a>,
 <a href="#Property:resource_replaces"></a>,
@@ -2008,7 +2028,9 @@ table.simple {width:100%;}
 <a href="#Property:resource_has_current_version"></a>,
 <a href="#Property:resource_has_version"></a>,
 <!-- <a href="#Property:resource_is_replaced_by"></a>, -->
+<!--
 <a href="#Property:resource_is_version_of"></a>,
+-->
 <a href="#Property:resource_previous_version"></a>,
 <a href="#Property:resource_release_date"></a>,
 <a href="#Property:resource_replaces"></a>,
@@ -2381,7 +2403,9 @@ table.simple {width:100%;}
 <!-- 
             <li><a href="#Property:resource_is_replaced_by">is replaced by</a></li> 
 -->
+<!--
             <li><a href="#Property:resource_is_version_of">is version of</a></li>
+-->
             <li><a href="#Property:resource_previous_version">previous version</a></li>
             <li><a href="#Property:resource_replaces">replaces</a></li>
             <li><a href="#Property:resource_status">status</a></li>
@@ -2668,7 +2692,9 @@ table.simple {width:100%;}
             <!-- 
             <li><a href="#Property:resource_is_replaced_by">is replaced by</a></li> 
 -->
+<!--
             <li><a href="#Property:resource_is_version_of">is version of</a></li>
+-->
             <li><a href="#Property:resource_previous_version">previous version</a></li>
             <li><a href="#Property:resource_replaces">replaces</a></li>
             <li><a href="#Property:resource_status">status</a></li>
@@ -3187,7 +3213,9 @@ table.simple {width:100%;}
 <!-- 
             <li><a href="#Property:resource_is_replaced_by">is replaced by</a></li> 
 -->
+<!--
             <li><a href="#Property:resource_is_version_of">is version of</a></li>
+-->
             <li><a href="#Property:resource_previous_version">previous version</a></li>
             <li><a href="#Property:resource_replaces">replaces</a></li>
             <li><a href="#Property:resource_status">status</a></li>

--- a/dcat/index.html
+++ b/dcat/index.html
@@ -1790,9 +1790,7 @@ table.simple {width:100%;}
 <a href="#Property:resource_has_current_version"></a>,
 <a href="#Property:resource_has_version"></a>,
 <a href="#Property:resource_is_replaced_by"></a>,
-<!--
 <a href="#Property:resource_is_version_of"></a>,
--->
 <a href="#Property:resource_previous_version"></a>,
 <a href="#Property:resource_release_date"></a>,
 <a href="#Property:resource_replaces"></a>,
@@ -1885,9 +1883,7 @@ table.simple {width:100%;}
 <td>
 <a href="#Property:resource_has_current_version"></a>,
 <a href="#Property:resource_has_version"></a>,
-<!--
 <a href="#Property:resource_is_version_of"></a>,
--->
 <a href="#Property:resource_previous_version"></a>,
 <a href="#Property:resource_release_date"></a>,
 <a href="#Property:resource_replaces"></a>,
@@ -1900,7 +1896,8 @@ table.simple {width:100%;}
 
 <p>For guidance on the use of this property, see <a href="#version-replace"></a>.</p>
 
-</section> -->
+</section> 
+-->
 
 <section id="Property:resource_version">
 

--- a/dcat/index.html
+++ b/dcat/index.html
@@ -1642,6 +1642,7 @@ table.simple {width:100%;}
 
 </section>
 
+<!--
 <section id="Property:resource_is_version_of">
 
 <h4>Property: is version of</h4>
@@ -1693,6 +1694,7 @@ table.simple {width:100%;}
 <p>For guidance on the use of this property, see <a href="#version-history"></a>.</p>
 
 </section>
+-->
 
 <section id="Property:resource_has_current_version">
 
@@ -3884,9 +3886,15 @@ The interval can also be open - i.e., it can have just a start or just an end.</
 <td><a href="#Property:resource_is_referenced_by"><code>dcterms:isReferencedBy</code></a></td>
 <td id="inverse-of-resource_is_referenced_by"><a href="https://www.dublincore.org/specifications/dublin-core/dcmi-terms/#http://purl.org/dc/terms/references"><code>dcterms:references</code></a></td>
 </tr>
+<!--
 <tr>
 <td><a href="#Property:resource_is_version_of"><code>dcat:isVersionOf</code></a></td>
 <td id="inverse-of-resource_is_version_of"><code>dcat:hasVersion</code></td>
+</tr>
+-->
+<tr>
+<td><a href="#Property:resource_has_version"><code>dcat:hasVersion</code></a></td>
+<td id="Property:resource_is_version_of"><code>dcat:isVersionOf</code></td>
 </tr>
 <!--
 <tr>
@@ -4535,10 +4543,14 @@ For example:</p>
 
 <ul>
 <li><a href="#Property:resource_previous_version"><code>dcat:previousVersion</code></a> (equivalent to <a data-cite="?PAV#d4e459"><code>pav:previousVersion</code></a>)</li>
+<!--
 <li><p><a href="#Property:resource_has_version"><code>dcat:hasVersion</code></a> (equivalent to <a data-cite="?PAV#d4e395"><code>pav:hasVersion</code></a>), plus the following additional properties:</p>
 <ul>
 <li><a href="#Property:resource_is_version_of"><code>dcat:isVersionOf</code></a> (inverse of <code>dcat:hasVersion</code>);</li>
 <li><a href="#Property:resource_has_current_version"><code>dcat:hasCurrentVersion</code></a> (equivalent to <a data-cite="?PAV#d4e359"><code>pav:hasCurrentVersion</code></a>, and subproperty of <code>dcat:hasVersion</code>)</li>
+-->
+<li><p><a href="#Property:resource_has_version"><code>dcat:hasVersion</code></a> (equivalent to <a data-cite="?PAV#d4e395"><code>pav:hasVersion</code></a>);</p>
+<li><a href="#Property:resource_has_current_version"><code>dcat:hasCurrentVersion</code></a> (equivalent to <a data-cite="?PAV#d4e359"><code>pav:hasCurrentVersion</code></a>, and subproperty of <code>dcat:hasVersion</code>).</li>
 <!--
 <li><a href="#Property:resource_has_last_version"><code>dcat:hasLastVersion</code></a> (subproperty of <code>dcat:hasVersion</code>)</li>
 -->
@@ -4565,7 +4577,11 @@ For example:</p>
 
 <p>In addition to this, property <code>dcat:hasVersion</code> can be used to specify a version hierarchy, by linking an abstract resource to its versions.</p>
 
+<!--
 <p>If needed, the version hierarchy can be further described by specific properties. More precisely, property <code>dcat:isVersionOf</code> (inverse of <code>dcat:hasVersion</code>) gives the possibility of specifying a back link from a version to the abstract resource, whereas property <code>dcat:hasCurrentVersion</code> link an abstract resource to snapshot corresponding to the current version of the content.</p>
+-->
+
+<p>If needed, the version hierarchy can be further described by specific properties. More precisely, property <code>dcat:hasCurrentVersion</code> link an abstract resource to snapshot corresponding to the current version of the content, whereas property <code>dcat:isVersionOf</code> (inverse of <code>dcat:hasVersion</code>) gives the possibility of specifying a back link from a version to the abstract resource (for the use of this property, see <a href="#inverse-properties"></a>).</p>
 
 <!--
 <p>If needed, the version hierarchy can be further described by specific properties. More precisely, property <code>dcat:isVersionOf</code> (inverse of <code>dcat:hasVersion</code>) gives the possibility of specifying a back link from a version to the abstract resource, whereas property <code>dcat:hasCurrentVersion</code> link an abstract resource to snapshot corresponding to the current version of the content. Finally, property <code>dcat:hasLastVersion</code> link the abstract resource to the latest version of the resource in the version chain. Note that the current version of a resource may be different from the last version: e.g., if the last version is still in draft status, the current one may correspond to the latest stable version of the resource.</p>

--- a/dcat/index.html
+++ b/dcat/index.html
@@ -1688,7 +1688,7 @@ table.simple {width:100%;}
 <td>
 <a href="#Property:resource_has_current_version"></a>,
 <a href="#Property:resource_has_version"></a>,
-<!-- <a href="#Property:resource_is_replaced_by"></a>, -->
+<a href="#Property:resource_is_replaced_by"></a>,
 <a href="#Property:resource_previous_version"></a>,
 <a href="#Property:resource_release_date"></a>,
 <a href="#Property:resource_replaces"></a>,


### PR DESCRIPTION
Addressing open issue in PR https://github.com/w3c/dxwg/pull/1410

Summary of changes:
- Commented section on `dcat:isVersionOf`
- Revised versioning section to clarify how to use property `dcat:isVersionOf`
- Revised section on inverse properties to clarify that the specification of `dcat:isVersionOf` is optional, and can only be used in addition to `dcat:hasVersion`

Preview: https://raw.githack.com/w3c/dxwg/andrea-perego-dcat-isversionof/dcat/index.html

Diff: https://services.w3.org/htmldiff?doc1=https%3A%2F%2Fraw.githack.com%2Fw3c%2Fdxwg%2FDCAT-adjustementForInverseProperties%2Fdcat%2Findex.html&doc2=https%3A%2F%2Fraw.githack.com%2Fw3c%2Fdxwg%2Fandrea-perego-dcat-isversionof%2Fdcat%2Findex.html