### PR TITLE
Editorial fix to DCAT2 implementation report

### DIFF
--- a/dcat-implementation-report/config.js
+++ b/dcat-implementation-report/config.js
@@ -1,5 +1,6 @@
 var respecConfig = {
   specStatus: "base",
+  publishDate: "2019-10-30",
   editors: [{
     name:       "Riccardo Albertoni",
     orcid:  "0000-0001-5648-2713",
@@ -85,7 +86,7 @@ var respecConfig = {
       "date": "2019"
     },
     "DCAT-AP-USE":{
-      "href":"https://joinup.ec.europa.eu/document/report-dcat-ap-use",
+      "href":"https://joinup.ec.europa.eu/solution/dcat-application-profile-data-portals-europe/document/report-dcat-ap-use",
       "title":"Report on DCAT-AP Use",
       "publisher":"European Commission",
       "date":"2017"

--- a/dcat-implementation-report/config.js
+++ b/dcat-implementation-report/config.js
@@ -90,6 +90,18 @@ var respecConfig = {
       "title":"Report on DCAT-AP Use",
       "publisher":"European Commission",
       "date":"2017"
+    },
+    "DCAT-AP":{
+      "href":"https://joinup.ec.europa.eu/release/dcat-ap/121",
+      "title":"DCAT Application Profile For Data Portals In Europe. Version 1.2.1",
+      "publisher":"European Commission",
+      "date":"28 May 2019"
+    },
+    "GeoDCAT-AP":{
+      "href":"https://joinup.ec.europa.eu/release/geodcat-ap/101",
+      "title":"GeoDCAT-AP: A Geospatial Extension For The DCAT Application Profile For Data Portals In Europe. Version 1.0.1",
+      "publisher":"European Commission",
+      "date":"2 August 2016"
     }
   }
 };

--- a/dcat-implementation-report/index.html
+++ b/dcat-implementation-report/index.html
@@ -3,7 +3,7 @@
   <head>
     <meta charset='utf-8'>
     <title>DCAT Version 2 Implementation Report</title>
-    <script src="https://www.w3.org/Tools/respec/respec-w3c-common" async class="remove"></script>
+    <script src="https://www.w3.org/Tools/respec/respec-w3c" async class="remove"></script>
     <script class="remove" src="config.js"></script>
     <style>
       table{width:100%;}


### PR DESCRIPTION
Editorial fixes:
- Fix broken link in bibref 
- Specify explicitly the publication date
- Switch to `respec-w3c`
- Harcode bib refs to relevant versions of DCAT-AP and GeoDCAT-AP in `config.js`

Preview: https://raw.githack.com/w3c/dxwg/fix-dcat2-implementation-report/dcat-implementation-report/index.html