### PR TITLE
Fix URL for dcat:byteSize

### DIFF
--- a/dcat/index.html
+++ b/dcat/index.html
@@ -2967,7 +2967,7 @@ table.simple {width:100%;}
             </p-->
 
             <table class="def">
-                <tr><th>RDF Property:</th><td><a href="http://www.w3.org/ns/dcat#size"><code>dcat:byteSize</code></a></td></tr>
+                <tr><th>RDF Property:</th><td><a href="http://www.w3.org/ns/dcat#byteSize"><code>dcat:byteSize</code></a></td></tr>
                 <tr><th class="prop">Definition:</th><td>The size of a distribution in bytes.</td></tr>
                 <tr><th class="prop">Domain:</th><td><a href="#Class:Distribution"><code>dcat:Distribution</code></a></td></tr>
                 <tr><th class="prop">Range:</th><td><a href="http://www.w3.org/2000/01/rdf-schema#Literal"><code>rdfs:Literal</code></a> typically typed as <a data-cite="XMLSCHEMA11-2#nonNegativeInteger"><code>xsd:nonNegativeInteger</code></a>.</td></tr>


### PR DESCRIPTION
As per typo reported in https://github.com/w3c/dxwg/issues/1412