### PR TITLE
Editorial revision to definitions of locn:geometry, dcat:bbox, dcat:centroid

### DIFF
--- a/dcat/index.html
+++ b/dcat/index.html
@@ -3666,7 +3666,7 @@ The interval can also be open - i.e., it can have just a start or just an end.</
 <!--
 <tr><th class="prop">Definition:</th><td>Associates any resource with the corresponding geometry. [[LOCN]]</td></tr>
 -->
-<tr><th class="prop">Definition:</th><td>Associates any spatial thing [[?SDW-BP]] with the corresponding geometry.</td></tr>
+<tr><th class="prop">Definition:</th><td>Associates a spatial thing [[?SDW-BP]] with a corresponding geometry.</td></tr>
 <tr><th class="prop">Range:</th><td><a data-cite="LOCN#locn:Geometry"><code title="https://www.w3.org/ns/locn#Geometry">locn:Geometry</code></a></td></tr>
 <tr><th class="prop">Usage note:</th><td>The range of this property (<code title="https://www.w3.org/ns/locn#Geometry">locn:Geometry</code>) allows for any type of geometry specification. E.g., the geometry could be encoded by a literal, as <abbr title="Well-known Text">WKT</abbr> (<a href="http://www.opengis.net/ont/geosparql#wktLiteral"><code title="http://www.opengis.net/ont/geosparql#wktLiteral">geosparql:wktLiteral</code></a> [[GeoSPARQL]]), or represented by a class, as <a href="http://www.opengis.net/ont/geosparql#Geometry"><code title="http://www.opengis.net/ont/geosparql#Geometry">geosparql:Geometry</code></a> (or any of its subclasses) [[GeoSPARQL]].</td></tr>
 </table>

--- a/dcat/index.html
+++ b/dcat/index.html
@@ -3666,7 +3666,7 @@ The interval can also be open - i.e., it can have just a start or just an end.</
 <!--
 <tr><th class="prop">Definition:</th><td>Associates any resource with the corresponding geometry. [[LOCN]]</td></tr>
 -->
-<tr><th class="prop">Definition:</th><td>Associates any spatial thing [[?SDW-BP]] with the corresponding geometry. [[LOCN]]</td></tr>
+<tr><th class="prop">Definition:</th><td>Associates any spatial thing [[?SDW-BP]] with the corresponding geometry.</td></tr>
 <tr><th class="prop">Range:</th><td><a data-cite="LOCN#locn:Geometry"><code title="https://www.w3.org/ns/locn#Geometry">locn:Geometry</code></a></td></tr>
 <tr><th class="prop">Usage note:</th><td>The range of this property (<code title="https://www.w3.org/ns/locn#Geometry">locn:Geometry</code>) allows for any type of geometry specification. E.g., the geometry could be encoded by a literal, as <abbr title="Well-known Text">WKT</abbr> (<a href="http://www.opengis.net/ont/geosparql#wktLiteral"><code title="http://www.opengis.net/ont/geosparql#wktLiteral">geosparql:wktLiteral</code></a> [[GeoSPARQL]]), or represented by a class, as <a href="http://www.opengis.net/ont/geosparql#Geometry"><code title="http://www.opengis.net/ont/geosparql#Geometry">geosparql:Geometry</code></a> (or any of its subclasses) [[GeoSPARQL]].</td></tr>
 </table>

--- a/dcat/index.html
+++ b/dcat/index.html
@@ -3663,7 +3663,10 @@ The interval can also be open - i.e., it can have just a start or just an end.</
 <th>RDF Property:</th>
 <td><a data-cite="LOCN#locn:geometry"><code title="http://www.w3.org/ns/locn#geometry">locn:geometry</code></a></td>
 </tr>
+<!--
 <tr><th class="prop">Definition:</th><td>Associates any resource with the corresponding geometry. [[LOCN]]</td></tr>
+-->
+<tr><th class="prop">Definition:</th><td>Associates any spatial thing [[?SDW-BP]] with the corresponding geometry. [[LOCN]]</td></tr>
 <tr><th class="prop">Range:</th><td><a data-cite="LOCN#locn:Geometry"><code title="https://www.w3.org/ns/locn#Geometry">locn:Geometry</code></a></td></tr>
 <tr><th class="prop">Usage note:</th><td>The range of this property (<code title="https://www.w3.org/ns/locn#Geometry">locn:Geometry</code>) allows for any type of geometry specification. E.g., the geometry could be encoded by a literal, as <abbr title="Well-known Text">WKT</abbr> (<a href="http://www.opengis.net/ont/geosparql#wktLiteral"><code title="http://www.opengis.net/ont/geosparql#wktLiteral">geosparql:wktLiteral</code></a> [[GeoSPARQL]]), or represented by a class, as <a href="http://www.opengis.net/ont/geosparql#Geometry"><code title="http://www.opengis.net/ont/geosparql#Geometry">geosparql:Geometry</code></a> (or any of its subclasses) [[GeoSPARQL]].</td></tr>
 </table>
@@ -3689,7 +3692,10 @@ The interval can also be open - i.e., it can have just a start or just an end.</
 <tr><th>RDF Property:</th>
 <td><a href="http://www.w3.org/ns/dcat#bbox"><code title="http://www.w3.org/ns/dcat#centroid">dcat:bbox</code></a></td>
 </tr>
+<!--
 <tr><th class="prop">Definition:</th><td>The geographic bounding box of a resource.</td></tr>
+-->
+<tr><th class="prop">Definition:</th><td>The geographic bounding box of a spatial thing [[?SDW-BP]].</td></tr>
 <tr><th class="prop">Range:</th><td><a data-cite="RDF-SCHEMA#ch_literal"><code title="http://www.w3.org/2000/01/rdf-schema#Literal">rdfs:Literal</code></a></td></tr>
 <tr><th class="prop">Usage note:</th><td>The range of this property (<code>rdfs:Literal</code>) is intentionally generic, with the purpose of allowing different geometry literal encodings. E.g., the geometry could be encoded as a <abbr title="Well-known Text">WKT</abbr> literal (<a href="http://www.opengis.net/ont/geosparql#wktLiteral"><code title="http://www.opengis.net/ont/geosparql#wktLiteral">geosparql:wktLiteral</code></a> [[GeoSPARQL]]).</td></tr>
 </table>
@@ -3716,7 +3722,10 @@ The interval can also be open - i.e., it can have just a start or just an end.</
 <th>RDF Property:</th>
 <td><a href="http://www.w3.org/ns/dcat#centroid"><code title="http://www.w3.org/ns/dcat#centroid">dcat:centroid</code></a></td>
 </tr>
+<!--
 <tr><th class="prop">Definition:</th><td>The geographic center (centroid) of a resource.</td></tr>
+-->
+<tr><th class="prop">Definition:</th><td>The geographic center (centroid) of a spatial thing [[?SDW-BP]].</td></tr>
 <tr><th class="prop">Range:</th><td><a data-cite="RDF-SCHEMA#ch_literal"><code title="http://www.w3.org/2000/01/rdf-schema#Literal">rdfs:Literal</code></a></td></tr>
 <tr><th class="prop">Usage note:</th><td>The range of this property (<code>rdfs:Literal</code>) is intentionally generic, with the purpose of allowing different geometry literal encodings. E.g., the geometry could be encoded as a <abbr title="Well-known Text">WKT</abbr> literal (<a href="http://www.opengis.net/ont/geosparql#wktLiteral"><code title="http://www.opengis.net/ont/geosparql#wktLiteral">geosparql:wktLiteral</code></a> [[GeoSPARQL]]).</td></tr>
 </table>

--- a/dcat/rdf/dcat-external.jsonld
+++ b/dcat/rdf/dcat-external.jsonld
@@ -1,102 +1,102 @@
 {
   "@graph" : [ {
     "@id" : "_:b0",
-    "homepage" : "https://csiro.au",
-    "foaf:name" : "Commonwealth Scientific and Industrial Research Organisation"
+    "homepage" : "http://stfc.ac.uk",
+    "foaf:name" : "Science and Technology Facilities Council, UK"
   }, {
     "@id" : "_:b1",
-    "foaf:name" : "Richard Cyganiak"
+    "seeAlso" : "http://fadmaa.me/foaf.ttl",
+    "foaf:name" : "Fadi Maali"
   }, {
     "@id" : "_:b10",
-    "@type" : "foaf:Person",
-    "affiliation" : "_:b0",
-    "seeAlso" : "https://orcid.org/0000-0002-3884-3420",
-    "foaf:name" : "Simon J D Cox",
-    "workInfoHomepage" : "http://people.csiro.au/Simon-Cox"
+    "homepage" : "http://www.asahi-net.or.jp/~ax2s-kmtn/",
+    "foaf:name" : "Shuji Kamitsuna"
   }, {
     "@id" : "_:b11",
-    "affiliation" : "_:b22",
-    "foaf:name" : "David Browning"
+    "foaf:name" : "Marios Meimaris"
   }, {
     "@id" : "_:b12",
-    "seeAlso" : "http://www.eurecom.fr/~atemezin/gatemezing-foaf.rdf",
-    "foaf:name" : "Ghislain Auguste Atemezing"
-  }, {
-    "@id" : "_:b13",
-    "seeAlso" : "https://orcid.org/0000-0001-9300-2694",
-    "homepage" : "http://www.andrea-perego.name/foaf/#me",
-    "foaf:name" : "Andrea Perego"
-  }, {
-    "@id" : "_:b14",
-    "affiliation" : "_:b21",
-    "foaf:name" : "Rufus Pollock"
-  }, {
-    "@id" : "_:b15",
-    "seeAlso" : "https://jakub.klímek.com/#me",
-    "homepage" : "https://jakub.klímek.com/",
-    "foaf:name" : "Jakub Klímek"
-  }, {
-    "@id" : "_:b16",
     "seeAlso" : "https://orcid.org/0000-0001-5648-2713",
     "homepage" : [ "https://w3id.org/people/ralbertoni/", "http://www.imati.cnr.it/index.php/people/8-curricula/178-riccardo-albertoni" ],
     "foaf:name" : "Riccardo Albertoni"
   }, {
-    "@id" : "_:b17",
+    "@id" : "_:b13",
     "seeAlso" : "http://makxdekkers.com/makxdekkers.rdf#me",
     "homepage" : "http://makxdekkers.com/",
     "foaf:name" : "Makx Dekkers"
   }, {
-    "@id" : "_:b18",
+    "@id" : "_:b14",
     "affiliation" : "_:b20",
+    "foaf:name" : "David Browning"
+  }, {
+    "@id" : "_:b15",
+    "affiliation" : "_:b22",
+    "foaf:name" : "Vassilios Peristeras"
+  }, {
+    "@id" : "_:b16",
+    "foaf:name" : "Boris Villazón-Terrazas"
+  }, {
+    "@id" : "_:b17",
+    "affiliation" : "_:b0",
     "seeAlso" : "https://orcid.org/0000-0003-3499-8262",
     "homepage" : "https://agbeltran.github.io",
     "foaf:name" : "Alejandra Gonzalez-Beltran"
   }, {
+    "@id" : "_:b18",
+    "seeAlso" : "http://www.eurecom.fr/~atemezin/gatemezing-foaf.rdf",
+    "foaf:name" : "Ghislain Auguste Atemezing"
+  }, {
     "@id" : "_:b19",
-    "homepage" : "http://ec.europa.eu/dgs/informatics/",
-    "foaf:name" : "European Commission, DG DIGIT"
+    "homepage" : "https://csiro.au",
+    "foaf:name" : "Commonwealth Scientific and Industrial Research Organisation"
   }, {
     "@id" : "_:b2",
-    "seeAlso" : "http://fadmaa.me/foaf.ttl",
-    "foaf:name" : "Fadi Maali"
+    "@type" : "foaf:Person",
+    "affiliation" : "_:b19",
+    "seeAlso" : "https://orcid.org/0000-0002-3884-3420",
+    "foaf:name" : "Simon J D Cox",
+    "workInfoHomepage" : "http://people.csiro.au/Simon-Cox"
   }, {
     "@id" : "_:b20",
-    "homepage" : "http://stfc.ac.uk",
-    "foaf:name" : "Science and Technology Facilities Council, UK"
+    "homepage" : "http://www.refinitiv.com",
+    "foaf:name" : "Refinitiv"
   }, {
     "@id" : "_:b21",
     "homepage" : "http://okfn.org",
     "foaf:name" : "Open Knowledge Foundation"
   }, {
     "@id" : "_:b22",
-    "homepage" : "http://www.refinitiv.com",
-    "foaf:name" : "Refinitiv"
+    "homepage" : "http://ec.europa.eu/dgs/informatics/",
+    "foaf:name" : "European Commission, DG DIGIT"
   }, {
     "@id" : "_:b3",
-    "foaf:name" : "Marios Meimaris"
+    "affiliation" : "_:b21",
+    "foaf:name" : "Rufus Pollock"
   }, {
     "@id" : "_:b4",
-    "foaf:name" : "Boris Villazón-Terrazas"
+    "seeAlso" : "https://jakub.klímek.com/#me",
+    "homepage" : "https://jakub.klímek.com/",
+    "foaf:name" : "Jakub Klímek"
   }, {
     "@id" : "_:b5",
     "foaf:name" : "John Erickson"
   }, {
     "@id" : "_:b6",
+    "foaf:name" : "Martin Alvarez-Espinar"
+  }, {
+    "@id" : "_:b7",
     "affiliation" : "http://www.w3.org/data#W3C",
     "seeAlso" : "http://philarcher.org/foaf.rdf#me",
     "homepage" : "http://www.w3.org/People/all#phila",
     "foaf:name" : "Phil Archer"
   }, {
-    "@id" : "_:b7",
-    "affiliation" : "_:b19",
-    "foaf:name" : "Vassilios Peristeras"
-  }, {
     "@id" : "_:b8",
-    "homepage" : "http://www.asahi-net.or.jp/~ax2s-kmtn/",
-    "foaf:name" : "Shuji Kamitsuna"
+    "foaf:name" : "Richard Cyganiak"
   }, {
     "@id" : "_:b9",
-    "foaf:name" : "Martin Alvarez-Espinar"
+    "seeAlso" : "https://orcid.org/0000-0001-9300-2694",
+    "homepage" : "http://www.andrea-perego.name/foaf/#me",
+    "foaf:name" : "Andrea Perego"
   }, {
     "@id" : "dct:Location",
     "skos:changeNote" : [ {
@@ -1236,8 +1236,8 @@
   }, {
     "@id" : "http://www.w3.org/ns/dcat/external",
     "@type" : "owl:Ontology",
-    "contributor" : [ "_:b3", "_:b4", "_:b1", "_:b6", "_:b7", "_:b8", "_:b9", "_:b10", "_:b11", "_:b12", "_:b13", "_:b14", "_:b15", "_:b16", "_:b17", "_:b18" ],
-    "creator" : [ "_:b5", "_:b2" ],
+    "contributor" : [ "_:b2", "_:b3", "_:b4", "_:b6", "_:b7", "_:b8", "_:b9", "_:b10", "_:b11", "_:b12", "_:b13", "_:b14", "_:b15", "_:b16", "_:b17", "_:b18" ],
+    "creator" : [ "_:b1", "_:b5" ],
     "license" : "https://creativecommons.org/licenses/by/4.0/",
     "modified" : [ "2019-09-09", "2013-11-28", "2012-04-24", "2013-09-20", "2017-12-19" ],
     "rdfs:comment" : {
@@ -1266,17 +1266,17 @@
       "@value" : "Vlastnost v tomto kontextu byla přidána ve verzi DCAT 2.0."
     } ],
     "skos:definition" : [ {
+      "@language" : "en",
+      "@value" : "Associates a spatial thing [SDW-BP] with a corresponding geometry."
+    }, {
       "@language" : "es",
       "@value" : "Asocia cualquier recurso con la geometría correspondiente."
     }, {
-      "@language" : "en",
-      "@value" : "Associates any resource with the corresponding geometry."
+      "@language" : "it",
+      "@value" : "Associa una risorsa a una geometria corrispondente."
     }, {
       "@language" : "cs",
       "@value" : "Přiřazuje geometrii jakémukoliv zdroji."
-    }, {
-      "@language" : "it",
-      "@value" : "Associa qualsiasi risorsa alla geometria corrispondente."
     } ],
     "skos:scopeNote" : [ {
       "@language" : "es",
@@ -1544,25 +1544,21 @@
       "@id" : "http://xmlns.com/foaf/0.1/homepage",
       "@type" : "@id"
     },
-    "seeAlso" : {
-      "@id" : "http://www.w3.org/2000/01/rdf-schema#seeAlso",
+    "creator" : {
+      "@id" : "http://purl.org/dc/terms/creator",
       "@type" : "@id"
     },
     "imports" : {
       "@id" : "http://www.w3.org/2002/07/owl#imports",
       "@type" : "@id"
     },
-    "modified" : {
-      "@id" : "http://purl.org/dc/terms/modified",
-      "@type" : "http://www.w3.org/2001/XMLSchema#date"
-    },
     "contributor" : {
       "@id" : "http://purl.org/dc/terms/contributor",
       "@type" : "@id"
     },
-    "creator" : {
-      "@id" : "http://purl.org/dc/terms/creator",
-      "@type" : "@id"
+    "modified" : {
+      "@id" : "http://purl.org/dc/terms/modified",
+      "@type" : "http://www.w3.org/2001/XMLSchema#date"
     },
     "label" : {
       "@id" : "http://www.w3.org/2000/01/rdf-schema#label",
@@ -1576,13 +1572,21 @@
       "@id" : "http://purl.org/dc/terms/license",
       "@type" : "@id"
     },
-    "changeNote" : {
-      "@id" : "http://www.w3.org/2004/02/skos/core#changeNote",
-      "@type" : "http://www.w3.org/1999/02/22-rdf-syntax-ns#langString"
+    "workInfoHomepage" : {
+      "@id" : "http://xmlns.com/foaf/0.1/workInfoHomepage",
+      "@type" : "@id"
+    },
+    "seeAlso" : {
+      "@id" : "http://www.w3.org/2000/01/rdf-schema#seeAlso",
+      "@type" : "@id"
     },
     "affiliation" : {
       "@id" : "http://schema.org/affiliation",
       "@type" : "@id"
+    },
+    "changeNote" : {
+      "@id" : "http://www.w3.org/2004/02/skos/core#changeNote",
+      "@type" : "http://www.w3.org/1999/02/22-rdf-syntax-ns#langString"
     },
     "range" : {
       "@id" : "http://www.w3.org/2000/01/rdf-schema#range",
@@ -1591,10 +1595,6 @@
     "editorialNote" : {
       "@id" : "http://www.w3.org/2004/02/skos/core#editorialNote",
       "@type" : "http://www.w3.org/1999/02/22-rdf-syntax-ns#langString"
-    },
-    "workInfoHomepage" : {
-      "@id" : "http://xmlns.com/foaf/0.1/workInfoHomepage",
-      "@type" : "@id"
     },
     "owl" : "http://www.w3.org/2002/07/owl#",
     "xsd" : "http://www.w3.org/2001/XMLSchema#",

--- a/dcat/rdf/dcat-external.rdf
+++ b/dcat/rdf/dcat-external.rdf
@@ -13,6 +13,42 @@
     xmlns:foaf="http://xmlns.com/foaf/0.1/"
     xmlns:xsd="http://www.w3.org/2001/XMLSchema#">
   <owl:Ontology rdf:about="http://www.w3.org/ns/dcat/external">
+    <owl:imports rdf:resource="http://www.w3.org/2004/02/skos/core"/>
+    <dct:contributor rdf:parseType="Resource">
+      <foaf:name>Jakub Klímek</foaf:name>
+      <foaf:homepage rdf:resource="https://jakub.klímek.com/"/>
+      <rdfs:seeAlso rdf:resource="https://jakub.klímek.com/#me"/>
+    </dct:contributor>
+    <dct:contributor rdf:parseType="Resource">
+      <foaf:name>Rufus Pollock</foaf:name>
+      <sdo:affiliation rdf:parseType="Resource">
+        <foaf:name>Open Knowledge Foundation</foaf:name>
+        <foaf:homepage rdf:resource="http://okfn.org"/>
+      </sdo:affiliation>
+    </dct:contributor>
+    <dct:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#date"
+    >2019-09-09</dct:modified>
+    <dct:contributor rdf:parseType="Resource">
+      <foaf:name>Richard Cyganiak</foaf:name>
+    </dct:contributor>
+    <dct:contributor rdf:parseType="Resource">
+      <foaf:name>Boris Villazón-Terrazas</foaf:name>
+    </dct:contributor>
+    <dct:contributor rdf:parseType="Resource">
+      <foaf:name>Vassilios Peristeras</foaf:name>
+      <sdo:affiliation rdf:parseType="Resource">
+        <foaf:name>European Commission, DG DIGIT</foaf:name>
+        <foaf:homepage rdf:resource="http://ec.europa.eu/dgs/informatics/"/>
+      </sdo:affiliation>
+    </dct:contributor>
+    <owl:imports rdf:resource="http://purl.org/dc/terms/"/>
+    <dct:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#date"
+    >2013-11-28</dct:modified>
+    <dct:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#date"
+    >2012-04-24</dct:modified>
+    <dct:creator rdf:parseType="Resource">
+      <foaf:name>John Erickson</foaf:name>
+    </dct:creator>
     <dct:contributor>
       <foaf:Person>
         <foaf:workInfoHomepage rdf:resource="http://people.csiro.au/Simon-Cox"/>
@@ -24,40 +60,6 @@
         </sdo:affiliation>
       </foaf:Person>
     </dct:contributor>
-    <dct:creator rdf:parseType="Resource">
-      <foaf:name>Fadi Maali</foaf:name>
-      <rdfs:seeAlso rdf:resource="http://fadmaa.me/foaf.ttl"/>
-    </dct:creator>
-    <owl:imports rdf:resource="http://www.w3.org/2004/02/skos/core"/>
-    <dct:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#date"
-    >2019-09-09</dct:modified>
-    <owl:imports rdf:resource="http://purl.org/dc/terms/"/>
-    <dct:contributor rdf:parseType="Resource">
-      <foaf:name>Shuji Kamitsuna</foaf:name>
-      <foaf:homepage rdf:resource="http://www.asahi-net.or.jp/~ax2s-kmtn/"/>
-    </dct:contributor>
-    <dct:contributor rdf:parseType="Resource">
-      <foaf:name>Martin Alvarez-Espinar</foaf:name>
-    </dct:contributor>
-    <dct:contributor rdf:parseType="Resource">
-      <foaf:name>Marios Meimaris</foaf:name>
-    </dct:contributor>
-    <dct:contributor rdf:parseType="Resource">
-      <foaf:name>Rufus Pollock</foaf:name>
-      <sdo:affiliation rdf:parseType="Resource">
-        <foaf:name>Open Knowledge Foundation</foaf:name>
-        <foaf:homepage rdf:resource="http://okfn.org"/>
-      </sdo:affiliation>
-    </dct:contributor>
-    <dct:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#date"
-    >2013-11-28</dct:modified>
-    <dct:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#date"
-    >2012-04-24</dct:modified>
-    <dct:contributor rdf:parseType="Resource">
-      <foaf:name>Makx Dekkers</foaf:name>
-      <foaf:homepage rdf:resource="http://makxdekkers.com/"/>
-      <rdfs:seeAlso rdf:resource="http://makxdekkers.com/makxdekkers.rdf#me"/>
-    </dct:contributor>
     <rdfs:label xml:lang="en">External terms used in the data catalog vocabulary.</rdfs:label>
     <rdfs:comment xml:lang="en">This RDF graph contains partial descriptions of elements from external vocabularies that are used by DCAT. The primary definitions for these terms are in the original specifications and standards. In the context of DCAT some additional axioms (sub-class and sub-property relationships) are introduced, and some more specific usage notes are added.</rdfs:comment>
     <dct:license rdf:resource="https://creativecommons.org/licenses/by/4.0/"/>
@@ -65,17 +67,31 @@
     >2013-09-20</dct:modified>
     <owl:imports rdf:resource="http://www.w3.org/ns/prov-o#"/>
     <dct:contributor rdf:parseType="Resource">
-      <foaf:name>Ghislain Auguste Atemezing</foaf:name>
-      <rdfs:seeAlso rdf:resource="http://www.eurecom.fr/~atemezin/gatemezing-foaf.rdf"/>
+      <foaf:name>David Browning</foaf:name>
+      <sdo:affiliation rdf:parseType="Resource">
+        <foaf:name>Refinitiv</foaf:name>
+        <foaf:homepage rdf:resource="http://www.refinitiv.com"/>
+      </sdo:affiliation>
     </dct:contributor>
     <dct:contributor rdf:parseType="Resource">
-      <foaf:name>Phil Archer</foaf:name>
-      <foaf:homepage rdf:resource="http://www.w3.org/People/all#phila"/>
-      <rdfs:seeAlso rdf:resource="http://philarcher.org/foaf.rdf#me"/>
-      <sdo:affiliation rdf:resource="http://www.w3.org/data#W3C"/>
+      <foaf:name>Riccardo Albertoni</foaf:name>
+      <foaf:homepage rdf:resource="https://w3id.org/people/ralbertoni/"/>
+      <foaf:homepage rdf:resource="http://www.imati.cnr.it/index.php/people/8-curricula/178-riccardo-albertoni"/>
+      <rdfs:seeAlso rdf:resource="https://orcid.org/0000-0001-5648-2713"/>
     </dct:contributor>
     <dct:contributor rdf:parseType="Resource">
-      <foaf:name>Richard Cyganiak</foaf:name>
+      <foaf:name>Marios Meimaris</foaf:name>
+    </dct:contributor>
+    <dct:contributor rdf:parseType="Resource">
+      <foaf:name>Shuji Kamitsuna</foaf:name>
+      <foaf:homepage rdf:resource="http://www.asahi-net.or.jp/~ax2s-kmtn/"/>
+    </dct:contributor>
+    <dct:creator rdf:parseType="Resource">
+      <foaf:name>Fadi Maali</foaf:name>
+      <rdfs:seeAlso rdf:resource="http://fadmaa.me/foaf.ttl"/>
+    </dct:creator>
+    <dct:contributor rdf:parseType="Resource">
+      <foaf:name>Martin Alvarez-Espinar</foaf:name>
     </dct:contributor>
     <dct:contributor rdf:parseType="Resource">
       <foaf:name>Alejandra Gonzalez-Beltran</foaf:name>
@@ -86,44 +102,28 @@
         <foaf:homepage rdf:resource="http://stfc.ac.uk"/>
       </sdo:affiliation>
     </dct:contributor>
+    <dct:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#date"
+    >2017-12-19</dct:modified>
     <dct:contributor rdf:parseType="Resource">
-      <foaf:name>Riccardo Albertoni</foaf:name>
-      <foaf:homepage rdf:resource="https://w3id.org/people/ralbertoni/"/>
-      <foaf:homepage rdf:resource="http://www.imati.cnr.it/index.php/people/8-curricula/178-riccardo-albertoni"/>
-      <rdfs:seeAlso rdf:resource="https://orcid.org/0000-0001-5648-2713"/>
+      <foaf:name>Makx Dekkers</foaf:name>
+      <foaf:homepage rdf:resource="http://makxdekkers.com/"/>
+      <rdfs:seeAlso rdf:resource="http://makxdekkers.com/makxdekkers.rdf#me"/>
     </dct:contributor>
+    <dct:contributor rdf:parseType="Resource">
+      <foaf:name>Phil Archer</foaf:name>
+      <foaf:homepage rdf:resource="http://www.w3.org/People/all#phila"/>
+      <rdfs:seeAlso rdf:resource="http://philarcher.org/foaf.rdf#me"/>
+      <sdo:affiliation rdf:resource="http://www.w3.org/data#W3C"/>
+    </dct:contributor>
+    <owl:imports rdf:resource="http://www.w3.org/ns/odrl/2/"/>
     <dct:contributor rdf:parseType="Resource">
       <foaf:name>Andrea Perego</foaf:name>
       <foaf:homepage rdf:resource="http://www.andrea-perego.name/foaf/#me"/>
       <rdfs:seeAlso rdf:resource="https://orcid.org/0000-0001-9300-2694"/>
     </dct:contributor>
     <dct:contributor rdf:parseType="Resource">
-      <foaf:name>Boris Villazón-Terrazas</foaf:name>
-    </dct:contributor>
-    <dct:creator rdf:parseType="Resource">
-      <foaf:name>John Erickson</foaf:name>
-    </dct:creator>
-    <dct:contributor rdf:parseType="Resource">
-      <foaf:name>Vassilios Peristeras</foaf:name>
-      <sdo:affiliation rdf:parseType="Resource">
-        <foaf:name>European Commission, DG DIGIT</foaf:name>
-        <foaf:homepage rdf:resource="http://ec.europa.eu/dgs/informatics/"/>
-      </sdo:affiliation>
-    </dct:contributor>
-    <dct:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#date"
-    >2017-12-19</dct:modified>
-    <owl:imports rdf:resource="http://www.w3.org/ns/odrl/2/"/>
-    <dct:contributor rdf:parseType="Resource">
-      <foaf:name>Jakub Klímek</foaf:name>
-      <foaf:homepage rdf:resource="https://jakub.klímek.com/"/>
-      <rdfs:seeAlso rdf:resource="https://jakub.klímek.com/#me"/>
-    </dct:contributor>
-    <dct:contributor rdf:parseType="Resource">
-      <foaf:name>David Browning</foaf:name>
-      <sdo:affiliation rdf:parseType="Resource">
-        <foaf:name>Refinitiv</foaf:name>
-        <foaf:homepage rdf:resource="http://www.refinitiv.com"/>
-      </sdo:affiliation>
+      <foaf:name>Ghislain Auguste Atemezing</foaf:name>
+      <rdfs:seeAlso rdf:resource="http://www.eurecom.fr/~atemezin/gatemezing-foaf.rdf"/>
     </dct:contributor>
   </owl:Ontology>
   <rdf:Description rdf:about="http://www.w3.org/ns/prov#wasQuotedFrom">
@@ -600,18 +600,18 @@
     <skos:definition xml:lang="it">Nel contesto di DCAT 2.0 dcat:CatalogRecord, la data più recente in cui la voce di catalogo è stata cambiata, aggiornata o modificata.</skos:definition>
   </rdf:Description>
   <rdf:Description rdf:about="http://www.w3.org/ns/locn#geometry">
+    <skos:definition xml:lang="en">Associates a spatial thing [SDW-BP] with a corresponding geometry.</skos:definition>
     <skos:scopeNote xml:lang="es">El rango de esta propiedad (locn:Geometry) permite cualquier tipo de especificación de la geometría. Por ejemplo, la geometría podría estar codificada por un literal, como WKT (geosparql:wktLiteral [GeoSPARQL]), o representada por una clase, como geosparql:Geometry (o cualquiera de sus subclases) [GeoSPARQL].</skos:scopeNote>
     <skos:definition xml:lang="es">Asocia cualquier recurso con la geometría correspondiente.</skos:definition>
     <skos:scopeNote xml:lang="cs">Rozsah této vlastnosti (locn: Geometry) umožňuje jakýkoli typ specifikace geometrie. Například geometrie může být kódována literálem, jako WKT (geosparql: wktLiteral [GeoSPARQL]), nebo reprezentována třídou, jako geosparql: Geometry (nebo jakoukoli z jeho podtříd) [GeoSPARQL].</skos:scopeNote>
-    <skos:definition xml:lang="en">Associates any resource with the corresponding geometry.</skos:definition>
     <skos:scopeNote xml:lang="en">The range of this property (locn:Geometry) allows for any type of geometry specification. E.g., the geometry could be encoded by a literal, as WKT (geosparql:wktLiteral [GeoSPARQL]), or represented by a class, as geosparql:Geometry (or any of its subclasses) [GeoSPARQL].</skos:scopeNote>
     <rdfs:range rdf:resource="http://www.w3.org/ns/locn#Geometry"/>
     <skos:changeNote xml:lang="es">Esta propiedad fue agregada en DCAT 2.0.</skos:changeNote>
+    <skos:definition xml:lang="it">Associa una risorsa a una geometria corrispondente.</skos:definition>
     <skos:definition xml:lang="cs">Přiřazuje geometrii jakémukoliv zdroji.</skos:definition>
     <skos:changeNote xml:lang="en">Property added in this context in DCAT 2.0.</skos:changeNote>
     <skos:changeNote xml:lang="it">Proprietà aggiunta in questo contesto in DCAT 2.0.</skos:changeNote>
     <skos:scopeNote xml:lang="it">Il range di questa proprietà (locn:Geometry) permette di specificare ogni tipo di geometria.  Ad esempio, la geometria potrebbe essere codificata da un letterale, come WKT (geosparql:wktLiteral [GeoSPARQL]), o rappresentata da una classe, come geosparql:Geometry (o una delle sue sottoclassi) [GeoSPARQL].</skos:scopeNote>
-    <skos:definition xml:lang="it">Associa qualsiasi risorsa alla geometria corrispondente.</skos:definition>
     <skos:changeNote xml:lang="cs">Vlastnost v tomto kontextu byla přidána ve verzi DCAT 2.0.</skos:changeNote>
   </rdf:Description>
   <rdf:Description rdf:about="http://www.w3.org/ns/prov#alternateOf">

--- a/dcat/rdf/dcat-external.ttl
+++ b/dcat/rdf/dcat-external.ttl
@@ -527,8 +527,8 @@ locn:geometry
   skos:changeNote "Proprietà aggiunta in questo contesto in DCAT 2.0."@it ;
   skos:changeNote "Vlastnost v tomto kontextu byla přidána ve verzi DCAT 2.0."@cs ;
   skos:definition "Asocia cualquier recurso con la geometría correspondiente."@es ;
-  skos:definition "Associa qualsiasi risorsa alla geometria corrispondente."@it ;
-  skos:definition "Associates any resource with the corresponding geometry."@en ;
+  skos:definition "Associa una risorsa a una geometria corrispondente."@it ;
+  skos:definition "Associates a spatial thing [SDW-BP] with a corresponding geometry."@en ;
   skos:definition "Přiřazuje geometrii jakémukoliv zdroji."@cs ;
   skos:scopeNote "El rango de esta propiedad (locn:Geometry) permite cualquier tipo de especificación de la geometría. Por ejemplo, la geometría podría estar codificada por un literal, como WKT (geosparql:wktLiteral [GeoSPARQL]), o representada por una clase, como geosparql:Geometry (o cualquiera de sus subclases) [GeoSPARQL]."@es ;
   skos:scopeNote "The range of this property (locn:Geometry) allows for any type of geometry specification. E.g., the geometry could be encoded by a literal, as WKT (geosparql:wktLiteral [GeoSPARQL]), or represented by a class, as geosparql:Geometry (or any of its subclasses) [GeoSPARQL]."@en;

--- a/dcat/rdf/dcat3.jsonld
+++ b/dcat/rdf/dcat3.jsonld
@@ -1,129 +1,129 @@
 {
   "@graph" : [ {
     "@id" : "_:b0",
-    "seeAlso" : "https://orcid.org/0000-0001-5648-2713",
-    "homepage" : [ "https://w3id.org/people/ralbertoni/", "http://www.imati.cnr.it/index.php/people/8-curricula/178-riccardo-albertoni" ],
-    "foaf:name" : "Riccardo Albertoni"
+    "foaf:name" : "Martin Alvarez-Espinar"
   }, {
     "@id" : "_:b1",
     "affiliation" : "_:b2",
-    "foaf:name" : "Vassilios Peristeras"
-  }, {
-    "@id" : "_:b10",
-    "seeAlso" : "https://orcid.org/0000-0001-9300-2694",
-    "homepage" : "https://www.andrea-perego.name/foaf/#me",
-    "foaf:name" : "Andrea Perego"
-  }, {
-    "@id" : "_:b11",
-    "foaf:name" : "John Erickson"
-  }, {
-    "@id" : "_:b12",
-    "homepage" : "http://www.w3.org/2011/gld/",
-    "foaf:name" : "Government Linked Data WG"
-  }, {
-    "@id" : "_:b13",
-    "foaf:name" : "Richard Cyganiak"
-  }, {
-    "@id" : "_:b14",
-    "affiliation" : "_:b15",
-    "foaf:name" : "Rufus Pollock"
-  }, {
-    "@id" : "_:b15",
-    "homepage" : "http://okfn.org",
-    "foaf:name" : "Open Knowledge Foundation"
-  }, {
-    "@id" : "_:b16",
-    "homepage" : "http://stfc.ac.uk",
-    "foaf:name" : "Science and Technology Facilities Council, UK"
-  }, {
-    "@id" : "_:b17",
-    "foaf:name" : "Boris Villazón-Terrazas"
-  }, {
-    "@id" : "_:b18",
-    "@type" : "foaf:Person",
-    "affiliation" : "_:b3",
-    "seeAlso" : "https://orcid.org/0000-0002-3884-3420",
-    "foaf:name" : "Simon J D Cox",
-    "workInfoHomepage" : "http://people.csiro.au/Simon-Cox"
-  }, {
-    "@id" : "_:b19",
-    "affiliation" : "http://www.w3.org/data#W3C",
-    "seeAlso" : "http://philarcher.org/foaf.rdf#me",
-    "homepage" : "http://www.w3.org/People/all#phila",
-    "foaf:name" : "Phil Archer"
-  }, {
-    "@id" : "_:b2",
-    "homepage" : "http://ec.europa.eu/dgs/informatics/",
-    "foaf:name" : "European Commission, DG DIGIT"
-  }, {
-    "@id" : "_:b20",
-    "foaf:name" : "Martin Alvarez-Espinar"
-  }, {
-    "@id" : "_:b21",
-    "affiliation" : "_:b16",
     "seeAlso" : "https://orcid.org/0000-0003-3499-8262",
     "homepage" : "https://agbeltran.github.io",
     "foaf:name" : "Alejandra Gonzalez-Beltran"
   }, {
-    "@id" : "_:b22",
-    "foaf:name" : "Marios Meimaris"
-  }, {
-    "@id" : "_:b23",
-    "seeAlso" : "https://jakub.klímek.com/#me",
-    "homepage" : "https://jakub.klímek.com/",
-    "foaf:name" : "Jakub Klímek"
-  }, {
-    "@id" : "_:b24",
-    "seeAlso" : "http://fadmaa.me/foaf.ttl",
-    "foaf:name" : "Fadi Maali"
-  }, {
-    "@id" : "_:b25",
-    "affiliation" : "_:b8",
-    "foaf:name" : "David Browning"
-  }, {
-    "@id" : "_:b26",
-    "seeAlso" : "http://www.eurecom.fr/~atemezin/gatemezing-foaf.rdf",
-    "foaf:name" : "Ghislain Auguste Atemezing"
-  }, {
-    "@id" : "_:b27",
-    "homepage" : "http://www.asahi-net.or.jp/~ax2s-kmtn/",
-    "foaf:name" : "Shuji Kamitsuna"
-  }, {
-    "@id" : "_:b29",
-    "@type" : "owl:Restriction",
-    "allValuesFrom" : "dcat:Resource",
-    "onProperty" : "foaf:primaryTopic"
-  }, {
-    "@id" : "_:b3",
-    "homepage" : "https://csiro.au",
-    "foaf:name" : "Commonwealth Scientific and Industrial Research Organisation"
-  }, {
-    "@id" : "_:b30",
-    "@type" : "owl:Restriction",
-    "cardinality" : "1",
-    "onProperty" : "foaf:primaryTopic"
-  }, {
-    "@id" : "_:b4",
-    "seeAlso" : "http://makxdekkers.com/makxdekkers.rdf#me",
-    "homepage" : "http://makxdekkers.com/",
-    "foaf:name" : "Makx Dekkers"
-  }, {
-    "@id" : "_:b5",
+    "@id" : "_:b10",
     "@type" : "owl:Class",
     "unionOf" : {
       "@list" : [ "prov:Attribution", "dcat:Relationship" ]
     }
   }, {
-    "@id" : "_:b8",
+    "@id" : "_:b11",
     "homepage" : "http://www.refinitiv.com",
     "foaf:name" : "Refinitiv"
   }, {
+    "@id" : "_:b12",
+    "seeAlso" : "http://makxdekkers.com/makxdekkers.rdf#me",
+    "homepage" : "http://makxdekkers.com/",
+    "foaf:name" : "Makx Dekkers"
+  }, {
+    "@id" : "_:b15",
+    "affiliation" : "_:b11",
+    "foaf:name" : "David Browning"
+  }, {
+    "@id" : "_:b16",
+    "@type" : "foaf:Person",
+    "affiliation" : "_:b4",
+    "seeAlso" : "https://orcid.org/0000-0002-3884-3420",
+    "foaf:name" : "Simon J D Cox",
+    "workInfoHomepage" : "http://people.csiro.au/Simon-Cox"
+  }, {
+    "@id" : "_:b17",
+    "foaf:name" : "Marios Meimaris"
+  }, {
+    "@id" : "_:b18",
+    "seeAlso" : "http://fadmaa.me/foaf.ttl",
+    "foaf:name" : "Fadi Maali"
+  }, {
+    "@id" : "_:b19",
+    "affiliation" : "_:b9",
+    "foaf:name" : "Rufus Pollock"
+  }, {
+    "@id" : "_:b2",
+    "homepage" : "http://stfc.ac.uk",
+    "foaf:name" : "Science and Technology Facilities Council, UK"
+  }, {
+    "@id" : "_:b20",
+    "homepage" : "http://www.w3.org/2011/gld/",
+    "foaf:name" : "Government Linked Data WG"
+  }, {
+    "@id" : "_:b21",
+    "affiliation" : "http://www.w3.org/data#W3C",
+    "seeAlso" : "http://philarcher.org/foaf.rdf#me",
+    "homepage" : "http://www.w3.org/People/all#phila",
+    "foaf:name" : "Phil Archer"
+  }, {
+    "@id" : "_:b22",
+    "foaf:name" : "John Erickson"
+  }, {
+    "@id" : "_:b23",
+    "homepage" : "http://www.asahi-net.or.jp/~ax2s-kmtn/",
+    "foaf:name" : "Shuji Kamitsuna"
+  }, {
+    "@id" : "_:b24",
+    "affiliation" : "_:b7",
+    "foaf:name" : "Vassilios Peristeras"
+  }, {
+    "@id" : "_:b25",
+    "seeAlso" : "https://jakub.klímek.com/#me",
+    "homepage" : "https://jakub.klímek.com/",
+    "foaf:name" : "Jakub Klímek"
+  }, {
+    "@id" : "_:b26",
+    "seeAlso" : "https://orcid.org/0000-0001-5648-2713",
+    "homepage" : [ "https://w3id.org/people/ralbertoni/", "http://www.imati.cnr.it/index.php/people/8-curricula/178-riccardo-albertoni" ],
+    "foaf:name" : "Riccardo Albertoni"
+  }, {
+    "@id" : "_:b27",
+    "seeAlso" : "https://orcid.org/0000-0001-9300-2694",
+    "homepage" : "https://www.andrea-perego.name/foaf/#me",
+    "foaf:name" : "Andrea Perego"
+  }, {
+    "@id" : "_:b28",
+    "foaf:name" : "Boris Villazón-Terrazas"
+  }, {
+    "@id" : "_:b3",
+    "foaf:name" : "Richard Cyganiak"
+  }, {
+    "@id" : "_:b30",
+    "@type" : "owl:Restriction",
+    "allValuesFrom" : "dcat:Resource",
+    "onProperty" : "foaf:primaryTopic"
+  }, {
+    "@id" : "_:b4",
+    "homepage" : "https://csiro.au",
+    "foaf:name" : "Commonwealth Scientific and Industrial Research Organisation"
+  }, {
+    "@id" : "_:b5",
+    "seeAlso" : "http://www.eurecom.fr/~atemezin/gatemezing-foaf.rdf",
+    "foaf:name" : "Ghislain Auguste Atemezing"
+  }, {
+    "@id" : "_:b7",
+    "homepage" : "http://ec.europa.eu/dgs/informatics/",
+    "foaf:name" : "European Commission, DG DIGIT"
+  }, {
+    "@id" : "_:b8",
+    "@type" : "owl:Restriction",
+    "cardinality" : "1",
+    "onProperty" : "foaf:primaryTopic"
+  }, {
+    "@id" : "_:b9",
+    "homepage" : "http://okfn.org",
+    "foaf:name" : "Open Knowledge Foundation"
+  }, {
     "@id" : "http://www.w3.org/ns/dcat",
     "@type" : "owl:Ontology",
-    "contributor" : [ "_:b19", "_:b4", "_:b20", "_:b1", "_:b21", "_:b22", "_:b14", "_:b23", "_:b17", "_:b18", "_:b25", "_:b10", "_:b13", "_:b0", "_:b26", "_:b27" ],
-    "creator" : [ "_:b11", "_:b24" ],
+    "contributor" : [ "_:b21", "_:b1", "_:b23", "_:b0", "_:b24", "_:b16", "_:b25", "_:b3", "_:b26", "_:b12", "_:b5", "_:b27", "_:b15", "_:b19", "_:b17", "_:b28" ],
+    "creator" : [ "_:b18", "_:b22" ],
     "license" : "https://creativecommons.org/licenses/by/4.0/",
-    "modified" : [ "2021-04-08", "2020-11-30", "2012-04-24", "2017-12-19", "2021-06-23", "2021-09-27", "2013-09-20", "2021-03-09", "2013-11-28" ],
+    "modified" : [ "2021-04-08", "2020-11-30", "2012-04-24", "2017-12-19", "2021-06-23", "2013-09-20", "2021-03-09", "2013-11-28", "2021-09-27" ],
     "dcterms:modified" : "2019",
     "rdfs:comment" : [ {
       "@language" : "da",
@@ -202,7 +202,7 @@
       "@language" : "en",
       "@value" : "English language definitions updated in this revision in line with ED. Multilingual text unevenly updated."
     },
-    "maker" : "_:b12"
+    "maker" : "_:b20"
   }, {
     "@id" : "dcat:Catalog",
     "@type" : [ "owl:Class", "rdfs:Class" ],
@@ -378,7 +378,7 @@
       "@language" : "fr",
       "@value" : "Registre du catalogue"
     } ],
-    "subClassOf" : [ "_:b29", "_:b30" ],
+    "subClassOf" : [ "_:b8", "_:b30" ],
     "skos:definition" : [ {
       "@language" : "it",
       "@value" : "Un record in un catalogo di dati che descrive un singolo dataset o servizio di dati."
@@ -630,6 +630,9 @@
       "@language" : "cs",
       "@value" : "Kolekce dat poskytovaná či řízená jedním zdrojem, která je k dispozici pro přístup či stažení v jednom či více formátech."
     }, {
+      "@language" : "en",
+      "@value" : "A collection of data, published or curated by a single source, and available for access or download in one or more representations."
+    }, {
       "@language" : "da",
       "@value" : "En samling a data, udgivet eller udvalgt og arrangeret af en enkelt kilde og som der er adgang til i en eller flere repræsentationer."
     }, {
@@ -638,9 +641,6 @@
     }, {
       "@language" : "el",
       "@value" : "Μία συλλογή από δεδομένα, δημοσιευμένη ή επιμελημένη από μία και μόνο πηγή, διαθέσιμη δε προς πρόσβαση ή μεταφόρτωση σε μία ή περισσότερες μορφές."
-    }, {
-      "@language" : "en",
-      "@value" : "A collection of data, published or curated by a single source, and available for access or download in one or more representations."
     } ],
     "skos:editorialNote" : {
       "@language" : "en",
@@ -1351,14 +1351,14 @@
       "@language" : "it",
       "@value" : "Il riquadro di delimitazione geografica di una risorsa."
     }, {
+      "@language" : "en",
+      "@value" : "The geographic bounding box of a spatial thing [SDW-BP]."
+    }, {
       "@language" : "cs",
       "@value" : "Ohraničení geografické oblasti zdroje."
     }, {
       "@language" : "es",
       "@value" : "El cuadro delimitador geográfico para un recurso."
-    }, {
-      "@language" : "en",
-      "@value" : "The geographic bounding box of a resource."
     } ],
     "skos:editorialNote" : {
       "@language" : "en",
@@ -1627,11 +1627,11 @@
       "@language" : "da",
       "@value" : "Det geometrisk tyngdepunkt (centroid) for en ressource."
     }, {
+      "@language" : "en",
+      "@value" : "The geographic center (centroid) of a spatial thing [SDW-BP]."
+    }, {
       "@language" : "es",
       "@value" : "El centro geográfico (centroide) de un recurso."
-    }, {
-      "@language" : "en",
-      "@value" : "The geographic center (centroid) of a resource."
     } ],
     "skos:editorialNote" : {
       "@language" : "en",
@@ -2416,7 +2416,7 @@
       "@language" : "en",
       "@value" : "The function of an entity or agent with respect to another entity or resource."
     } ],
-    "domain" : "_:b5",
+    "domain" : "_:b10",
     "rdfs:label" : [ {
       "@language" : "it",
       "@value" : "tiene rol"
@@ -3844,17 +3844,13 @@
       "@id" : "http://www.w3.org/2000/01/rdf-schema#range",
       "@type" : "@id"
     },
-    "editorialNote" : {
-      "@id" : "http://www.w3.org/2004/02/skos/core#editorialNote",
-      "@type" : "http://www.w3.org/1999/02/22-rdf-syntax-ns#langString"
-    },
-    "altLabel" : {
-      "@id" : "http://www.w3.org/2004/02/skos/core#altLabel",
-      "@type" : "http://www.w3.org/1999/02/22-rdf-syntax-ns#langString"
-    },
     "name" : {
       "@id" : "http://xmlns.com/foaf/0.1/name",
       "@type" : "http://www.w3.org/2001/XMLSchema#string"
+    },
+    "editorialNote" : {
+      "@id" : "http://www.w3.org/2004/02/skos/core#editorialNote",
+      "@type" : "http://www.w3.org/1999/02/22-rdf-syntax-ns#langString"
     },
     "homepage" : {
       "@id" : "http://xmlns.com/foaf/0.1/homepage",
@@ -3868,10 +3864,6 @@
       "@id" : "http://schema.org/affiliation",
       "@type" : "@id"
     },
-    "unionOf" : {
-      "@id" : "http://www.w3.org/2002/07/owl#unionOf",
-      "@type" : "@id"
-    },
     "rest" : {
       "@id" : "http://www.w3.org/1999/02/22-rdf-syntax-ns#rest",
       "@type" : "@id"
@@ -3880,17 +3872,41 @@
       "@id" : "http://www.w3.org/1999/02/22-rdf-syntax-ns#first",
       "@type" : "@id"
     },
-    "rangeIncludes" : {
-      "@id" : "http://schema.org/rangeIncludes",
+    "onProperty" : {
+      "@id" : "http://www.w3.org/2002/07/owl#onProperty",
       "@type" : "@id"
+    },
+    "cardinality" : {
+      "@id" : "http://www.w3.org/2002/07/owl#cardinality",
+      "@type" : "http://www.w3.org/2001/XMLSchema#nonNegativeInteger"
+    },
+    "altLabel" : {
+      "@id" : "http://www.w3.org/2004/02/skos/core#altLabel",
+      "@type" : "http://www.w3.org/1999/02/22-rdf-syntax-ns#langString"
     },
     "workInfoHomepage" : {
       "@id" : "http://xmlns.com/foaf/0.1/workInfoHomepage",
       "@type" : "@id"
     },
+    "rangeIncludes" : {
+      "@id" : "http://schema.org/rangeIncludes",
+      "@type" : "@id"
+    },
     "versionInfo" : {
       "@id" : "http://www.w3.org/2002/07/owl#versionInfo",
       "@type" : "http://www.w3.org/1999/02/22-rdf-syntax-ns#langString"
+    },
+    "contributor" : {
+      "@id" : "http://purl.org/dc/terms/contributor",
+      "@type" : "@id"
+    },
+    "modified" : {
+      "@id" : "http://purl.org/dc/terms/modified",
+      "@type" : "http://www.w3.org/2001/XMLSchema#date"
+    },
+    "imports" : {
+      "@id" : "http://www.w3.org/2002/07/owl#imports",
+      "@type" : "@id"
     },
     "maker" : {
       "@id" : "http://xmlns.com/foaf/0.1/maker",
@@ -3898,18 +3914,6 @@
     },
     "creator" : {
       "@id" : "http://purl.org/dc/terms/creator",
-      "@type" : "@id"
-    },
-    "modified" : {
-      "@id" : "http://purl.org/dc/terms/modified",
-      "@type" : "http://www.w3.org/2001/XMLSchema#date"
-    },
-    "contributor" : {
-      "@id" : "http://purl.org/dc/terms/contributor",
-      "@type" : "@id"
-    },
-    "imports" : {
-      "@id" : "http://www.w3.org/2002/07/owl#imports",
       "@type" : "@id"
     },
     "license" : {
@@ -3924,17 +3928,13 @@
       "@id" : "http://www.w3.org/2002/07/owl#propertyChainAxiom",
       "@type" : "@id"
     },
-    "onProperty" : {
-      "@id" : "http://www.w3.org/2002/07/owl#onProperty",
+    "unionOf" : {
+      "@id" : "http://www.w3.org/2002/07/owl#unionOf",
       "@type" : "@id"
     },
     "allValuesFrom" : {
       "@id" : "http://www.w3.org/2002/07/owl#allValuesFrom",
       "@type" : "@id"
-    },
-    "cardinality" : {
-      "@id" : "http://www.w3.org/2002/07/owl#cardinality",
-      "@type" : "http://www.w3.org/2001/XMLSchema#nonNegativeInteger"
     },
     "owl" : "http://www.w3.org/2002/07/owl#",
     "rdf" : "http://www.w3.org/1999/02/22-rdf-syntax-ns#",

--- a/dcat/rdf/dcat3.rdf
+++ b/dcat/rdf/dcat3.rdf
@@ -1,4 +1,3 @@
-
 <rdf:RDF
     xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
     xmlns:dcterms="http://purl.org/dc/terms/"
@@ -14,34 +13,53 @@
     xmlns:xsd="http://www.w3.org/2001/XMLSchema#">
   <owl:Ontology rdf:about="http://www.w3.org/ns/dcat">
     <rdfs:label xml:lang="cs">Slovník pro datové katalogy</rdfs:label>
-    <dcterms:contributor rdf:parseType="Resource">
-      <foaf:name>Jakub Klímek</foaf:name>
-      <foaf:homepage rdf:resource="https://jakub.klímek.com/"/>
-      <rdfs:seeAlso rdf:resource="https://jakub.klímek.com/#me"/>
-    </dcterms:contributor>
     <rdfs:label xml:lang="it">Il vocabolario del catalogo dei dati</rdfs:label>
+    <owl:versionInfo xml:lang="en">Questa è una copia aggiornata del vocabolario DCAT v2.0 disponibile in https://www.w3.org/ns/dcat.ttl</owl:versionInfo>
+    <rdfs:comment xml:lang="da">DCAT er et RDF-vokabular som har til formål at understøtte interoperabilitet mellem datakataloger udgivet på nettet. Ved at anvende DCAT til at beskrive datasæt i datakataloger, kan udgivere øge findbarhed og gøre det gøre det lettere for applikationer at anvende metadata fra forskellige kataloger. Derudover understøttes decentraliseret udstilling af kataloger og fødererede datasætsøgninger på tværs af websider. Aggregerede DCAT-metadata kan fungere som fortegnelsesfiler der kan understøtte digital bevaring. DCAT er defineret på http://www.w3.org/TR/vocab-dcat/. Enhver forskel mellem det normative dokument og dette schema er en fejl i dette schema.</rdfs:comment>
+    <dcterms:contributor rdf:parseType="Resource">
+      <foaf:name>Makx Dekkers</foaf:name>
+      <foaf:homepage rdf:resource="http://makxdekkers.com/"/>
+      <rdfs:seeAlso rdf:resource="http://makxdekkers.com/makxdekkers.rdf#me"/>
+    </dcterms:contributor>
+    <owl:versionInfo xml:lang="en">This is an updated copy of v2.0 of the DCAT vocabulary, taken from https://www.w3.org/ns/dcat.ttl</owl:versionInfo>
+    <dcterms:contributor rdf:parseType="Resource">
+      <foaf:name>Alejandra Gonzalez-Beltran</foaf:name>
+      <foaf:homepage rdf:resource="https://agbeltran.github.io"/>
+      <rdfs:seeAlso rdf:resource="https://orcid.org/0000-0003-3499-8262"/>
+      <sdo:affiliation rdf:parseType="Resource">
+        <foaf:name>Science and Technology Facilities Council, UK</foaf:name>
+        <foaf:homepage rdf:resource="http://stfc.ac.uk"/>
+      </sdo:affiliation>
+    </dcterms:contributor>
+    <dcterms:contributor rdf:parseType="Resource">
+      <foaf:name>Phil Archer</foaf:name>
+      <foaf:homepage rdf:resource="http://www.w3.org/People/all#phila"/>
+      <rdfs:seeAlso rdf:resource="http://philarcher.org/foaf.rdf#me"/>
+      <sdo:affiliation rdf:resource="http://www.w3.org/data#W3C"/>
+    </dcterms:contributor>
+    <rdfs:label xml:lang="fr">Le vocabulaire des jeux de données</rdfs:label>
     <dcterms:contributor rdf:parseType="Resource">
       <foaf:name>Riccardo Albertoni</foaf:name>
       <foaf:homepage rdf:resource="https://w3id.org/people/ralbertoni/"/>
       <foaf:homepage rdf:resource="http://www.imati.cnr.it/index.php/people/8-curricula/178-riccardo-albertoni"/>
       <rdfs:seeAlso rdf:resource="https://orcid.org/0000-0001-5648-2713"/>
     </dcterms:contributor>
-    <owl:versionInfo xml:lang="en">Questa è una copia aggiornata del vocabolario DCAT v2.0 disponibile in https://www.w3.org/ns/dcat.ttl</owl:versionInfo>
-    <rdfs:comment xml:lang="da">DCAT er et RDF-vokabular som har til formål at understøtte interoperabilitet mellem datakataloger udgivet på nettet. Ved at anvende DCAT til at beskrive datasæt i datakataloger, kan udgivere øge findbarhed og gøre det gøre det lettere for applikationer at anvende metadata fra forskellige kataloger. Derudover understøttes decentraliseret udstilling af kataloger og fødererede datasætsøgninger på tværs af websider. Aggregerede DCAT-metadata kan fungere som fortegnelsesfiler der kan understøtte digital bevaring. DCAT er defineret på http://www.w3.org/TR/vocab-dcat/. Enhver forskel mellem det normative dokument og dette schema er en fejl i dette schema.</rdfs:comment>
-    <owl:versionInfo xml:lang="en">This is an updated copy of v2.0 of the DCAT vocabulary, taken from https://www.w3.org/ns/dcat.ttl</owl:versionInfo>
-    <dcterms:creator rdf:parseType="Resource">
-      <foaf:name>John Erickson</foaf:name>
-    </dcterms:creator>
-    <rdfs:label xml:lang="fr">Le vocabulaire des jeux de données</rdfs:label>
+    <dcterms:contributor rdf:parseType="Resource">
+      <foaf:name>Vassilios Peristeras</foaf:name>
+      <sdo:affiliation rdf:parseType="Resource">
+        <foaf:name>European Commission, DG DIGIT</foaf:name>
+        <foaf:homepage rdf:resource="http://ec.europa.eu/dgs/informatics/"/>
+      </sdo:affiliation>
+    </dcterms:contributor>
+    <dcterms:contributor rdf:parseType="Resource">
+      <foaf:name>David Browning</foaf:name>
+      <sdo:affiliation rdf:parseType="Resource">
+        <foaf:name>Refinitiv</foaf:name>
+        <foaf:homepage rdf:resource="http://www.refinitiv.com"/>
+      </sdo:affiliation>
+    </dcterms:contributor>
     <dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#date"
     >2021-04-08</dcterms:modified>
-    <dcterms:contributor rdf:parseType="Resource">
-      <foaf:name>Richard Cyganiak</foaf:name>
-    </dcterms:contributor>
-    <dcterms:contributor rdf:parseType="Resource">
-      <foaf:name>Shuji Kamitsuna</foaf:name>
-      <foaf:homepage rdf:resource="http://www.asahi-net.or.jp/~ax2s-kmtn/"/>
-    </dcterms:contributor>
     <dcterms:contributor>
       <foaf:Person>
         <foaf:workInfoHomepage rdf:resource="http://people.csiro.au/Simon-Cox"/>
@@ -53,31 +71,11 @@
         </sdo:affiliation>
       </foaf:Person>
     </dcterms:contributor>
-    <dcterms:contributor rdf:parseType="Resource">
-      <foaf:name>Alejandra Gonzalez-Beltran</foaf:name>
-      <foaf:homepage rdf:resource="https://agbeltran.github.io"/>
-      <rdfs:seeAlso rdf:resource="https://orcid.org/0000-0003-3499-8262"/>
-      <sdo:affiliation rdf:parseType="Resource">
-        <foaf:name>Science and Technology Facilities Council, UK</foaf:name>
-        <foaf:homepage rdf:resource="http://stfc.ac.uk"/>
-      </sdo:affiliation>
-    </dcterms:contributor>
     <dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#date"
     >2020-11-30</dcterms:modified>
     <rdfs:comment xml:lang="fr">DCAT est un vocabulaire développé pour faciliter l'interopérabilité entre les jeux de données publiées sur le Web. En utilisant DCAT pour décrire les jeux de données dans les catalogues de données, les fournisseurs de données augmentent leur découverte et permettent que les applications facilement les métadonnées de plusieurs catalogues. Il permet en plus la publication décentralisée des catalogues et facilitent la recherche fédérée des données entre plusieurs sites. Les métadonnées DCAT aggrégées peuvent servir comme un manifeste pour faciliter la préservation digitale des ressources. DCAT est définie à l'adresse http://www.w3.org/TR/vocab-dcat/. Une quelconque version de ce document normatif et ce vocabulaire est une erreur dans ce vocabulaire.</rdfs:comment>
-    <dcterms:contributor rdf:parseType="Resource">
-      <foaf:name>Marios Meimaris</foaf:name>
-    </dcterms:contributor>
     <rdfs:label xml:lang="es">El vocabulario de catálogo de datos</rdfs:label>
     <owl:imports rdf:resource="http://www.w3.org/2004/02/skos/core"/>
-    <dcterms:creator rdf:parseType="Resource">
-      <foaf:name>Fadi Maali</foaf:name>
-      <rdfs:seeAlso rdf:resource="http://fadmaa.me/foaf.ttl"/>
-    </dcterms:creator>
-    <foaf:maker rdf:parseType="Resource">
-      <foaf:name>Government Linked Data WG</foaf:name>
-      <foaf:homepage rdf:resource="http://www.w3.org/2011/gld/"/>
-    </foaf:maker>
     <rdfs:comment xml:lang="cs">DCAT je RDF slovník navržený pro zprostředkování interoperability mezi datovými katalogy publikovanými na Webu. Poskytovatelé dat používáním slovníku DCAT pro popis datových sad v datových katalozích zvyšují jejich dohledatelnost a umožňují aplikacím konzumovat metadata z více katalogů. Dále je umožňena decentralizovaná publikace katalogů a federované dotazování na datové sady napříč katalogy. Agregovaná DCAT metadata mohou také sloužit jako průvodka umožňující digitální uchování informace. DCAT je definován na http://www.w3.org/TR/vocab-dcat/. Jakýkoliv nesoulad mezi odkazovaným dokumentem a tímto schématem je chybou v tomto schématu.</rdfs:comment>
     <owl:versionInfo xml:lang="es">Esta es una copia del vocabulario DCAT v2.0 disponible en https://www.w3.org/ns/dcat.ttl</owl:versionInfo>
     <dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#date"
@@ -85,15 +83,8 @@
     <rdfs:comment xml:lang="ar">هي أنطولوجية تسهل تبادل البيانات بين مختلف الفهارس على الوب. استخدام هذه الأنطولوجية يساعد على اكتشاف قوائم  البيانات المنشورة على الوب و يمكن التطبيقات المختلفة من الاستفادة أتوماتيكيا من البيانات المتاحة من مختلف الفهارس.</rdfs:comment>
     <skos:editorialNote xml:lang="en">English language definitions updated in this revision in line with ED. Multilingual text unevenly updated.</skos:editorialNote>
     <dcterms:contributor rdf:parseType="Resource">
-      <foaf:name>Boris Villazón-Terrazas</foaf:name>
+      <foaf:name>Martin Alvarez-Espinar</foaf:name>
     </dcterms:contributor>
-    <rdfs:label xml:lang="da">Datakatalogvokabular</rdfs:label>
-    <dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#date"
-    >2017-12-19</dcterms:modified>
-    <dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#date"
-    >2021-06-23</dcterms:modified>
-      <dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#date"
-    >2021-09-27</dcterms:modified>
     <dcterms:contributor rdf:parseType="Resource">
       <foaf:name>Rufus Pollock</foaf:name>
       <sdo:affiliation rdf:parseType="Resource">
@@ -101,11 +92,20 @@
         <foaf:homepage rdf:resource="http://okfn.org"/>
       </sdo:affiliation>
     </dcterms:contributor>
+    <foaf:maker rdf:parseType="Resource">
+      <foaf:name>Government Linked Data WG</foaf:name>
+      <foaf:homepage rdf:resource="http://www.w3.org/2011/gld/"/>
+    </foaf:maker>
+    <rdfs:label xml:lang="da">Datakatalogvokabular</rdfs:label>
+    <dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#date"
+    >2017-12-19</dcterms:modified>
+    <dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#date"
+    >2021-06-23</dcterms:modified>
+    <dcterms:contributor rdf:parseType="Resource">
+      <foaf:name>Richard Cyganiak</foaf:name>
+    </dcterms:contributor>
     <dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#date"
     >2013-09-20</dcterms:modified>
-    <dcterms:contributor rdf:parseType="Resource">
-      <foaf:name>Martin Alvarez-Espinar</foaf:name>
-    </dcterms:contributor>
     <owl:imports rdf:resource="http://www.w3.org/ns/prov-o#"/>
     <rdfs:comment xml:lang="ja">DCATは、ウェブ上で公開されたデータ・カタログ間の相互運用性の促進を目的とするRDFの語彙です。このドキュメントでは、その利用のために、スキーマを定義し、例を提供します。データ・カタログ内のデータセットを記述するためにDCATを用いると、公開者が、発見可能性を増加させ、アプリケーションが複数のカタログのメタデータを容易に利用できるようになります。さらに、カタログの分散公開を可能にし、複数のサイトにまたがるデータセットの統合検索を促進します。集約されたDCATメタデータは、ディジタル保存を促進するためのマニフェスト・ファイルとして使用できます。</rdfs:comment>
     <owl:versionInfo xml:lang="da">Dette er en opdateret kopi af DCAT v. 2.0 som er tilgænglig på https://www.w3.org/ns/dcat.ttl</owl:versionInfo>
@@ -115,47 +115,46 @@
     <dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#date"
     >2013-11-28</dcterms:modified>
     <dcterms:modified>2019</dcterms:modified>
-    <dcterms:contributor rdf:parseType="Resource">
-      <foaf:name>Andrea Perego</foaf:name>
-      <foaf:homepage rdf:resource="https://www.andrea-perego.name/foaf/#me"/>
-      <rdfs:seeAlso rdf:resource="https://orcid.org/0000-0001-9300-2694"/>
-    </dcterms:contributor>
     <dcterms:license rdf:resource="https://creativecommons.org/licenses/by/4.0/"/>
-    <dcterms:contributor rdf:parseType="Resource">
-      <foaf:name>David Browning</foaf:name>
-      <sdo:affiliation rdf:parseType="Resource">
-        <foaf:name>Refinitiv</foaf:name>
-        <foaf:homepage rdf:resource="http://www.refinitiv.com"/>
-      </sdo:affiliation>
-    </dcterms:contributor>
     <owl:imports rdf:resource="http://purl.org/dc/terms/"/>
-    <dcterms:contributor rdf:parseType="Resource">
-      <foaf:name>Makx Dekkers</foaf:name>
-      <foaf:homepage rdf:resource="http://makxdekkers.com/"/>
-      <rdfs:seeAlso rdf:resource="http://makxdekkers.com/makxdekkers.rdf#me"/>
-    </dcterms:contributor>
+    <dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#date"
+    >2021-09-27</dcterms:modified>
     <rdfs:comment xml:lang="es">DCAT es un vocabulario RDF diseñado para facilitar la interoperabilidad entre catálogos de datos publicados en la Web. Utilizando DCAT para describir datos disponibles en catálogos se aumenta la posibilidad de que sean descubiertos y se permite que las aplicaciones consuman fácilmente los metadatos de varios catálogos.</rdfs:comment>
+    <dcterms:contributor rdf:parseType="Resource">
+      <foaf:name>Jakub Klímek</foaf:name>
+      <foaf:homepage rdf:resource="https://jakub.klímek.com/"/>
+      <rdfs:seeAlso rdf:resource="https://jakub.klímek.com/#me"/>
+    </dcterms:contributor>
+    <dcterms:contributor rdf:parseType="Resource">
+      <foaf:name>Shuji Kamitsuna</foaf:name>
+      <foaf:homepage rdf:resource="http://www.asahi-net.or.jp/~ax2s-kmtn/"/>
+    </dcterms:contributor>
+    <dcterms:creator rdf:parseType="Resource">
+      <foaf:name>Fadi Maali</foaf:name>
+      <rdfs:seeAlso rdf:resource="http://fadmaa.me/foaf.ttl"/>
+    </dcterms:creator>
     <rdfs:label xml:lang="ar">أنطولوجية فهارس قوائم البيانات</rdfs:label>
     <rdfs:label xml:lang="el">Το λεξιλόγιο των καταλόγων δεδομένων</rdfs:label>
+    <owl:versionInfo xml:lang="cs">Toto je aktualizovaná kopie slovníku DCAT verze 2.0, převzatá z https://www.w3.org/ns/dcat.ttl</owl:versionInfo>
     <dcterms:contributor rdf:parseType="Resource">
       <foaf:name>Ghislain Auguste Atemezing</foaf:name>
       <rdfs:seeAlso rdf:resource="http://www.eurecom.fr/~atemezin/gatemezing-foaf.rdf"/>
     </dcterms:contributor>
-    <owl:versionInfo xml:lang="cs">Toto je aktualizovaná kopie slovníku DCAT verze 2.0, převzatá z https://www.w3.org/ns/dcat.ttl</owl:versionInfo>
     <rdfs:comment xml:lang="el">Το DCAT είναι ένα RDF λεξιλόγιο που σχεδιάσθηκε για να κάνει εφικτή τη διαλειτουργικότητα μεταξύ καταλόγων δεδομένων στον Παγκόσμιο Ιστό. Χρησιμοποιώντας το DCAT για την περιγραφή συνόλων δεδομένων, οι εκδότες αυτών αυξάνουν την ανακαλυψιμότητα και επιτρέπουν στις εφαρμογές την εύκολη κατανάλωση μεταδεδομένων από πολλαπλούς καταλόγους. Επιπλέον, δίνει τη δυνατότητα για αποκεντρωμένη έκδοση και διάθεση καταλόγων και επιτρέπει δυνατότητες ενοποιημένης αναζήτησης μεταξύ διαφορετικών πηγών. Συγκεντρωτικά μεταδεδομένα που έχουν περιγραφεί με το DCAT μπορούν να χρησιμοποιηθούν σαν ένα δηλωτικό αρχείο (manifest file) ώστε να διευκολύνουν την ψηφιακή συντήρηση.</rdfs:comment>
-    <dcterms:contributor rdf:parseType="Resource">
-      <foaf:name>Vassilios Peristeras</foaf:name>
-      <sdo:affiliation rdf:parseType="Resource">
-        <foaf:name>European Commission, DG DIGIT</foaf:name>
-        <foaf:homepage rdf:resource="http://ec.europa.eu/dgs/informatics/"/>
-      </sdo:affiliation>
-    </dcterms:contributor>
+    <dcterms:creator rdf:parseType="Resource">
+      <foaf:name>John Erickson</foaf:name>
+    </dcterms:creator>
     <rdfs:label xml:lang="ja">データ・カタログ語彙（DCAT）</rdfs:label>
     <dcterms:contributor rdf:parseType="Resource">
-      <foaf:name>Phil Archer</foaf:name>
-      <foaf:homepage rdf:resource="http://www.w3.org/People/all#phila"/>
-      <rdfs:seeAlso rdf:resource="http://philarcher.org/foaf.rdf#me"/>
-      <sdo:affiliation rdf:resource="http://www.w3.org/data#W3C"/>
+      <foaf:name>Boris Villazón-Terrazas</foaf:name>
+    </dcterms:contributor>
+    <dcterms:contributor rdf:parseType="Resource">
+      <foaf:name>Marios Meimaris</foaf:name>
+    </dcterms:contributor>
+    <dcterms:contributor rdf:parseType="Resource">
+      <foaf:name>Andrea Perego</foaf:name>
+      <foaf:homepage rdf:resource="https://www.andrea-perego.name/foaf/#me"/>
+      <rdfs:seeAlso rdf:resource="https://orcid.org/0000-0001-9300-2694"/>
     </dcterms:contributor>
     <rdfs:comment xml:lang="it">DCAT è un vocabolario RDF progettato per facilitare l'interoperabilità tra i cataloghi di dati pubblicati nel Web. Utilizzando DCAT per descrivere i dataset nei cataloghi di dati, i fornitori migliorano la capacità di individuazione dei dati e abilitano le  applicazioni al consumo di dati provenienti da cataloghi differenti. DCAT permette di decentralizzare la pubblicazione di cataloghi e facilita la ricerca federata dei dataset. L'aggregazione dei metadati federati può fungere da file manifesto per facilitare la conservazione digitale. DCAT è definito all'indirizzo http://www.w3.org/TR/vocab-dcat/. Qualsiasi scostamento tra tale definizione normativa e questo schema è da considerarsi un errore di questo schema.</rdfs:comment>
     <rdfs:label xml:lang="en">The data catalog vocabulary</rdfs:label>
@@ -180,6 +179,7 @@
     <skos:definition xml:lang="cs">Kolekce dat poskytovaná či řízená jedním zdrojem, která je k dispozici pro přístup či stažení v jednom či více formátech.</skos:definition>
     <rdfs:label xml:lang="ar">قائمة بيانات</rdfs:label>
     <rdfs:comment xml:lang="ar">قائمة بيانات منشورة أو مجموعة من قبل مصدر ما و متاح الوصول إليها أو تحميلها</rdfs:comment>
+    <skos:definition xml:lang="en">A collection of data, published or curated by a single source, and available for access or download in one or more representations.</skos:definition>
     <skos:scopeNote xml:lang="it">Questa classe rappresenta il dataset come pubblicato dall’editore. Nel caso in cui sia necessario operare  una distinzione fra i metadati originali del dataset e il record dei metadati ad esso associato nel catalogo (ad esempio, per distinguere la data di modifica del dataset da quella del dataset nel catalogo) si può impiegare la classe catalog record.</skos:scopeNote>
     <rdfs:label xml:lang="es">Conjunto de datos</rdfs:label>
     <rdfs:label xml:lang="el">Σύνολο Δεδομένων</rdfs:label>
@@ -205,7 +205,6 @@
     <rdfs:comment xml:lang="es">Una colección de datos, publicados o conservados por una única fuente, y disponibles para ser accedidos o descargados en uno o más formatos.</rdfs:comment>
     <skos:scopeNote xml:lang="en">The notion of dataset in DCAT is broad and inclusive, with the intention of accommodating resource types arising from all communities. Data comes in many forms including numbers, text, pixels, imagery, sound and other multi-media, and potentially other types, any of which might be collected into a dataset.</skos:scopeNote>
     <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#Class"/>
-    <skos:definition xml:lang="en">A collection of data, published or curated by a single source, and available for access or download in one or more representations.</skos:definition>
     <skos:scopeNote xml:lang="da">Denne klasse beskriver det konceptuelle datasæt. En eller flere repræsentationer kan være tilgængelige med forskellige skematiske opsætninger, formater eller serialiseringer.</skos:scopeNote>
     <skos:changeNote xml:lang="it">2018-02 - sottoclasse di dctype:Dataset rimosso perché l'ambito di dcat:Dataset include diversi altri tipi dal vocabolario dctype.</skos:changeNote>
     <skos:scopeNote xml:lang="da">Denne klasse repræsenterer det konkrete datasæt som det udgives af datasætleverandøren. I de tilfælde hvor det er nødvendigt at skelne mellem det konkrete datasæt og dets registrering i kataloget (fordi metadata såsom ændringsdato og vedligeholder er forskellige), så kan klassen katalogpost anvendes. </skos:scopeNote>
@@ -262,6 +261,8 @@
     <rdfs:label xml:lang="it">Record di catalogo</rdfs:label>
     <skos:scopeNote xml:lang="it">Questa classe è opzionale e non tutti i cataloghi la utilizzeranno. Esiste per cataloghi in cui si opera una distinzione tra i metadati relativi al dataset ed i metadati relativi alla gestione del dataset nel catalogo. Ad esempio, la  proprietà per indicare la data di pubblicazione del dataset rifletterà la data in cui l'informazione è stata originariamente messa a disposizione dalla casa editrice, mentre la data di pubblicazione per il record nel catalogo rifletterà la data in cui il dataset è stato aggiunto al catalogo. Nei casi dove solo quest'ultima sia nota, si utilizzerà esclusivamente la data di  pubblicazione relativa al record del catalogo. Si noti che l'Ontologia W3C PROV permette di descrivere ulteriori informazioni sulla provenienza, quali i dettagli del processo, la procedura e l'agente coinvolto in una particolare modifica di un dataset.</skos:scopeNote>
     <skos:scopeNote xml:lang="cs">Tato třída je volitelná a ne všechny katalogy ji využijí. Existuje pro katalogy, ve kterých se rozlišují metadata datové sady či datové služby a metadata o záznamu o datové sadě či datové službě v katalogu. Například datum publikace datové sady odráží datum, kdy byla datová sada původně zveřejněna poskytovatelem dat, zatímco datum publikace katalogizačního záznamu je datum zanesení datové sady do katalogu. V případech kdy se obě data liší, nebo je známo jen to druhé, by mělo být specifikováno jen datum publikace katalogizačního záznamu. Všimněte si, že ontologie W3C PROV umožňuje popsat další informace o původu jako například podrobnosti o procesu konkrétní změny datové sady a jeho účastnících.</skos:scopeNote>
+    <skos:definition xml:lang="es">Un registro en un catálogo de datos que describe un solo conjunto de datos o un servicio de datos.</skos:definition>
+    <rdfs:comment xml:lang="da">En post i et datakatalog der beskriver registreringen af et enkelt datasæt eller en datatjeneste.</rdfs:comment>
     <rdfs:subClassOf>
       <owl:Restriction>
         <owl:onProperty>
@@ -272,14 +273,21 @@
         </owl:allValuesFrom>
       </owl:Restriction>
     </rdfs:subClassOf>
-    <skos:definition xml:lang="es">Un registro en un catálogo de datos que describe un solo conjunto de datos o un servicio de datos.</skos:definition>
-    <rdfs:comment xml:lang="da">En post i et datakatalog der beskriver registreringen af et enkelt datasæt eller en datatjeneste.</rdfs:comment>
     <skos:definition xml:lang="da">En post i et datakatalog der beskriver registreringen af et enkelt datasæt eller en datatjeneste.</skos:definition>
     <rdfs:comment xml:lang="cs">Záznam v datovém katalogu popisující jednu datovou sadu či datovou službu.</rdfs:comment>
     <rdf:type rdf:resource="http://www.w3.org/2000/01/rdf-schema#Class"/>
     <rdfs:comment xml:lang="fr">Un registre du catalogue ou une entrée du catalogue, décrivant un seul jeu de données.</rdfs:comment>
     <skos:definition xml:lang="ja">1つのデータセットを記述したデータ・カタログ内のレコード。</skos:definition>
     <rdfs:label xml:lang="en">Catalog Record</rdfs:label>
+    <rdfs:subClassOf>
+      <owl:Restriction>
+        <owl:onProperty>
+          <owl:ObjectProperty rdf:about="http://xmlns.com/foaf/0.1/primaryTopic"/>
+        </owl:onProperty>
+        <owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger"
+        >1</owl:cardinality>
+      </owl:Restriction>
+    </rdfs:subClassOf>
     <skos:scopeNote xml:lang="es">Esta clase es opcional y no todos los catálogos la utilizarán. Esta clase existe para catálogos que hacen una distinción entre los metadatos acerca de un conjunto de datos o un servicio de datos y los metadatos acerca de una entrada en ese conjunto de datos en el catálogo. Por ejemplo, la propiedad sobre la fecha de la publicación de los datos refleja la fecha en que la información fue originalmente publicada, mientras que la fecha de publicación del registro del catálogo es la fecha en que los datos se agregaron al mismo. En caso en que ambas fechas fueran diferentes, o en que sólo la fecha de publicación del registro del catálogo estuviera disponible, sólo debe especificarse en el registro del catálogo. Tengan en cuenta que la ontología PROV de W3C permite describir otra información sobre la proveniencia de los datos, como por ejemplo detalles del proceso y de los agentes involucrados en algún cambio específico a los datos.</skos:scopeNote>
     <skos:editorialNote xml:lang="en">English definition updated in this revision. Multilingual text not yet updated except the Spanish one and the Czech one and Italian one.</skos:editorialNote>
     <rdfs:label xml:lang="da">Katalogpost</rdfs:label>
@@ -290,15 +298,6 @@
     <rdfs:comment xml:lang="es">Un registro en un catálogo de datos que describe un solo conjunto de datos o un servicio de datos.</rdfs:comment>
     <skos:scopeNote xml:lang="en">This class is optional and not all catalogs will use it. It exists for catalogs where a distinction is made between metadata about a dataset or data service and metadata about the entry for the dataset or data service in the catalog. For example, the publication date property of the dataset reflects the date when the information was originally made available by the publishing agency, while the publication date of the catalog record is the date when the dataset was added to the catalog. In cases where both dates differ, or where only the latter is known, the publication date should only be specified for the catalog record. Notice that the W3C PROV Ontology allows describing further provenance information such as the details of the process and the agent involved in a particular change to a dataset.</skos:scopeNote>
     <skos:scopeNote xml:lang="el">Αυτή η κλάση είναι προαιρετική και δεν χρησιμοποιείται από όλους τους καταλόγους. Υπάρχει για τις περιπτώσεις καταλόγων όπου γίνεται διαχωρισμός μεταξύ των μεταδεδομένων για το σύνολο των δεδομένων και των μεταδεδομένων για την καταγραφή του συνόλου δεδομένων εντός του καταλόγου. Για παράδειγμα, η ιδιότητα της ημερομηνίας δημοσίευσης του συνόλου δεδομένων δείχνει την ημερομηνία κατά την οποία οι πληροφορίες έγιναν διαθέσιμες από τον φορέα δημοσίευσης, ενώ η ημερομηνία δημοσίευσης της καταγραφής του καταλόγου δείχνει την ημερομηνία που το σύνολο δεδομένων προστέθηκε στον κατάλογο. Σε περιπτώσεις που οι δύο ημερομηνίες διαφέρουν, ή που μόνο η τελευταία είναι γνωστή, η ημερομηνία δημοσίευσης θα πρέπει να δίνεται για την καταγραφή του καταλόγου. Να σημειωθεί πως η οντολογία W3C PROV επιτρέπει την περιγραφή επιπλέον πληροφοριών ιστορικού όπως λεπτομέρειες για τη διαδικασία και τον δράστη που εμπλέκονται σε μία συγκεκριμένη αλλαγή εντός του συνόλου δεδομένων.</skos:scopeNote>
-    <rdfs:subClassOf>
-      <owl:Restriction>
-        <owl:onProperty>
-          <owl:ObjectProperty rdf:about="http://xmlns.com/foaf/0.1/primaryTopic"/>
-        </owl:onProperty>
-        <owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger"
-        >1</owl:cardinality>
-      </owl:Restriction>
-    </rdfs:subClassOf>
     <skos:scopeNote xml:lang="da">Denne klasse er valgfri og ikke alle kataloger vil anvende denne klasse. Den kan anvendes i de kataloger hvor der skelnes mellem metadata om datasættet eller datatjenesten og metadata om selve posten til registreringen af datasættet eller datatjenesten i kataloget. Udgivelsesdatoen for datasættet afspejler for eksempel den dato hvor informationerne oprindeligt blev gjort tilgængelige af udgiveren, hvorimod udgivelsesdatoen for katalogposten er den dato hvor datasættet blev føjet til kataloget. I de tilfælde hvor de to datoer er forskellige eller hvor blot sidstnævnte er kendt, bør udgivelsesdatoen kun angives for katalogposten. Bemærk at W3Cs PROV ontologi gør til muligt at tilføje yderligere proveniensoplysninger eksempelvis om processen eller aktøren involveret i en given ændring af datasættet.</skos:scopeNote>
     <skos:definition xml:lang="el">Μία καταγραφή ενός καταλόγου, η οποία περιγράφει ένα συγκεκριμένο σύνολο δεδομένων.</skos:definition>
     <rdfs:label xml:lang="fr">Registre du catalogue</rdfs:label>
@@ -872,6 +871,14 @@
     <rdfs:label xml:lang="it">tiene rol</rdfs:label>
     <skos:editorialNote xml:lang="cs">Přidáno do DCAT pro doplnění vlastnosti prov:hadRole (jejíž užití je omezeno na role v kontextu aktivity, s definičním oborem prov:Association).</skos:editorialNote>
     <skos:changeNote xml:lang="en">New property added in DCAT 2.0.</skos:changeNote>
+    <rdfs:domain>
+      <owl:Class>
+        <owl:unionOf rdf:parseType="Collection">
+          <rdf:Description rdf:about="http://www.w3.org/ns/prov#Attribution"/>
+          <owl:Class rdf:about="http://www.w3.org/ns/dcat#Relationship"/>
+        </owl:unionOf>
+      </owl:Class>
+    </rdfs:domain>
     <skos:definition xml:lang="da">Den funktion en entitet eller aktør har i forhold til en anden ressource.</skos:definition>
     <skos:editorialNote xml:lang="da">Introduceret i DCAT for at supplere prov:hadRole (hvis anvendelse er begrænset til roller i forbindelse med en aktivitet med domænet prov:Association).</skos:editorialNote>
     <rdfs:comment xml:lang="it">La funzione di un'entità o un agente rispetto ad un'altra entità o risorsa.</rdfs:comment>
@@ -900,14 +907,6 @@
     <rdfs:range rdf:resource="http://www.w3.org/ns/dcat#Role"/>
     <skos:scopeNote xml:lang="es">Puede usarse en una atribución cualificada para especificar el rol de un Agente con respecto a una Entidad. Se recomienda que el valor sea de un vocabulario controlado de roles de agentes, como por ejemplo http://registry.it.csiro.au/def/isotc211/CI_RoleCode.</skos:scopeNote>
     <skos:editorialNote xml:lang="es">Agregada en DCAT para complementar prov:hadRole (cuyo uso está limitado a roles en el contexto de una actividad, con dominio prov:Association.</skos:editorialNote>
-    <rdfs:domain>
-      <owl:Class>
-        <owl:unionOf rdf:parseType="Collection">
-          <rdf:Description rdf:about="http://www.w3.org/ns/prov#Attribution"/>
-          <owl:Class rdf:about="http://www.w3.org/ns/dcat#Relationship"/>
-        </owl:unionOf>
-      </owl:Class>
-    </rdfs:domain>
     <skos:scopeNote xml:lang="da">Kan vendes ved kvalificerede krediteringer til at angive en aktørs rolle i forhold en entitet. Det anbefales at værdierne styres som et kontrolleret udfaldsrum med aktørroller, såsom http://registry.it.csiro.au/def/isotc211/CI_RoleCode.</skos:scopeNote>
     <skos:scopeNote xml:lang="es">Puede usarse en una atribución cualificada para especificar el rol de una Entidad con respecto a otra Entidad. Se recomienda que su valor se tome de un vocabulario controlado de roles de entidades como por ejemplo: ISO 19115 DS_AssociationTypeCode http://registry.it.csiro.au/def/isotc211/DS_AssociationTypeCode; IANA Registry of Link Relations https://www.iana.org/assignments/link-relation; esquema de metadatos de DataCite; MARC relators https://id.loc.gov/vocabulary/relators.</skos:scopeNote>
   </owl:ObjectProperty>
@@ -1170,12 +1169,12 @@
     <rdfs:label xml:lang="es">URL de acceso</rdfs:label>
     <skos:scopeNote xml:lang="ja">確実にダウンロードでない場合や、ダウンロードかどうかが不明である場合は、downloadURLではなく、accessURLを用いてください。ランディング・ページを通じてしか配信にアクセスできない場合（つまり、直接的なダウンロードURLが不明）は、配信におけるaccessURLとしてランディング・ページのリンクをコピーすべきです（SHOULD）。</skos:scopeNote>
     <rdfs:label xml:lang="it">indirizzo di accesso</rdfs:label>
+    <rdfs:comment xml:lang="ar">أي رابط يتيح الوصول إلى البيانات. إذا كان الرابط هو ربط مباشر لملف يمكن تحميله استخدم الخاصية downloadURL</rdfs:comment>
+    <skos:definition xml:lang="cs">URL zdroje, přes které je přístupná distribuce datové sady. Příkladem může být vstupní stránka, RSS kanál či SPARQL endpoint. Použijte ve všech případech kromě URL souboru ke stažení, pro které je lepší použít dcat:downloadURL.</skos:definition>
     <owl:propertyChainAxiom rdf:parseType="Collection">
       <owl:ObjectProperty rdf:about="http://www.w3.org/ns/dcat#accessService"/>
       <owl:ObjectProperty rdf:about="http://www.w3.org/ns/dcat#endpointURL"/>
     </owl:propertyChainAxiom>
-    <rdfs:comment xml:lang="ar">أي رابط يتيح الوصول إلى البيانات. إذا كان الرابط هو ربط مباشر لملف يمكن تحميله استخدم الخاصية downloadURL</rdfs:comment>
-    <skos:definition xml:lang="cs">URL zdroje, přes které je přístupná distribuce datové sady. Příkladem může být vstupní stránka, RSS kanál či SPARQL endpoint. Použijte ve všech případech kromě URL souboru ke stažení, pro které je lepší použít dcat:downloadURL.</skos:definition>
     <skos:definition xml:lang="ar">أي رابط يتيح الوصول إلى البيانات. إذا كان الرابط هو ربط مباشر لملف يمكن تحميله استخدم الخاصية downloadURL</skos:definition>
     <rdfs:label xml:lang="da">adgangsadresse</rdfs:label>
     <skos:scopeNote xml:lang="en">If the distribution(s) are accessible only through a landing page (i.e. direct download URLs are not known), then the landing page link should be duplicated as accessURL on a distribution.</skos:scopeNote>
@@ -1297,6 +1296,7 @@
     <rdfs:label xml:lang="en">bounding box</rdfs:label>
     <rdf:type rdf:resource="http://www.w3.org/2002/07/owl#DatatypeProperty"/>
     <skos:changeNote xml:lang="es">Propiedad nueva agregada en DCAT 2.0.</skos:changeNote>
+    <skos:definition xml:lang="en">The geographic bounding box of a spatial thing [SDW-BP].</skos:definition>
     <rdfs:label xml:lang="es">cuadro delimitador</rdfs:label>
     <skos:changeNote xml:lang="en">New property added in DCAT 2.0.</skos:changeNote>
     <rdfs:range rdf:resource="http://www.w3.org/2000/01/rdf-schema#Literal"/>
@@ -1307,7 +1307,6 @@
     <skos:definition xml:lang="es">El cuadro delimitador geográfico para un recurso.</skos:definition>
     <skos:changeNote xml:lang="it">Nuova proprietà aggiunta in DCAT 2.0.</skos:changeNote>
     <skos:scopeNote xml:lang="it">Il range di questa proprietà (rdfs:Literal) è volutamente generica, con lo scopo di consentire diverse codifiche geometriche letterali. Ad esempio, la geometria potrebbe essere codificata con un letterale WKT (geosparql:wktLiteral [GeoSPARQL]) o [GML] (geosparql:asGML [GeoSPARQL]).</skos:scopeNote>
-    <skos:definition xml:lang="en">The geographic bounding box of a resource.</skos:definition>
     <rdfs:label xml:lang="it">quadro di delimitazione</rdfs:label>
     <skos:scopeNote xml:lang="da">Rækkevidden for denne egenskab er bevidst generisk defineret med det formål at tillade forskellige kodninger af geometrier. Geometrien kan eksempelvis repræsenteres som WKT (geosparql:asWKT [GeoSPARQL]) eller [GML] (geosparql:asGML [GeoSPARQL]).</skos:scopeNote>
   </rdf:Property>
@@ -1413,11 +1412,11 @@
     <skos:scopeNote xml:lang="en">The range of this property (rdfs:Literal) is intentionally generic, with the purpose of allowing different geometry literal encodings. E.g., the geometry could be encoded as a WKT literal (geosparql:wktLiteral [GeoSPARQL]).</skos:scopeNote>
     <skos:scopeNote xml:lang="it">Il range di questa proprietà (rdfs:Literal) è volutamente generica, con lo scopo di consentire diverse codifiche geometriche letterali. Ad esempio, la geometria potrebbe essere codificata con un letterale WKT (geosparql:wktLiteral [GeoSPARQL]) o [GML] (geosparql:asGML [GeoSPARQL]).</skos:scopeNote>
     <skos:definition xml:lang="da">Det geometrisk tyngdepunkt (centroid) for en ressource.</skos:definition>
+    <skos:definition xml:lang="en">The geographic center (centroid) of a spatial thing [SDW-BP].</skos:definition>
     <skos:definition xml:lang="es">El centro geográfico (centroide) de un recurso.</skos:definition>
     <rdfs:range rdf:resource="http://www.w3.org/2000/01/rdf-schema#Literal"/>
     <rdf:type rdf:resource="http://www.w3.org/1999/02/22-rdf-syntax-ns#Property"/>
     <skos:altLabel xml:lang="da">centroide</skos:altLabel>
-    <skos:definition xml:lang="en">The geographic center (centroid) of a resource.</skos:definition>
   </owl:DatatypeProperty>
   <owl:DatatypeProperty rdf:about="http://www.w3.org/ns/dcat#temporalResolution">
     <skos:scopeNote xml:lang="en">Alternative temporal resolutions might be provided as different dataset distributions.</skos:scopeNote>

--- a/dcat/rdf/dcat3.ttl
+++ b/dcat/rdf/dcat3.ttl
@@ -570,7 +570,7 @@ dcat:bbox
   skos:changeNote "Ny egenskab tilføjet i DCAT 2.0."@da ;
   skos:definition "El cuadro delimitador geográfico para un recurso."@es ;
   skos:definition "Ohraničení geografické oblasti zdroje."@cs ;
-  skos:definition "The geographic bounding box of a resource."@en ;
+  skos:definition "The geographic bounding box of a spatial thing [SDW-BP]."@en ;
   skos:definition "Il riquadro di delimitazione geografica di una risorsa."@it ;
   skos:definition "Den geografiske omskrevne firkant af en ressource."@da ;
   skos:scopeNote "El rango de esta propiedad es intencionalmente genérico con el propósito de permitir distintas codificaciones geométricas. Por ejemplo, la geometría puede ser codificada como WKT (geosparql:wktLiteral [GeoSPARQL]) o [GML] (geosparql:asGML [GeoSPARQL])."@es ;
@@ -670,7 +670,7 @@ dcat:centroid
   skos:changeNote "Ny egenskab tilføjet i DCAT 2.0."@da ;
   skos:definition "El centro geográfico (centroide) de un recurso."@es ;
   skos:definition "Geografický střed (centroid) zdroje."@cs ;
-  skos:definition "The geographic center (centroid) of a resource."@en ;
+  skos:definition "The geographic center (centroid) of a spatial thing [SDW-BP]."@en ;
   skos:definition "Il centro geografico (centroide) di una risorsa."@it ;
   skos:definition "Det geometrisk tyngdepunkt (centroid) for en ressource."@da ;
   skos:scopeNote "El rango de esta propiedad es intencionalmente genérico con el objetivo de permitir distintas codificaciones geométricas. Por ejemplo, la geometría puede codificarse como WKT (geosparql:wktLiteral [GeoSPARQL]) o [GML] (geosparql:asGML [GeoSPARQL])."@es ;


### PR DESCRIPTION
See https://github.com/w3c/dxwg/issues/1392#issuecomment-907498910

This PR tries to address the ambiguity of the term "resource" in the definitions of properties `locn:geometry`, `dcat:bbox`, and `dcat:centroid` by replacing it with "spatial thing", in the SDW-BP sense - see https://www.w3.org/TR/sdw-bp/#spatial-things-features-and-geometry
