### PR TITLE
replacing TAR with ZIP  dcat:packageFormat's usage NOTE

### DIFF
--- a/dcat/index.html
+++ b/dcat/index.html
@@ -3109,7 +3109,7 @@ table.simple {width:100%;}
                 <tr><th>RDF Property:</th><td><a href="http://www.w3.org/ns/dcat#packageFormat"><code>dcat:packageFormat</code></a></td></tr>
                 <tr><th class="prop">Definition:</th><td>The package format of the distribution in which one or more data files are grouped together, e.g. to enable a set of related files to be downloaded together.</td></tr>
                 <tr><th class="prop">Range:</th><td><a href="http://purl.org/dc/terms/MediaType"><code>dcterms:MediaType</code></a></td></tr>
-                <tr><th class="prop">Usage note:</th><td>This property to be used when the files in the distribution are packaged, e.g. in a <a href="https://en.wikipedia.org/wiki/Tar_(computing)">TAR file</a>, a <a href="http://frictionlessdata.io/data-package/">Frictionless Data Package</a> or a <a href="https://datatracker.ietf.org/doc/html/draft-kunze-bagit-14">Bagit</a> file. The format SHOULD be expressed using a media type as defined by IANA [[!IANA-MEDIA-TYPES]], if available.</td></tr>
+                <tr><th class="prop">Usage note:</th><td>This property to be used when the files in the distribution are packaged, e.g. in a <a href="https://en.wikipedia.org/wiki/ZIP_(file_format)">ZIP file</a>, a <a href="http://frictionlessdata.io/data-package/">Frictionless Data Package</a> or a <a href="https://datatracker.ietf.org/doc/html/draft-kunze-bagit-14">Bagit</a> file. The format SHOULD be expressed using a media type as defined by IANA [[!IANA-MEDIA-TYPES]], if available.</td></tr>
                 <tr><th class="prop">See also:</th><td><a href="#Property:distribution_compression_format"></a>.</td></tr>
                 </table>
 

--- a/dcat/index.html
+++ b/dcat/index.html
@@ -3109,7 +3109,7 @@ table.simple {width:100%;}
                 <tr><th>RDF Property:</th><td><a href="http://www.w3.org/ns/dcat#packageFormat"><code>dcat:packageFormat</code></a></td></tr>
                 <tr><th class="prop">Definition:</th><td>The package format of the distribution in which one or more data files are grouped together, e.g. to enable a set of related files to be downloaded together.</td></tr>
                 <tr><th class="prop">Range:</th><td><a href="http://purl.org/dc/terms/MediaType"><code>dcterms:MediaType</code></a></td></tr>
-                <tr><th class="prop">Usage note:</th><td>This property to be used when the files in the distribution are packaged, e.g. in a <a href="https://en.wikipedia.org/wiki/ZIP_(file_format)">ZIP file</a>, a <a href="http://frictionlessdata.io/data-package/">Frictionless Data Package</a> or a <a href="https://datatracker.ietf.org/doc/html/draft-kunze-bagit-14">Bagit</a> file. The format SHOULD be expressed using a media type as defined by IANA [[!IANA-MEDIA-TYPES]], if available.</td></tr>
+                <tr><th class="prop">Usage note:</th><td>This property to be used when the files in the distribution are packaged, e.g. in a <a href="https://en.wikipedia.org/wiki/Tar_(computing)">TAR file</a>, a <a href="https://en.wikipedia.org/wiki/ZIP_(file_format)">ZIP file</a>, a <a href="http://frictionlessdata.io/data-package/">Frictionless Data Package</a> or a <a href="https://datatracker.ietf.org/doc/html/draft-kunze-bagit-14">Bagit</a> file. The format SHOULD be expressed using a media type as defined by IANA [[!IANA-MEDIA-TYPES]], if available.</td></tr>
                 <tr><th class="prop">See also:</th><td><a href="#Property:distribution_compression_format"></a>.</td></tr>
                 </table>
 


### PR DESCRIPTION
 closes #1438
This PR addresses #1438 by replacing TAR with ZIP in the usage note of dcat:packageFormat. 
So that, at least one of the examples mentioned is contained in the IANA list.

