### PR TITLE
Dcat issue 1437

### DIFF
--- a/dcat/examples/vocab-dcat-3/compress-and-package.jsonld
+++ b/dcat/examples/vocab-dcat-3/compress-and-package.jsonld
@@ -4,16 +4,11 @@
   "conformsTo" : "https://mvcr1.opendata.cz/czechpoint/2007.json",
   "format" : "http://publications.europa.eu/resource/authority/file-type/CSV",
   "license" : "https://data.gov.cz/podmínky-užití/volný-přístup/",
-  "accessURL" : [ "https://mvcr1.opendata.cz/czechpoint/data.tar", "https://mvcr1.opendata.cz/czechpoint/2007.csv.gz", "https://mvcr1.opendata.cz/czechpoint/data.tar.gz" ],
   "compressFormat" : "http://www.iana.org/assignments/media-types/application/gzip",
   "downloadURL" : [ "https://mvcr1.opendata.cz/czechpoint/2007.csv.gz", "https://mvcr1.opendata.cz/czechpoint/data.tar.gz", "https://mvcr1.opendata.cz/czechpoint/data.tar" ],
   "mediaType" : "http://www.iana.org/assignments/media-types/text/csv",
   "packageFormat" : "http://publications.europa.eu/resource/authority/file-type/TAR",
   "@context" : {
-    "accessURL" : {
-      "@id" : "http://www.w3.org/ns/dcat#accessURL",
-      "@type" : "@id"
-    },
     "format" : {
       "@id" : "http://purl.org/dc/terms/format",
       "@type" : "@id"

--- a/dcat/examples/vocab-dcat-3/compress-and-package.rdf
+++ b/dcat/examples/vocab-dcat-3/compress-and-package.rdf
@@ -13,12 +13,9 @@
     xmlns:dap="https://data.csiro.au/dataset/"
     xmlns:xsd="http://www.w3.org/2001/XMLSchema#">
   <dcat:Distribution rdf:about="https://data.gov.cz/zdroj/datová-sada/247025684/22">
-    <dcat:accessURL rdf:resource="https://mvcr1.opendata.cz/czechpoint/data.tar"/>
     <dcterms:format rdf:resource="http://publications.europa.eu/resource/authority/file-type/CSV"/>
-    <dcat:accessURL rdf:resource="https://mvcr1.opendata.cz/czechpoint/2007.csv.gz"/>
     <dcat:mediaType rdf:resource="http://www.iana.org/assignments/media-types/text/csv"/>
     <dcat:packageFormat rdf:resource="http://publications.europa.eu/resource/authority/file-type/TAR"/>
-    <dcat:accessURL rdf:resource="https://mvcr1.opendata.cz/czechpoint/data.tar.gz"/>
     <dcat:downloadURL rdf:resource="https://mvcr1.opendata.cz/czechpoint/2007.csv.gz"/>
     <dcterms:license rdf:resource="https://data.gov.cz/podmínky-užití/volný-přístup/"/>
     <dcat:downloadURL rdf:resource="https://mvcr1.opendata.cz/czechpoint/data.tar.gz"/>

--- a/dcat/examples/vocab-dcat-3/compress-and-package.ttl
+++ b/dcat/examples/vocab-dcat-3/compress-and-package.ttl
@@ -22,7 +22,6 @@
 
 
 <https://data.gov.cz/zdroj/datová-sada/247025684/22> a dcat:Distribution ;
-    dcat:accessURL <https://mvcr1.opendata.cz/czechpoint/2007.csv.gz> ;
     dcat:downloadURL <https://mvcr1.opendata.cz/czechpoint/2007.csv.gz> ;
     dcterms:license <https://data.gov.cz/podmínky-užití/volný-přístup/> ;
     dcterms:conformsTo <https://mvcr1.opendata.cz/czechpoint/2007.json> ;
@@ -33,7 +32,6 @@
 # packaging
 
 <https://data.gov.cz/zdroj/datová-sada/247025684/22> a dcat:Distribution ;
-    dcat:accessURL <https://mvcr1.opendata.cz/czechpoint/data.tar> ;
     dcat:downloadURL <https://mvcr1.opendata.cz/czechpoint/data.tar> ;
     dcterms:license <https://data.gov.cz/podmínky-užití/volný-přístup/> ;
     dcterms:conformsTo <https://mvcr1.opendata.cz/czechpoint/2007.json> ;
@@ -44,7 +42,6 @@
 # packaging and compression
 
 <https://data.gov.cz/zdroj/datová-sada/247025684/22> a dcat:Distribution ;
-    dcat:accessURL <https://mvcr1.opendata.cz/czechpoint/data.tar.gz> ;
     dcat:downloadURL <https://mvcr1.opendata.cz/czechpoint/data.tar.gz> ;
     dcterms:conformsTo <https://mvcr1.opendata.cz/czechpoint/2007.json> ;
     dcterms:license <https://data.gov.cz/podmínky-užití/volný-přístup/> ;

--- a/dcat/index.html
+++ b/dcat/index.html
@@ -6539,7 +6539,6 @@ ga-courts:jc-wms
 @prefix dcterms: &lt;http://purl.org/dc/terms/&gt; .
 
 &lt;https://data.gov.cz/zdroj/datová-sada/247025684/22&gt; a dcat:Distribution ;
-  dcat:accessURL &lt;https://mvcr1.opendata.cz/czechpoint/2007.csv.gz&gt; ;
   dcat:downloadURL &lt;https://mvcr1.opendata.cz/czechpoint/2007.csv.gz&gt; ;
   dcterms:license &lt;https://data.gov.cz/podmínky-užití/volný-přístup/&gt; ;
   dcterms:conformsTo &lt;https://mvcr1.opendata.cz/czechpoint/2007.json&gt; ;
@@ -6558,7 +6557,6 @@ ga-courts:jc-wms
 @prefix dcterms: &lt;http://purl.org/dc/terms/> .
 
 &lt;https://data.gov.cz/zdroj/datová-sada/247025684/22&gt; a dcat:Distribution ;
-  dcat:accessURL &lt;https://mvcr1.opendata.cz/czechpoint/data.tar&gt; ;
   dcat:downloadURL &lt;https://mvcr1.opendata.cz/czechpoint/data.tar&gt; ;
   dcterms:license &lt;https://data.gov.cz/podmínky-užití/volný-přístup/&gt; ;
   dcterms:conformsTo &lt;https://mvcr1.opendata.cz/czechpoint/2007.json&gt; ;
@@ -6577,7 +6575,6 @@ ga-courts:jc-wms
 @prefix dcterms: &lt;http://purl.org/dc/terms/&gt; .
 
 &lt;https://data.gov.cz/zdroj/datová-sada/247025684/22&gt; a dcat:Distribution ;
-  dcat:accessURL &lt;https://mvcr1.opendata.cz/czechpoint/data.tar.gz&gt; ;
   dcat:downloadURL &lt;https://mvcr1.opendata.cz/czechpoint/data.tar.gz&gt; ;
   dcterms:conformsTo &lt;https://mvcr1.opendata.cz/czechpoint/2007.json&gt; ;
   dcterms:license &lt;https://data.gov.cz/podmínky-užití/volný-přístup/&gt; ;


### PR DESCRIPTION
As discussed in the last call (see https://www.w3.org/2022/01/25-dxwgdcat-minutes) we drop the dcat:accessURL to address #1437 
closes #1437 