### PR TITLE
Editorial changes to Notes

### DIFF
--- a/dcat/index.html
+++ b/dcat/index.html
@@ -4578,7 +4578,7 @@ For example:</p>
 </ul>
 
 <aside class="ednote">
-<p>The previous draft [[VOCAB-DCAT-3-20201217]] was making use of similar properties from [[DCTERMS]] and [[VOCAB-ADMS]], namely:</p>
+<p>An earlier working draft [[VOCAB-DCAT-3-20201217]] was making use of similar properties from [[DCTERMS]] and [[VOCAB-ADMS]], namely:</p>
 <ul>
 <li><code>dcterms:hasVersion</code> / <code>dcterms:isVersionOf</code>, for version hierarchies, and</li>
 <li><code>adms:prev</code>, <code>adms:next</code>, <code>adms:last</code> for both versions chains and dataset series.</li>
@@ -4589,7 +4589,7 @@ For example:</p>
 <li><a data-cite="VOCAB-ADMS#adms-last"><code>adms:last</code></a> is defined as <q>A link to the current or latest version of the Asset</q>, whereas in [[PAV]] the current and latest versions of a resource may be different, and link to by using different properties.</li>
 </ul>
 <p>Moreover, although the definitions of the [[VOCAB-ADMS]] properties states explicitly that they are meant to be used for "versions", they are subproperties of the corresponding terms in [[XHTML-VOCAB]], where they are used to link resources in a collection (e.g., the set of pages of a Web site). E.g., the definition of <a data-cite="XHTML-VOCAB#last"><code>xhv:last</code></a> reads as follows: <q>last refers to the last resource in a collection of resources.</q>.</p>
-<p>Based on that, in this draft, [[PAV]]-equivalent properties are used for versions, whereas the [[VOCAB-ADMS]] properties, and properties <code>dcterms:hasVersion</code> / <code>dcterms:isVersionOf</code> are not used.</p>
+<p>Based on that, in subsequent drafts, [[PAV]]-equivalent properties are used for versions, whereas the [[VOCAB-ADMS]] properties, and properties <code>dcterms:hasVersion</code> / <code>dcterms:isVersionOf</code> are not used.</p>
 </aside>
 
 <p>Property <code>dcat:previousVersion</code> is used to build a version chain, that can be navigated backward from a given version to the first one. This reflects the most typical use case - i.e., linking different versions published as distinct resources in a catalog.</p>

--- a/dcat/index.html
+++ b/dcat/index.html
@@ -770,9 +770,9 @@ table.simple {width:100%;}
         <h3>Class: Catalog</h3>
 
         <aside class="note">
-          <p>The scope of DCAT 1 was catalogs of datasets [[?VOCAB-DCAT-20140116]]. This has been generalized, and properties common to all cataloged resources are now associated with a super-class <a href="#Class:Resource"><code>dcat:Resource</code></a>.</p>
-          <p>Moreover, an explicit class for <a href="#Class:Data_Service">data services</a> has been added in DCAT 2, to enable these to be part of a catalog.</p>
-          <p>Finally, <code>dcat:Catalog</code> has been made a sub-class of <code>dcat:Dataset</code>, and provision for catalogs to be composed of other catalogs is also enabled.</p>
+          <p>The scope of <code>dcat:Catalog</code> in DCAT 1 was catalogs of datasets [[?VOCAB-DCAT-20140116]]. For DCAT 2, this was generalized, and properties common to all cataloged resources were associated with a super-class <a href="#Class:Resource"><code>dcat:Resource</code></a>.</p>
+          <p>Moreover, an explicit class for <a href="#Class:Data_Service">data services</a> was added in DCAT 2, to enable these to be part of a catalog.</p>
+          <p>Finally, <code>dcat:Catalog</code> was made a sub-class of <code>dcat:Dataset</code>, and provision for catalogs to be composed of other catalogs is also enabled.</p>
           <p>See Issue <a href="https://github.com/w3c/dxwg/issues/116">#116</a> and Issue <a href="https://github.com/w3c/dxwg/issues/172">#172</a>.</p>
         </aside>
 <!--
@@ -1121,7 +1121,7 @@ table.simple {width:100%;}
 
             <aside class="note">
               <p>
-                In DCAT 1 [[VOCAB-DCAT-20140116]] the domain of <code>dcat:contactPoint</code> was <code>dcat:Dataset</code>, which limited use of this property in other contexts. The domain has been relaxed in DCAT 2. See Issue <a href="https://github.com/w3c/dxwg/issues/95">#95</a>.
+                In DCAT 1 [[VOCAB-DCAT-20140116]] the domain of <code>dcat:contactPoint</code> was <code>dcat:Dataset</code>, which limited use of this property in other contexts. The domain was relaxed in DCAT 2. See Issue <a href="https://github.com/w3c/dxwg/issues/95">#95</a>.
               </p>
             </aside>
 
@@ -1258,7 +1258,7 @@ table.simple {width:100%;}
 
             <aside class="note">
               <p>
-                In DCAT 1 [[?VOCAB-DCAT-20140116]] the domain of <code>dcat:theme</code> was <code>dcat:Dataset</code>, which limited use of this property in other contexts. The domain has been relaxed in DCAT 2. 
+                In DCAT 1 [[?VOCAB-DCAT-20140116]] the domain of <code>dcat:theme</code> was <code>dcat:Dataset</code>, which limited use of this property in other contexts. The domain was relaxed in DCAT 2. 
                 See Issue <a href="https://github.com/w3c/dxwg/issues/123">#123</a>.
             </p>
             <p> 
@@ -1407,7 +1407,7 @@ table.simple {width:100%;}
 
             <aside class="note">
               <p>
-                In DCAT 1 [[?VOCAB-DCAT-20140116]] the domain of <code>dcat:keyword</code> was <code>dcat:Dataset</code>, which limited use of this property in other contexts. The domain has been relaxed in DCAT 2 - see Issue <a href="https://github.com/w3c/dxwg/issues/121">#121</a>.
+                In DCAT 1 [[?VOCAB-DCAT-20140116]] the domain of <code>dcat:keyword</code> was <code>dcat:Dataset</code>, which limited use of this property in other contexts. The domain was relaxed in DCAT 2 - see Issue <a href="https://github.com/w3c/dxwg/issues/121">#121</a>.
               </p>
             </aside>
 
@@ -1424,7 +1424,7 @@ table.simple {width:100%;}
 
             <aside class="note">
               <p>
-                In DCAT 1 [[?VOCAB-DCAT-20140116]] the domain of <code>dcat:landingPage</code> was <code>dcat:Dataset</code>, which limited use of this property in other contexts. The domain has been relaxed in DCAT 2 - see Issue <a href="https://github.com/w3c/dxwg/issues/122">#122</a>.
+                In DCAT 1 [[?VOCAB-DCAT-20140116]] the domain of <code>dcat:landingPage</code> was <code>dcat:Dataset</code>, which limited use of this property in other contexts. The domain was relaxed in DCAT 2 - see Issue <a href="https://github.com/w3c/dxwg/issues/122">#122</a>.
               </p>
             </aside>
 
@@ -2346,7 +2346,7 @@ table.simple {width:100%;}
         <aside class="note">
             <p>
               In DCAT 1 [[?VOCAB-DCAT-20140116]] <a href="#Class:Dataset"><code>dcat:Dataset</code></a> was a sub-class of <a href="http://purl.org/dc/dcmitype/Dataset"><code>dctype:Dataset</code></a>, which is a member of the <a data-cite="?DCTERMS#section-7">DCMI Types vocabulary</a> [[?DCTERMS]].
-              The scope of <a href="#Class:Dataset"><code>dcat:Dataset</code></a> also includes other members of the <a data-cite="?DCTERMS#section-7">DCMI Types vocabulary</a>, such as various multimedia (imagery, sound, video) and text, so the sub-class relationship from DCAT 1 [[?VOCAB-DCAT-20140116]] has been removed in this revised DCAT vocabulary - see Issue <a href="https://github.com/w3c/dxwg/issues/98">#98</a>.
+              The scope of <a href="#Class:Dataset"><code>dcat:Dataset</code></a> also includes other members of the <a data-cite="?DCTERMS#section-7">DCMI Types vocabulary</a>, such as various multimedia (imagery, sound, video) and text, so the sub-class relationship defined in DCAT 1 [[?VOCAB-DCAT-20140116]] was removed in the DCAT 2 vocabulary - see Issue <a href="https://github.com/w3c/dxwg/issues/98">#98</a>.
             </p>
             <p>
               Note that members of the <a data-cite="?DCTERMS#section-7">DCMI Types vocabulary</a> may appear as the value of the <a href="#Property:resource_type"><code>dcterms:type</code></a> property, as shown in <a href="#classifying-dataset-types"></a>.
@@ -3048,7 +3048,7 @@ table.simple {width:100%;}
 
             <aside class="note">
               <p>
-                The range of <code>dcat:mediaType</code> has been tightened from <code>dcterms:MediaTypeOrExtent</code> to <code>dcterms:MediaType</code> as part of the DCAT 2.
+                The range of <code>dcat:mediaType</code> was tightened from <code>dcterms:MediaTypeOrExtent</code> to <code>dcterms:MediaType</code> as part of the DCAT 2 vocabulary.
               </p>
             </aside>
 


### PR DESCRIPTION
Tidy up notes (mainly section 6) to make clear progression from DCAT1 to DCAT2 to DCAT3.  In the interests of time, I've avoided making larger changes (for example to include vocab version in the tables etc).

Rendered at: http://raw.githack.com/w3c/dxwg/dcat-issue-1441/dcat/index.html

Diff at: https://services.w3.org/htmldiff?doc1=https%3A%2F%2Fw3c.github.io%2Fdxwg%2Fdcat&doc2=https%3A%2F%2Fraw.githack.com%2Fw3c%2Fdxwg%2Fdcat-issue-1441%2Fdcat%2F

When merged, will close #1441 