### PR TITLE
Fixed example

### DIFF
--- a/dcat/examples/vocab-dcat-3/dryad-globtherm-sdata.ttl
+++ b/dcat/examples/vocab-dcat-3/dryad-globtherm-sdata.ttl
@@ -1,9 +1,12 @@
+@prefix dcterms: <http://purl.org/dc/terms/> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
 :globtherm
   dcterms:title "Data from: GlobTherm, a global database on thermal tolerances for aquatic and terrestrial organisms"@en ;
   dcterms:description "How climate affects species distributions is a longstanding question receiving renewed interest owing to the need to predict the impacts of global warming on biodiversity. Is climate change forcing species to live near their critical thermal limits? Are these limits likely to change through natural selection? These and other important questions can be addressed with models relating geographical distributions of species with climate data, but inferences made with these models are highly contingent on non-climatic factors such as biotic interactions. Improved understanding of climate change effects on species will require extensive analysis of thermal physiological traits, but such data are scarce and scattered. To overcome current limitations, we created the GlobTherm database. The database contains experimentally derived species’ thermal tolerance data currently comprising over 2,000 species of terrestrial, freshwater, intertidal and marine multicellular algae, pl ants, fungi, and animals. The GlobTherm database will be maintained and curated by iDiv with the aim of expanding it, and enable further investigations on the effects of climate on the distribution of life on Earth."@en ;
   dcterms:identifier "https://doi.org/10.5061/dryad.1cv08"^^xsd:anyURI ;
   dcterms:creator <https://orcid.org/0000-0002-7883-3577>;
-  dcterms:relation <https://doi.org/10.5061/dryad.1cv08/6>
-  dcterms:relation <https://doi.org/10.5061/dryad.1cv08/7>
+  dcterms:relation <https://doi.org/10.5061/dryad.1cv08/6>;
+  dcterms:relation <https://doi.org/10.5061/dryad.1cv08/7>;
   dcterms:isReferencedBy <https://doi.org/10.1038/sdata.2018.22>
 .


### PR DESCRIPTION
wrote a little script to validate the examples, and this one was missing the prefixes and a couple of semicolons