### PR TITLE
replacing colon namespace and a:

### DIFF
--- a/dcat/examples/vocab-dcat-3/dataset-002.jsonld
+++ b/dcat/examples/vocab-dcat-3/dataset-002.jsonld
@@ -1,11 +1,11 @@
 {
   "@graph" : [ {
-    "@id" : "http://dcat.example.org/dataset-002",
+    "@id" : "ex:dataset-002",
     "@type" : "dcat:Dataset",
-    "distribution" : "http://dcat.example.org/dataset-002-csv",
+    "distribution" : "ex:dataset-002-csv",
     "landingPage" : "http://example.org/dataset-002.html"
   }, {
-    "@id" : "http://dcat.example.org/dataset-002-csv",
+    "@id" : "ex:dataset-002-csv",
     "@type" : "dcat:Distribution",
     "accessURL" : "http://example.org/dataset-002.html",
     "mediaType" : "https://www.iana.org/assignments/media-types/text/csv"
@@ -35,6 +35,7 @@
       "@id" : "http://www.w3.org/ns/dcat#landingPage",
       "@type" : "@id"
     },
+    "ex" : "http://dcat.example.org/",
     "owl" : "http://www.w3.org/2002/07/owl#",
     "rdf" : "http://www.w3.org/1999/02/22-rdf-syntax-ns#",
     "xsd" : "http://www.w3.org/2001/XMLSchema#",

--- a/dcat/examples/vocab-dcat-3/dataset-002.rdf
+++ b/dcat/examples/vocab-dcat-3/dataset-002.rdf
@@ -4,7 +4,7 @@
     xmlns:owl="http://www.w3.org/2002/07/owl#"
     xmlns:dcat="http://www.w3.org/ns/dcat#"
     xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
-    xmlns="http://dcat.example.org/"
+    xmlns:ex="http://dcat.example.org/"
     xmlns:xsd="http://www.w3.org/2001/XMLSchema#">
   <owl:Ontology rdf:about="http://example.org/dataset-002">
     <owl:imports rdf:resource="http://www.w3.org/ns/dcat"/>

--- a/dcat/examples/vocab-dcat-3/dataset-002.ttl
+++ b/dcat/examples/vocab-dcat-3/dataset-002.ttl
@@ -1,7 +1,7 @@
 # baseURI: http://example.org/dataset-002
 # imports: http://www.w3.org/ns/dcat
 
-@prefix : <http://dcat.example.org/> .
+@prefix ex: <http://dcat.example.org/> .
 @prefix dcat: <http://www.w3.org/ns/dcat#> .
 @prefix dcterms: <http://purl.org/dc/terms/> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
@@ -13,12 +13,12 @@
   rdf:type owl:Ontology ;
   owl:imports <http://www.w3.org/ns/dcat> ;
 .
-:dataset-002
+ex:dataset-002
   a dcat:Dataset ;
   dcat:landingPage <http://example.org/dataset-002.html> ;
-  dcat:distribution :dataset-002-csv ;
+  dcat:distribution ex:dataset-002-csv ;
   .
-:dataset-002-csv
+ex:dataset-002-csv
   a dcat:Distribution ;
   dcat:accessURL <http://example.org/dataset-002.html> ;
   dcat:mediaType <https://www.iana.org/assignments/media-types/text/csv> ;

--- a/dcat/examples/vocab-dcat-3/dataset-003.jsonld
+++ b/dcat/examples/vocab-dcat-3/dataset-003.jsonld
@@ -1,11 +1,11 @@
 {
   "@graph" : [ {
-    "@id" : "http://dcat.example.org/dataset-003",
+    "@id" : "ex:dataset-003",
     "@type" : "dcat:Dataset",
-    "distribution" : "http://dcat.example.org/dataset-003-csv",
+    "distribution" : "ex:dataset-003-csv",
     "landingPage" : "http://example.org/dataset-003.html"
   }, {
-    "@id" : "http://dcat.example.org/dataset-003-csv",
+    "@id" : "ex:dataset-003-csv",
     "@type" : "dcat:Distribution",
     "downloadURL" : "http://example.org/dataset-003.csv",
     "mediaType" : "https://www.iana.org/assignments/media-types/text/csv"
@@ -35,6 +35,7 @@
       "@id" : "http://www.w3.org/ns/dcat#downloadURL",
       "@type" : "@id"
     },
+    "ex" : "http://dcat.example.org/",
     "owl" : "http://www.w3.org/2002/07/owl#",
     "rdf" : "http://www.w3.org/1999/02/22-rdf-syntax-ns#",
     "xsd" : "http://www.w3.org/2001/XMLSchema#",

--- a/dcat/examples/vocab-dcat-3/dataset-003.rdf
+++ b/dcat/examples/vocab-dcat-3/dataset-003.rdf
@@ -4,7 +4,7 @@
     xmlns:owl="http://www.w3.org/2002/07/owl#"
     xmlns:dcat="http://www.w3.org/ns/dcat#"
     xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
-    xmlns="http://dcat.example.org/"
+    xmlns:ex="http://dcat.example.org/"
     xmlns:xsd="http://www.w3.org/2001/XMLSchema#">
   <owl:Ontology rdf:about="http://example.org/dataset-003">
     <owl:imports rdf:resource="http://www.w3.org/ns/dcat"/>

--- a/dcat/examples/vocab-dcat-3/dataset-003.ttl
+++ b/dcat/examples/vocab-dcat-3/dataset-003.ttl
@@ -1,7 +1,7 @@
 # baseURI: http://example.org/dataset-003
 # imports: http://www.w3.org/ns/dcat
 
-@prefix : <http://dcat.example.org/> .
+@prefix ex: <http://dcat.example.org/> .
 @prefix dcat: <http://www.w3.org/ns/dcat#> .
 @prefix dcterms: <http://purl.org/dc/terms/> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
@@ -13,12 +13,12 @@
   rdf:type owl:Ontology ;
   owl:imports <http://www.w3.org/ns/dcat> ;
 .
-:dataset-003
+ex:dataset-003
   a dcat:Dataset ;
   dcat:landingPage <http://example.org/dataset-003.html> ;
-  dcat:distribution :dataset-003-csv ;
+  dcat:distribution ex:dataset-003-csv ;
   .
-:dataset-003-csv
+ex:dataset-003-csv
   a dcat:Distribution ;
   dcat:downloadURL <http://example.org/dataset-003.csv> ;
   dcat:mediaType <https://www.iana.org/assignments/media-types/text/csv> ;

--- a/dcat/examples/vocab-dcat-3/dataset-004-sdo.jsonld
+++ b/dcat/examples/vocab-dcat-3/dataset-004-sdo.jsonld
@@ -9,29 +9,29 @@
     },
     "imports" : [ "http://www.w3.org/ns/dcat", "http://schema.org/" ]
   }, {
-    "@id" : "http://dcat.example.org/dataset-004/s/dataset-004",
+    "@id" : "ex:dataset-004",
     "@type" : "sdo:Dataset",
-    "distribution" : [ "http://example.org/dataset-004/s/dataset-004-png", "http://example.org/dataset-004/s/dataset-004-csv" ]
+    "distribution" : [ "ex:dataset-004-png", "ex:dataset-004-csv" ]
   }, {
-    "@id" : "http://dcat.example.org/dataset-004/s/dataset-004-csv",
+    "@id" : "ex:dataset-004-csv",
     "@type" : "sdo:DataDownload",
     "encodingFormat" : "mime:text/csv",
     "url" : "http://dcat.example.org/api/table-005",
-    "accessService" : "http://dcat.example.org/dataset-004/s/table-service-005"
+    "accessService" : "ex:table-service-005"
   }, {
-    "@id" : "http://dcat.example.org/dataset-004/s/dataset-004-png",
+    "@id" : "ex:dataset-004-png",
     "@type" : "sdo:DataDownload",
     "encodingFormat" : "mime:image/png",
     "url" : "http://dcat.example.org/api/figure-006",
-    "accessService" : "http://dcat.example.org/dataset-004/s/figure-service-006"
+    "accessService" : "ex:figure-service-006"
   }, {
-    "@id" : "http://dcat.example.org/dataset-004/s/figure-service-006",
+    "@id" : "ex:figure-service-006",
     "@type" : "sdo:EntryPoint",
     "conformsTo" : "http://dcat.example.org/apidef/figure/v1.0",
     "additionalType" : "https://inspire.ec.europa.eu/metadata-codelist/SpatialDataServiceType/view",
     "url" : "http://dcat.example.org/api/figure-006"
   }, {
-    "@id" : "http://dcat.example.org/dataset-004/s/table-service-005",
+    "@id" : "ex:table-service-005",
     "@type" : "sdo:EntryPoint",
     "conformsTo" : "http://dcat.example.org/apidef/table/v2.2",
     "additionalType" : "https://inspire.ec.europa.eu/metadata-codelist/SpatialDataServiceType/download",
@@ -71,6 +71,7 @@
       "@type" : "@id"
     },
     "dap" : "https://data.csiro.au/dataset/",
+    "ex" : "http://dcat.example.org/dataset-004/s/",
     "owl" : "http://www.w3.org/2002/07/owl#",
     "rdf" : "http://www.w3.org/1999/02/22-rdf-syntax-ns#",
     "dctype" : "http://purl.org/dc/dcmitype/",

--- a/dcat/examples/vocab-dcat-3/dataset-004-sdo.rdf
+++ b/dcat/examples/vocab-dcat-3/dataset-004-sdo.rdf
@@ -2,13 +2,13 @@
     xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
     xmlns:mime="https://www.iana.org/assignments/media-types/"
     xmlns:dcterms="http://purl.org/dc/terms/"
-    xmlns="http://dcat.example.org/dataset-004/s/"
     xmlns:owl="http://www.w3.org/2002/07/owl#"
     xmlns:dctype="http://purl.org/dc/dcmitype/"
     xmlns:sdo="http://schema.org/"
     xmlns:dcat="http://www.w3.org/ns/dcat#"
     xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
     xmlns:dap="https://data.csiro.au/dataset/"
+    xmlns:ex="http://dcat.example.org/dataset-004/s/"
     xmlns:xsd="http://www.w3.org/2001/XMLSchema#">
   <owl:Ontology rdf:about="http://dcat.example.org/dataset-004/s/">
     <owl:imports rdf:resource="http://www.w3.org/ns/dcat"/>

--- a/dcat/examples/vocab-dcat-3/dataset-004-sdo.ttl
+++ b/dcat/examples/vocab-dcat-3/dataset-004-sdo.ttl
@@ -2,7 +2,7 @@
 # imports: http://schema.org/
 # imports: http://www.w3.org/ns/dcat
 
-@prefix : <http://dcat.example.org/dataset-004/s/> .
+@prefix ex: <http://dcat.example.org/dataset-004/s/> .
 @prefix dap: <https://data.csiro.au/dataset/> .
 @prefix dcat: <http://www.w3.org/ns/dcat#> .
 @prefix dcterms: <http://purl.org/dc/terms/> .
@@ -21,30 +21,30 @@
   owl:imports sdo: ;
   owl:imports <http://www.w3.org/ns/dcat> ;
 .
-:dataset-004
+ex:dataset-004
   a sdo:Dataset ;
-  sdo:distribution :dataset-004-csv ;
-  sdo:distribution :dataset-004-png ;
+  sdo:distribution ex:dataset-004-csv ;
+  sdo:distribution ex:dataset-004-png ;
 .
-:dataset-004-csv
+ex:dataset-004-csv
   a sdo:DataDownload ;
-  dcat:accessService :table-service-005 ;
+  dcat:accessService ex:table-service-005 ;
   sdo:url <http://dcat.example.org/api/table-005> ;
   sdo:encodingFormat <https://www.iana.org/assignments/media-types/text/csv> ;
 .
-:dataset-004-png
+ex:dataset-004-png
   a sdo:DataDownload ;
-  dcat:accessService :figure-service-006 ;
+  dcat:accessService ex:figure-service-006 ;
   sdo:url <http://dcat.example.org/api/figure-006> ;
   sdo:encodingFormat <https://www.iana.org/assignments/media-types/image/png> ;
 .
-:figure-service-006
+ex:figure-service-006
   a sdo:EntryPoint ;
   dcterms:conformsTo <http://dcat.example.org/apidef/figure/v1.0> ;
   sdo:additionalType <https://inspire.ec.europa.eu/metadata-codelist/SpatialDataServiceType/view> ;
   sdo:url <http://dcat.example.org/api/figure-006> ;
 .
-:table-service-005
+ex:table-service-005
   a sdo:EntryPoint ;
   dcterms:conformsTo <http://dcat.example.org/apidef/table/v2.2> ;
   sdo:additionalType <https://inspire.ec.europa.eu/metadata-codelist/SpatialDataServiceType/download> ;

--- a/dcat/examples/vocab-dcat-3/dataset-004.jsonld
+++ b/dcat/examples/vocab-dcat-3/dataset-004.jsonld
@@ -4,37 +4,37 @@
     "@type" : "owl:Ontology",
     "imports" : "http://www.w3.org/ns/dcat"
   }, {
-    "@id" : "http://dcat.example.org/dataset-004#dataset-004",
+    "@id" : "ex:dataset-004",
     "@type" : "dcat:Dataset",
-    "distribution" : [ "http://dcat.example.org/dataset-004#dataset-004-png", "http://example.org/dataset-004#dataset-004-csv" ]
+    "distribution" : [ "ex:dataset-004-png", "ex:dataset-004-csv" ]
   }, {
-    "@id" : "http://dcat.example.org/dataset-004#dataset-004-csv",
+    "@id" : "ex:dataset-004-csv",
     "@type" : "dcat:Distribution",
-    "accessService" : "http://dcat.example.org/dataset-004#table-service-005",
+    "accessService" : "ex:table-service-005",
     "accessURL" : "http://dcat.example.org/api/table-005",
     "mediaType" : "https://www.iana.org/assignments/media-types/text/csv"
   }, {
-    "@id" : "http://dcat.example.org/dataset-004#dataset-004-png",
+    "@id" : "ex:dataset-004-png",
     "@type" : "dcat:Distribution",
-    "accessService" : "http://dcat.example.org/dataset-004#figure-service-006",
+    "accessService" : "ex:figure-service-006",
     "accessURL" : "http://dcat.example.org/api/figure-006",
     "mediaType" : "https://www.iana.org/assignments/media-types/image/png"
   }, {
-    "@id" : "http://dcat.example.org/dataset-004#figure-service-006",
+    "@id" : "ex:figure-service-006",
     "@type" : "dcat:DataService",
     "conformsTo" : "http://dcat.example.org/apidef/figure/v1.0",
     "type" : "https://inspire.ec.europa.eu/metadata-codelist/SpatialDataServiceType/view",
     "endpointDescription" : "http://dcat.example.org/api/figure-006/params",
     "endpointURL" : "http://dcat.example.org/api/figure-006",
-    "servesDataset" : "http://dcat.example.org/dataset-004#dataset-004"
+    "servesDataset" : "ex:dataset-004"
   }, {
-    "@id" : "http://dcat.example.org/dataset-004#table-service-005",
+    "@id" : "ex:table-service-005",
     "@type" : "dcat:DataService",
     "conformsTo" : "http://dcat.example.org/apidef/table/v2.2",
     "type" : "https://inspire.ec.europa.eu/metadata-codelist/SpatialDataServiceType/download",
     "endpointDescription" : "http://dcat.example.org/api/table-005/capability",
     "endpointURL" : "http://dcat.example.org/api/table-005",
-    "servesDataset" : "http://dcat.example.org/dataset-004#dataset-004"
+    "servesDataset" : "ex:dataset-004"
   } ],
   "@context" : {
     "distribution" : {
@@ -51,10 +51,6 @@
     },
     "accessService" : {
       "@id" : "http://www.w3.org/ns/dcat#accessService",
-      "@type" : "@id"
-    },
-    "imports" : {
-      "@id" : "http://www.w3.org/2002/07/owl#imports",
       "@type" : "@id"
     },
     "servesDataset" : {
@@ -77,6 +73,11 @@
       "@id" : "http://purl.org/dc/terms/conformsTo",
       "@type" : "@id"
     },
+    "imports" : {
+      "@id" : "http://www.w3.org/2002/07/owl#imports",
+      "@type" : "@id"
+    },
+    "ex" : "http://dcat.example.org/dataset-004#",
     "owl" : "http://www.w3.org/2002/07/owl#",
     "rdf" : "http://www.w3.org/1999/02/22-rdf-syntax-ns#",
     "xsd" : "http://www.w3.org/2001/XMLSchema#",

--- a/dcat/examples/vocab-dcat-3/dataset-004.rdf
+++ b/dcat/examples/vocab-dcat-3/dataset-004.rdf
@@ -1,10 +1,10 @@
 <rdf:RDF
     xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
     xmlns:dcterms="http://purl.org/dc/terms/"
-    xmlns="http://dcat.example.org/dataset-004#"
     xmlns:owl="http://www.w3.org/2002/07/owl#"
     xmlns:dcat="http://www.w3.org/ns/dcat#"
     xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
+    xmlns:ex="http://dcat.example.org/dataset-004#"
     xmlns:xsd="http://www.w3.org/2001/XMLSchema#">
   <owl:Ontology rdf:about="http://dcat.example.org/dataset-004">
     <owl:imports rdf:resource="http://www.w3.org/ns/dcat"/>

--- a/dcat/examples/vocab-dcat-3/dataset-004.ttl
+++ b/dcat/examples/vocab-dcat-3/dataset-004.ttl
@@ -1,7 +1,7 @@
 # baseURI: http://dcat.xample.org/dataset-004
 # imports: http://www.w3.org/ns/dcat
 
-@prefix : <http://dcat.example.org/dataset-004#> .
+@prefix ex: <http://dcat.example.org/dataset-004#> .
 @prefix dcat: <http://www.w3.org/ns/dcat#> .
 @prefix dcterms: <http://purl.org/dc/terms/> .
 @prefix owl: <http://www.w3.org/2002/07/owl#> .
@@ -13,36 +13,36 @@
   rdf:type owl:Ontology ;
   owl:imports <http://www.w3.org/ns/dcat> ;
 .
-:dataset-004
+ex:dataset-004
   rdf:type dcat:Dataset ;
-  dcat:distribution :dataset-004-csv ;
-  dcat:distribution :dataset-004-png ;
-.
-:dataset-004-csv
+  dcat:distribution ex:dataset-004-csv ;
+  dcat:distribution ex:dataset-004-png ;
+. 
+ex:dataset-004-csv
   rdf:type dcat:Distribution ;
-  dcat:accessService :table-service-005 ;
+  dcat:accessService ex:table-service-005 ;
   dcat:accessURL <http://dcat.example.org/api/table-005> ;
   dcat:mediaType <https://www.iana.org/assignments/media-types/text/csv> ;
 .
-:dataset-004-png
+ex:dataset-004-png
   rdf:type dcat:Distribution ;
-  dcat:accessService :figure-service-006 ;
+  dcat:accessService ex:figure-service-006 ;
   dcat:accessURL <http://dcat.example.org/api/figure-006> ;
   dcat:mediaType <https://www.iana.org/assignments/media-types/image/png> ;
 .
-:figure-service-006
+ex:figure-service-006
   rdf:type dcat:DataService ;
   dcterms:conformsTo <http://dcat.example.org/apidef/figure/v1.0> ;
   dcterms:type <https://inspire.ec.europa.eu/metadata-codelist/SpatialDataServiceType/view> ;
   dcat:endpointDescription <http://dcat.example.org/api/figure-006/params> ;
   dcat:endpointURL <http://dcat.example.org/api/figure-006> ;
-  dcat:servesDataset :dataset-004 ;
+  dcat:servesDataset ex:dataset-004 ;
 .
-:table-service-005
+ex:table-service-005
   rdf:type dcat:DataService ;
   dcterms:conformsTo <http://dcat.example.org/apidef/table/v2.2> ;
   dcterms:type <https://inspire.ec.europa.eu/metadata-codelist/SpatialDataServiceType/download> ;
   dcat:endpointDescription <http://dcat.example.org/api/table-005/capability> ;
   dcat:endpointURL <http://dcat.example.org/api/table-005> ;
-  dcat:servesDataset :dataset-004 ;
+  dcat:servesDataset ex:dataset-004 ;
 .

--- a/dcat/examples/vocab-dcat-3/dryad-globtherm-sdata.jsonld
+++ b/dcat/examples/vocab-dcat-3/dryad-globtherm-sdata.jsonld
@@ -1,0 +1,44 @@
+{
+  "@id" : "ex:globtherm",
+  "creator" : "https://orcid.org/0000-0002-7883-3577",
+  "dcterms:description" : {
+    "@language" : "en",
+    "@value" : "How climate affects species distributions is a longstanding question receiving renewed interest owing to the need to predict the impacts of global warming on biodiversity. Is climate change forcing species to live near their critical thermal limits? Are these limits likely to change through natural selection? These and other important questions can be addressed with models relating geographical distributions of species with climate data, but inferences made with these models are highly contingent on non-climatic factors such as biotic interactions. Improved understanding of climate change effects on species will require extensive analysis of thermal physiological traits, but such data are scarce and scattered. To overcome current limitations, we created the GlobTherm database. The database contains experimentally derived species’ thermal tolerance data currently comprising over 2,000 species of terrestrial, freshwater, intertidal and marine multicellular algae, pl ants, fungi, and animals. The GlobTherm database will be maintained and curated by iDiv with the aim of expanding it, and enable further investigations on the effects of climate on the distribution of life on Earth."
+  },
+  "identifier" : "https://doi.org/10.5061/dryad.1cv08",
+  "isReferencedBy" : "https://doi.org/10.1038/sdata.2018.22",
+  "relation" : [ "https://doi.org/10.5061/dryad.1cv08/7", "https://doi.org/10.5061/dryad.1cv08/6" ],
+  "dcterms:title" : {
+    "@language" : "en",
+    "@value" : "Data from: GlobTherm, a global database on thermal tolerances for aquatic and terrestrial organisms"
+  },
+  "@context" : {
+    "isReferencedBy" : {
+      "@id" : "http://purl.org/dc/terms/isReferencedBy",
+      "@type" : "@id"
+    },
+    "relation" : {
+      "@id" : "http://purl.org/dc/terms/relation",
+      "@type" : "@id"
+    },
+    "creator" : {
+      "@id" : "http://purl.org/dc/terms/creator",
+      "@type" : "@id"
+    },
+    "identifier" : {
+      "@id" : "http://purl.org/dc/terms/identifier",
+      "@type" : "http://www.w3.org/2001/XMLSchema#anyURI"
+    },
+    "description" : {
+      "@id" : "http://purl.org/dc/terms/description",
+      "@type" : "http://www.w3.org/1999/02/22-rdf-syntax-ns#langString"
+    },
+    "title" : {
+      "@id" : "http://purl.org/dc/terms/title",
+      "@type" : "http://www.w3.org/1999/02/22-rdf-syntax-ns#langString"
+    },
+    "ex" : "http://dcat.example.org/dryad-globtherm-sdata",
+    "xsd" : "http://www.w3.org/2001/XMLSchema#",
+    "dcterms" : "http://purl.org/dc/terms/"
+  }
+}

--- a/dcat/examples/vocab-dcat-3/dryad-globtherm-sdata.rdf
+++ b/dcat/examples/vocab-dcat-3/dryad-globtherm-sdata.rdf
@@ -1,0 +1,16 @@
+<rdf:RDF
+    xmlns:dcterms="http://purl.org/dc/terms/"
+    xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+    xmlns:ex="http://dcat.example.org/dryad-globtherm-sdata"
+    xmlns:xsd="http://www.w3.org/2001/XMLSchema#">
+  <rdf:Description rdf:about="http://dcat.example.org/dryad-globtherm-sdataglobtherm">
+    <dcterms:isReferencedBy rdf:resource="https://doi.org/10.1038/sdata.2018.22"/>
+    <dcterms:relation rdf:resource="https://doi.org/10.5061/dryad.1cv08/7"/>
+    <dcterms:relation rdf:resource="https://doi.org/10.5061/dryad.1cv08/6"/>
+    <dcterms:creator rdf:resource="https://orcid.org/0000-0002-7883-3577"/>
+    <dcterms:identifier rdf:datatype="http://www.w3.org/2001/XMLSchema#anyURI"
+    >https://doi.org/10.5061/dryad.1cv08</dcterms:identifier>
+    <dcterms:description xml:lang="en">How climate affects species distributions is a longstanding question receiving renewed interest owing to the need to predict the impacts of global warming on biodiversity. Is climate change forcing species to live near their critical thermal limits? Are these limits likely to change through natural selection? These and other important questions can be addressed with models relating geographical distributions of species with climate data, but inferences made with these models are highly contingent on non-climatic factors such as biotic interactions. Improved understanding of climate change effects on species will require extensive analysis of thermal physiological traits, but such data are scarce and scattered. To overcome current limitations, we created the GlobTherm database. The database contains experimentally derived species’ thermal tolerance data currently comprising over 2,000 species of terrestrial, freshwater, intertidal and marine multicellular algae, pl ants, fungi, and animals. The GlobTherm database will be maintained and curated by iDiv with the aim of expanding it, and enable further investigations on the effects of climate on the distribution of life on Earth.</dcterms:description>
+    <dcterms:title xml:lang="en">Data from: GlobTherm, a global database on thermal tolerances for aquatic and terrestrial organisms</dcterms:title>
+  </rdf:Description>
+</rdf:RDF>

--- a/dcat/examples/vocab-dcat-3/dryad-globtherm-sdata.ttl
+++ b/dcat/examples/vocab-dcat-3/dryad-globtherm-sdata.ttl
@@ -1,7 +1,8 @@
 @prefix dcterms: <http://purl.org/dc/terms/> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+@prefix ex: <http://dcat.example.org/dryad-globtherm-sdata> .
 
-:globtherm
+ex:globtherm
   dcterms:title "Data from: GlobTherm, a global database on thermal tolerances for aquatic and terrestrial organisms"@en ;
   dcterms:description "How climate affects species distributions is a longstanding question receiving renewed interest owing to the need to predict the impacts of global warming on biodiversity. Is climate change forcing species to live near their critical thermal limits? Are these limits likely to change through natural selection? These and other important questions can be addressed with models relating geographical distributions of species with climate data, but inferences made with these models are highly contingent on non-climatic factors such as biotic interactions. Improved understanding of climate change effects on species will require extensive analysis of thermal physiological traits, but such data are scarce and scattered. To overcome current limitations, we created the GlobTherm database. The database contains experimentally derived species’ thermal tolerance data currently comprising over 2,000 species of terrestrial, freshwater, intertidal and marine multicellular algae, pl ants, fungi, and animals. The GlobTherm database will be maintained and curated by iDiv with the aim of expanding it, and enable further investigations on the effects of climate on the distribution of life on Earth."@en ;
   dcterms:identifier "https://doi.org/10.5061/dryad.1cv08"^^xsd:anyURI ;

--- a/dcat/examples/vocab-dcat-3/eea-csw.jsonld
+++ b/dcat/examples/vocab-dcat-3/eea-csw.jsonld
@@ -8,12 +8,12 @@
       "@value" : "<gml:Envelope srsName=\"http://www.opengis.net/def/crs/OGC/1.3/CRS84\"><gml:lowerCorner>-180 -90</gml:lowerCorner><gml:upperCorner>180 90</gml:upperCorner></gml:Envelope>"
     }
   }, {
-    "@id" : "a:CatalogA",
+    "@id" : "ex:CatalogA",
     "@type" : "dcat:Catalog",
-    "record" : "a:EEA-CSW-Endpoint-Record",
-    "service" : "a:EEA-CSW-Endpoint"
+    "record" : "ex:EEA-CSW-Endpoint-Record",
+    "service" : "ex:EEA-CSW-Endpoint"
   }, {
-    "@id" : "a:EEA",
+    "@id" : "ex:EEA",
     "@type" : "v:Organization",
     "hasEmail" : "mailto:info@eea.europa.eu",
     "hasURL" : "http://www.eea.europa.eu",
@@ -22,7 +22,7 @@
       "@value" : "European Environment Agency"
     }
   }, {
-    "@id" : "a:EEA-CSW-Endpoint",
+    "@id" : "ex:EEA-CSW-Endpoint",
     "@type" : "dcat:DataService",
     "dc:subject" : {
       "@language" : "en",
@@ -42,22 +42,22 @@
       "@language" : "en",
       "@value" : "European Environment Agency's public catalogue of spatial datasets."
     },
-    "type" : [ "http://inspire.ec.europa.eu/metadata-codelist/ResourceType/service", "http://inspire.ec.europa.eu/metadata-codelist/SpatialDataServiceType/discovery" ],
-    "contactPoint" : "a:EEA",
+    "type" : [ "http://inspire.ec.europa.eu/metadata-codelist/SpatialDataServiceType/discovery", "http://inspire.ec.europa.eu/metadata-codelist/ResourceType/service" ],
+    "contactPoint" : "ex:EEA",
     "endpointDescription" : "https://sdi.eea.europa.eu/catalogue/srv/eng/csw?service=CSW&request=GetCapabilities",
     "endpointURL" : "http://sdi.eea.europa.eu/catalogue/srv/eng/csw"
   }, {
-    "@id" : "a:EEA-CSW-Endpoint-Record",
+    "@id" : "ex:EEA-CSW-Endpoint-Record",
     "@type" : "dcat:CatalogRecord",
     "conformsTo" : "http://data.europa.eu/930",
     "dcterms:identifier" : "4be5cb08-e082-426a-9c57-8a53d7cd3f65",
     "language" : "http://publications.europa.eu/resource/authority/language/ENG",
     "modified" : "2012-05-21",
-    "source" : "a:EEA-CSW-Endpoint-SourceRecord",
-    "contactPoint" : "a:EEA",
-    "primaryTopic" : "a:EEA-CSW-Endpoint"
+    "source" : "ex:EEA-CSW-Endpoint-SourceRecord",
+    "contactPoint" : "ex:EEA",
+    "primaryTopic" : "ex:EEA-CSW-Endpoint"
   }, {
-    "@id" : "a:EEA-CSW-Endpoint-SourceRecord",
+    "@id" : "ex:EEA-CSW-Endpoint-SourceRecord",
     "conformsTo" : "http://www.isotc211.org/2005/gmd"
   }, {
     "@id" : "https://dcat.example.org/eea-csw",
@@ -65,6 +65,14 @@
     "imports" : [ "http://www.w3.org/2004/02/skos/core", "http://purl.org/dc/terms/" ]
   } ],
   "@context" : {
+    "conformsTo" : {
+      "@id" : "http://purl.org/dc/terms/conformsTo",
+      "@type" : "@id"
+    },
+    "geometry" : {
+      "@id" : "http://www.w3.org/ns/locn#geometry",
+      "@type" : "http://www.opengis.net/ont/geosparql#wktLiteral"
+    },
     "organization-name" : {
       "@id" : "http://www.w3.org/2006/vcard/ns#organization-name",
       "@type" : "http://www.w3.org/1999/02/22-rdf-syntax-ns#langString"
@@ -77,76 +85,12 @@
       "@id" : "http://www.w3.org/2006/vcard/ns#hasEmail",
       "@type" : "@id"
     },
-    "imports" : {
-      "@id" : "http://www.w3.org/2002/07/owl#imports",
-      "@type" : "@id"
-    },
-    "title" : {
-      "@id" : "http://purl.org/dc/terms/title",
-      "@type" : "http://www.w3.org/1999/02/22-rdf-syntax-ns#langString"
-    },
-    "endpointURL" : {
-      "@id" : "http://www.w3.org/ns/dcat#endpointURL",
-      "@type" : "@id"
-    },
-    "conformsTo" : {
-      "@id" : "http://purl.org/dc/terms/conformsTo",
-      "@type" : "@id"
-    },
-    "type" : {
-      "@id" : "http://purl.org/dc/terms/type",
-      "@type" : "@id"
-    },
-    "license" : {
-      "@id" : "http://purl.org/dc/terms/license",
+    "primaryTopic" : {
+      "@id" : "http://xmlns.com/foaf/0.1/primaryTopic",
       "@type" : "@id"
     },
     "contactPoint" : {
       "@id" : "http://www.w3.org/ns/dcat#contactPoint",
-      "@type" : "@id"
-    },
-    "issued" : {
-      "@id" : "http://purl.org/dc/terms/issued",
-      "@type" : "http://www.w3.org/2001/XMLSchema#date"
-    },
-    "spatial" : {
-      "@id" : "http://purl.org/dc/terms/spatial",
-      "@type" : "@id"
-    },
-    "subject" : {
-      "@id" : "http://purl.org/dc/elements/1.1/subject",
-      "@type" : "http://www.w3.org/1999/02/22-rdf-syntax-ns#langString"
-    },
-    "identifier" : {
-      "@id" : "http://purl.org/dc/terms/identifier",
-      "@type" : "http://www.w3.org/2001/XMLSchema#string"
-    },
-    "accessRights" : {
-      "@id" : "http://purl.org/dc/terms/accessRights",
-      "@type" : "@id"
-    },
-    "description" : {
-      "@id" : "http://purl.org/dc/terms/description",
-      "@type" : "http://www.w3.org/1999/02/22-rdf-syntax-ns#langString"
-    },
-    "endpointDescription" : {
-      "@id" : "http://www.w3.org/ns/dcat#endpointDescription",
-      "@type" : "@id"
-    },
-    "geometry" : {
-      "@id" : "http://www.w3.org/ns/locn#geometry",
-      "@type" : "http://www.opengis.net/ont/geosparql#wktLiteral"
-    },
-    "service" : {
-      "@id" : "http://www.w3.org/ns/dcat#service",
-      "@type" : "@id"
-    },
-    "record" : {
-      "@id" : "http://www.w3.org/ns/dcat#record",
-      "@type" : "@id"
-    },
-    "primaryTopic" : {
-      "@id" : "http://xmlns.com/foaf/0.1/primaryTopic",
       "@type" : "@id"
     },
     "source" : {
@@ -161,13 +105,69 @@
       "@id" : "http://purl.org/dc/terms/language",
       "@type" : "@id"
     },
+    "identifier" : {
+      "@id" : "http://purl.org/dc/terms/identifier",
+      "@type" : "http://www.w3.org/2001/XMLSchema#string"
+    },
+    "service" : {
+      "@id" : "http://www.w3.org/ns/dcat#service",
+      "@type" : "@id"
+    },
+    "record" : {
+      "@id" : "http://www.w3.org/ns/dcat#record",
+      "@type" : "@id"
+    },
+    "imports" : {
+      "@id" : "http://www.w3.org/2002/07/owl#imports",
+      "@type" : "@id"
+    },
+    "endpointDescription" : {
+      "@id" : "http://www.w3.org/ns/dcat#endpointDescription",
+      "@type" : "@id"
+    },
+    "title" : {
+      "@id" : "http://purl.org/dc/terms/title",
+      "@type" : "http://www.w3.org/1999/02/22-rdf-syntax-ns#langString"
+    },
+    "spatial" : {
+      "@id" : "http://purl.org/dc/terms/spatial",
+      "@type" : "@id"
+    },
+    "description" : {
+      "@id" : "http://purl.org/dc/terms/description",
+      "@type" : "http://www.w3.org/1999/02/22-rdf-syntax-ns#langString"
+    },
+    "endpointURL" : {
+      "@id" : "http://www.w3.org/ns/dcat#endpointURL",
+      "@type" : "@id"
+    },
+    "type" : {
+      "@id" : "http://purl.org/dc/terms/type",
+      "@type" : "@id"
+    },
+    "accessRights" : {
+      "@id" : "http://purl.org/dc/terms/accessRights",
+      "@type" : "@id"
+    },
+    "license" : {
+      "@id" : "http://purl.org/dc/terms/license",
+      "@type" : "@id"
+    },
+    "issued" : {
+      "@id" : "http://purl.org/dc/terms/issued",
+      "@type" : "http://www.w3.org/2001/XMLSchema#date"
+    },
+    "subject" : {
+      "@id" : "http://purl.org/dc/elements/1.1/subject",
+      "@type" : "http://www.w3.org/1999/02/22-rdf-syntax-ns#langString"
+    },
     "schema" : "http://schema.org/",
-    "a" : "http://dcat.example.org/eea-csw/",
     "gsp" : "http://www.opengis.net/ont/geosparql#",
     "owl" : "http://www.w3.org/2002/07/owl#",
     "xsd" : "http://www.w3.org/2001/XMLSchema#",
     "skos" : "http://www.w3.org/2004/02/skos/core#",
     "rdfs" : "http://www.w3.org/2000/01/rdf-schema#",
+    "ex" : "http://dcat.example.org/eea-csw/",
     "rdf" : "http://www.w3.org/1999/02/22-rdf-syntax-ns#",
     "v" : "http://www.w3.org/2006/vcard/ns#",
     "dctype" : "http://purl.org/dc/dcmitype/",

--- a/dcat/examples/vocab-dcat-3/eea-csw.rdf
+++ b/dcat/examples/vocab-dcat-3/eea-csw.rdf
@@ -11,8 +11,8 @@
     xmlns:v="http://www.w3.org/2006/vcard/ns#"
     xmlns:skos="http://www.w3.org/2004/02/skos/core#"
     xmlns:gsp="http://www.opengis.net/ont/geosparql#"
+    xmlns:ex="http://dcat.example.org/eea-csw/"
     xmlns:dcat="http://www.w3.org/ns/dcat#"
-    xmlns:a="http://dcat.example.org/eea-csw/"
     xmlns:foaf="http://xmlns.com/foaf/0.1/"
     xmlns:xsd="http://www.w3.org/2001/XMLSchema#">
   <owl:Ontology rdf:about="https://dcat.example.org/eea-csw">
@@ -22,11 +22,6 @@
   <dcat:Catalog rdf:about="http://dcat.example.org/eea-csw/CatalogA">
     <dcat:service>
       <dcat:DataService rdf:about="http://dcat.example.org/eea-csw/EEA-CSW-Endpoint">
-        <dcterms:title xml:lang="en">European Environment Agency's public catalogue of spatial datasets.</dcterms:title>
-        <dcat:endpointURL rdf:resource="http://sdi.eea.europa.eu/catalogue/srv/eng/csw"/>
-        <dcterms:conformsTo rdf:resource="http://www.opengis.net/def/serviceType/ogc/csw"/>
-        <dcterms:type rdf:resource="http://inspire.ec.europa.eu/metadata-codelist/ResourceType/service"/>
-        <dcterms:license rdf:resource="https://creativecommons.org/licenses/by/2.5/dk/"/>
         <dcat:contactPoint>
           <v:Organization rdf:about="http://dcat.example.org/eea-csw/EEA">
             <v:organization-name xml:lang="en">European Environment Agency</v:organization-name>
@@ -34,8 +29,8 @@
             <v:hasEmail rdf:resource="mailto:info@eea.europa.eu"/>
           </v:Organization>
         </dcat:contactPoint>
-        <dcterms:issued rdf:datatype="http://www.w3.org/2001/XMLSchema#date"
-        >2012-01-01</dcterms:issued>
+        <dcat:endpointDescription rdf:resource="https://sdi.eea.europa.eu/catalogue/srv/eng/csw?service=CSW&amp;request=GetCapabilities"/>
+        <dcterms:title xml:lang="en">European Environment Agency's public catalogue of spatial datasets.</dcterms:title>
         <dcterms:spatial>
           <dcterms:Location>
             <locn:geometry rdf:datatype="http://www.opengis.net/ont/geosparql#wktLiteral"
@@ -44,12 +39,17 @@
             >&lt;gml:Envelope srsName="http://www.opengis.net/def/crs/OGC/1.3/CRS84"&gt;&lt;gml:lowerCorner&gt;-180 -90&lt;/gml:lowerCorner&gt;&lt;gml:upperCorner&gt;180 90&lt;/gml:upperCorner&gt;&lt;/gml:Envelope&gt;</locn:geometry>
           </dcterms:Location>
         </dcterms:spatial>
-        <dc:subject xml:lang="en">infoCatalogueService</dc:subject>
-        <dcterms:identifier>eea-sdi-public-catalogue</dcterms:identifier>
-        <dcterms:accessRights rdf:resource="http://publications.europa.eu/resource/authority/access-right/PUBLIC"/>
-        <dcterms:type rdf:resource="http://inspire.ec.europa.eu/metadata-codelist/SpatialDataServiceType/discovery"/>
         <dcterms:description xml:lang="en">The EEA public catalogue of spatial datasets references the spatial datasets used by the European Environment Agency as well as the spatial datasets produced by or for the EEA. In the latter case, when datasets are publicly available, a link to the location from where they can be downloaded is included in the dataset's metadata. The catalogue has been initially populated with the most important spatial datasets already available on the data&amp;maps section of the EEA website and is currently updated with any newly published spatial dataset.</dcterms:description>
-        <dcat:endpointDescription rdf:resource="https://sdi.eea.europa.eu/catalogue/srv/eng/csw?service=CSW&amp;request=GetCapabilities"/>
+        <dcat:endpointURL rdf:resource="http://sdi.eea.europa.eu/catalogue/srv/eng/csw"/>
+        <dcterms:type rdf:resource="http://inspire.ec.europa.eu/metadata-codelist/SpatialDataServiceType/discovery"/>
+        <dcterms:accessRights rdf:resource="http://publications.europa.eu/resource/authority/access-right/PUBLIC"/>
+        <dcterms:license rdf:resource="https://creativecommons.org/licenses/by/2.5/dk/"/>
+        <dcterms:identifier>eea-sdi-public-catalogue</dcterms:identifier>
+        <dcterms:issued rdf:datatype="http://www.w3.org/2001/XMLSchema#date"
+        >2012-01-01</dcterms:issued>
+        <dcterms:conformsTo rdf:resource="http://www.opengis.net/def/serviceType/ogc/csw"/>
+        <dcterms:type rdf:resource="http://inspire.ec.europa.eu/metadata-codelist/ResourceType/service"/>
+        <dc:subject xml:lang="en">infoCatalogueService</dc:subject>
       </dcat:DataService>
     </dcat:service>
     <dcat:record>

--- a/dcat/examples/vocab-dcat-3/eea-csw.ttl
+++ b/dcat/examples/vocab-dcat-3/eea-csw.ttl
@@ -2,7 +2,7 @@
 # imports: http://purl.org/dc/terms/
 # imports: http://www.w3.org/2004/02/skos/core
 
-@prefix a: <http://dcat.example.org/eea-csw/> .
+@prefix ex: <http://dcat.example.org/eea-csw/> .
 @prefix dc: <http://purl.org/dc/elements/1.1/> .
 @prefix dcat: <http://www.w3.org/ns/dcat#> .
 @prefix dcterms: <http://purl.org/dc/terms/> .
@@ -19,18 +19,18 @@
 @prefix v: <http://www.w3.org/2006/vcard/ns#> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
-a:CatalogA
+ex:CatalogA
   rdf:type dcat:Catalog ;
-  dcat:record a:EEA-CSW-Endpoint-Record ;
-  dcat:service a:EEA-CSW-Endpoint ;
+  dcat:record ex:EEA-CSW-Endpoint-Record ;
+  dcat:service ex:EEA-CSW-Endpoint ;
 .
-a:EEA
+ex:EEA
   rdf:type v:Organization ;
   v:hasEmail <mailto:info@eea.europa.eu> ;
   v:hasURL <http://www.eea.europa.eu> ;
   v:organization-name "European Environment Agency"@en ;
 .
-a:EEA-CSW-Endpoint
+ex:EEA-CSW-Endpoint
   rdf:type dcat:DataService ;
   dc:subject "infoCatalogueService"@en ;
   dcterms:accessRights <http://publications.europa.eu/resource/authority/access-right/PUBLIC> ;
@@ -47,21 +47,21 @@ a:EEA-CSW-Endpoint
   dcterms:title "European Environment Agency's public catalogue of spatial datasets."@en ;
   dcterms:type <http://inspire.ec.europa.eu/metadata-codelist/ResourceType/service> ;
   dcterms:type <http://inspire.ec.europa.eu/metadata-codelist/SpatialDataServiceType/discovery> ;
-  dcat:contactPoint a:EEA ;
+  dcat:contactPoint ex:EEA ;
   dcat:endpointDescription <https://sdi.eea.europa.eu/catalogue/srv/eng/csw?service=CSW&request=GetCapabilities> ;
   dcat:endpointURL <http://sdi.eea.europa.eu/catalogue/srv/eng/csw> ;
 .
-a:EEA-CSW-Endpoint-Record
+ex:EEA-CSW-Endpoint-Record
   rdf:type dcat:CatalogRecord ;
   dcterms:conformsTo <http://data.europa.eu/930> ;
   dcterms:identifier "4be5cb08-e082-426a-9c57-8a53d7cd3f65" ;
   dcterms:language <http://publications.europa.eu/resource/authority/language/ENG> ;
   dcterms:modified "2012-05-21"^^xsd:date ;
-  dcterms:source a:EEA-CSW-Endpoint-SourceRecord ;
-  dcat:contactPoint a:EEA ;
-  foaf:primaryTopic a:EEA-CSW-Endpoint ;
+  dcterms:source ex:EEA-CSW-Endpoint-SourceRecord ;
+  dcat:contactPoint ex:EEA ;
+  foaf:primaryTopic ex:EEA-CSW-Endpoint ;
 .
-a:EEA-CSW-Endpoint-SourceRecord
+ex:EEA-CSW-Endpoint-SourceRecord
   dcterms:conformsTo <http://www.isotc211.org/2005/gmd> ;
 .
 <https://dcat.example.org/eea-csw>

--- a/dcat/examples/vocab-dcat-3/genoa-busstop.jsonld
+++ b/dcat/examples/vocab-dcat-3/genoa-busstop.jsonld
@@ -1,6 +1,6 @@
 {
   "@graph" : [ {
-    "@id" : "https://dcat.example.org/completenessWRTExpectedNumberOfEntities",
+    "@id" : "ex:completenessWRTExpectedNumberOfEntities",
     "@type" : "dqv:Metric",
     "skos:definition" : {
       "@language" : "en",
@@ -9,56 +9,56 @@
     "expectedDataType" : "xsd:decimal",
     "inDimension" : "ldqd:completeness"
   }, {
-    "@id" : "https://dcat.example.org/genoa-busstop",
+    "@id" : "ex:genoa-busstop",
     "@type" : "owl:Ontology",
     "imports" : "http://www.w3.org/ns/dcat"
   }, {
-    "@id" : "https://dcat.example.org/genoaBusStopsDataset",
+    "@id" : "ex:genoaBusStopsDataset",
     "@type" : "dcat:Dataset",
-    "hasQualityAnnotation" : "https://dcat.example.org/genoaBusStopsDatasetCompletenessNote",
-    "hasQualityMeasurement" : "https://dcat.example.org/genoaBusStopsDatasetCompletenessMeasurement"
+    "hasQualityAnnotation" : "ex:genoaBusStopsDatasetCompletenessNote",
+    "hasQualityMeasurement" : "ex:genoaBusStopsDatasetCompletenessMeasurement"
   }, {
-    "@id" : "https://dcat.example.org/genoaBusStopsDatasetCompletenessMeasurement",
+    "@id" : "ex:genoaBusStopsDatasetCompletenessMeasurement",
     "@type" : "dqv:QualityMeasurement",
-    "computedOn" : "https://dcat.example.org/genoaBusStopsDataset",
-    "isMeasurementOf" : "https://dcat.example.org/completenessWRTExpectedNumberOfEntities",
+    "computedOn" : "ex:genoaBusStopsDataset",
+    "isMeasurementOf" : "ex:completenessWRTExpectedNumberOfEntities",
     "dqv:value" : {
       "@type" : "xsd:decimal",
       "@value" : "0.6833333"
     },
     "generatedAtTime" : "2018-05-27T02:52:02Z",
-    "wasAttributedTo" : "https://dcat.example.org/myQualityChecker",
-    "wasGeneratedBy" : "https://dcat.example.org/myQualityChecking"
+    "wasAttributedTo" : "ex:myQualityChecker",
+    "wasGeneratedBy" : "ex:myQualityChecking"
   }, {
-    "@id" : "https://dcat.example.org/genoaBusStopsDatasetCompletenessNote",
+    "@id" : "ex:genoaBusStopsDatasetCompletenessNote",
     "@type" : "dqv:UserQualityFeedback",
     "inDimension" : "ldqd:completeness",
-    "hasBody" : "https://dcat.example.org/textBody",
-    "hasTarget" : "https://dcat.example.org/genoaBusStopsDataset",
+    "hasBody" : "ex:textBody",
+    "hasTarget" : "ex:genoaBusStopsDataset",
     "motivatedBy" : "dqv:qualityAssessment",
     "generatedAtTime" : "2018-05-27T02:52:02Z",
-    "wasAttributedTo" : "https://dcat.example.org/consumer1"
+    "wasAttributedTo" : "ex:consumer1"
   }, {
-    "@id" : "https://dcat.example.org/myQualityChecker",
+    "@id" : "ex:myQualityChecker",
     "@type" : "prov:SoftwareAgent",
     "rdfs:label" : {
       "@language" : "en",
       "@value" : "A quality assessment service"
     }
   }, {
-    "@id" : "https://dcat.example.org/myQualityChecking",
+    "@id" : "ex:myQualityChecking",
     "@type" : "prov:Activity",
     "rdfs:label" : {
       "@language" : "en",
       "@value" : "The checking of genoaBusStopsDataset's quality"
     },
     "endedAtTime" : "2018-05-27T02:52:02Z",
-    "generated" : "https://dcat.example.org/genoaBusStopsDatasetCompletenessMeasurement",
+    "generated" : "ex:genoaBusStopsDatasetCompletenessMeasurement",
     "startedAtTime" : "2018-05-27T00:52:02Z",
-    "used" : "https://dcat.example.org/genoaBusStopsDataset",
-    "wasAssociatedWith" : "https://dcat.example.org/myQualityChecker"
+    "used" : "ex:genoaBusStopsDataset",
+    "wasAssociatedWith" : "ex:myQualityChecker"
   }, {
-    "@id" : "https://dcat.example.org/textBody",
+    "@id" : "ex:textBody",
     "@type" : "oa:TextualBody",
     "dcterms:format" : "text/plain",
     "dcterms:language" : "en",
@@ -166,6 +166,7 @@
     "rdfs" : "http://www.w3.org/2000/01/rdf-schema#",
     "geosparql" : "http://www.opengis.net/ont/geosparql#",
     "oa" : "http://www.w3.org/ns/oa#",
+    "ex" : "https://dcat.example.org/",
     "rdf" : "http://www.w3.org/1999/02/22-rdf-syntax-ns#",
     "dcterms" : "http://purl.org/dc/terms/",
     "ldqd" : "http://dcat.example.org/ldqd/",

--- a/dcat/examples/vocab-dcat-3/genoa-busstop.rdf
+++ b/dcat/examples/vocab-dcat-3/genoa-busstop.rdf
@@ -7,7 +7,7 @@
     xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
     xmlns:oa="http://www.w3.org/ns/oa#"
     xmlns:dcterms="http://purl.org/dc/terms/"
-    xmlns="https://dcat.example.org/"
+    xmlns:ex="https://dcat.example.org/"
     xmlns:time="http://www.w3.org/2006/time#"
     xmlns:dqv="http://www.w3.org/ns/dqv#"
     xmlns:owl="http://www.w3.org/2002/07/owl#"

--- a/dcat/examples/vocab-dcat-3/genoa-busstop.ttl
+++ b/dcat/examples/vocab-dcat-3/genoa-busstop.ttl
@@ -1,7 +1,7 @@
 # baseURI: https://dcat.example.org/genoa-busstop
 # imports: http://www.w3.org/ns/dcat
 
-@prefix : <https://dcat.example.org/> .
+@prefix ex: <https://dcat.example.org/> .
 @prefix adms: <https://www.w3.org/ns/adms#> .
 @prefix dcat: <http://www.w3.org/ns/dcat#> .
 @prefix dcterms: <http://purl.org/dc/terms/> .
@@ -20,53 +20,53 @@
 @prefix w3cgeo: <http://www.w3.org/2003/01/geo/wgs84_pos#> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
-:completenessWRTExpectedNumberOfEntities
+ex:completenessWRTExpectedNumberOfEntities
   a dqv:Metric ;
   skos:definition "The degree of completeness as ratio between the actual number of entities included in the dataset and the declared expected number of entities."@en ;
   dqv:expectedDataType xsd:decimal ;
   dqv:inDimension ldqd:completeness ;
 .
-:genoa-busstop
+ex:genoa-busstop
   a owl:Ontology ;
   owl:imports <http://www.w3.org/ns/dcat> ;
 .
-:genoaBusStopsDataset
+ex:genoaBusStopsDataset
   a dcat:Dataset ;
-  dqv:hasQualityAnnotation :genoaBusStopsDatasetCompletenessNote ;
-  dqv:hasQualityMeasurement :genoaBusStopsDatasetCompletenessMeasurement ;
+  dqv:hasQualityAnnotation ex:genoaBusStopsDatasetCompletenessNote ;
+  dqv:hasQualityMeasurement ex:genoaBusStopsDatasetCompletenessMeasurement ;
 .
-:genoaBusStopsDatasetCompletenessMeasurement
+ex:genoaBusStopsDatasetCompletenessMeasurement
   a dqv:QualityMeasurement ;
-  dqv:computedOn :genoaBusStopsDataset ;
-  dqv:isMeasurementOf :completenessWRTExpectedNumberOfEntities ;
+  dqv:computedOn ex:genoaBusStopsDataset ;
+  dqv:isMeasurementOf ex:completenessWRTExpectedNumberOfEntities ;
   dqv:value 0.6833333 ;
   prov:generatedAtTime "2018-05-27T02:52:02Z"^^xsd:dateTime ;
-  prov:wasAttributedTo :myQualityChecker ;
-  prov:wasGeneratedBy :myQualityChecking ;
+  prov:wasAttributedTo ex:myQualityChecker ;
+  prov:wasGeneratedBy ex:myQualityChecking ;
 .
-:genoaBusStopsDatasetCompletenessNote
+ex:genoaBusStopsDatasetCompletenessNote
   a dqv:UserQualityFeedback ;
   dqv:inDimension ldqd:completeness ;
-  oa:hasBody :textBody ;
-  oa:hasTarget :genoaBusStopsDataset ;
+  oa:hasBody ex:textBody ;
+  oa:hasTarget ex:genoaBusStopsDataset ;
   oa:motivatedBy dqv:qualityAssessment ;
   prov:generatedAtTime "2018-05-27T02:52:02Z"^^xsd:dateTime ;
-  prov:wasAttributedTo :consumer1 ;
+  prov:wasAttributedTo ex:consumer1 ;
 .
-:myQualityChecker
+ex:myQualityChecker
   a prov:SoftwareAgent ;
   rdfs:label "A quality assessment service"@en ;
 .
-:myQualityChecking
+ex:myQualityChecking
   a prov:Activity ;
   rdfs:label "The checking of genoaBusStopsDataset's quality"@en ;
   prov:endedAtTime "2018-05-27T02:52:02Z"^^xsd:dateTime ;
-  prov:generated :genoaBusStopsDatasetCompletenessMeasurement ;
+  prov:generated ex:genoaBusStopsDatasetCompletenessMeasurement ;
   prov:startedAtTime "2018-05-27T00:52:02Z"^^xsd:dateTime ;
-  prov:used :genoaBusStopsDataset ;
-  prov:wasAssociatedWith :myQualityChecker ;
+  prov:used ex:genoaBusStopsDataset ;
+  prov:wasAssociatedWith ex:myQualityChecker ;
 .
-:textBody
+ex:textBody
   a oa:TextualBody ;
   dcterms:format "text/plain" ;
   dcterms:language "en" ;

--- a/dcat/examples/vocab-dcat-3/service1.jsonld
+++ b/dcat/examples/vocab-dcat-3/service1.jsonld
@@ -12,7 +12,7 @@
     "@type" : "owl:Ontology",
     "imports" : "http://www.w3.org/ns/dcat"
   }, {
-    "@id" : "http://dcat.example.org/EEA",
+    "@id" : "ex:EEA",
     "@type" : "foaf:Organization",
     "hasEmail" : "mailto:info@eea.europa.eu",
     "hasURL" : "http://www.eea.europa.eu",
@@ -21,7 +21,7 @@
       "@value" : "European Environment Agency"
     }
   }, {
-    "@id" : "http://dcat.example.org/EEA-CSW-Endpoint",
+    "@id" : "ex:EEA-CSW-Endpoint",
     "@type" : "dcat:DataService",
     "dc:subject" : {
       "@language" : "en",
@@ -41,37 +41,29 @@
       "@language" : "en",
       "@value" : "European Environment Agency's public catalogue of spatial datasets."
     },
-    "type" : [ "http://inspire.ec.europa.eu/metadata-codelist/ResourceType/service", "http://inspire.ec.europa.eu/metadata-codelist/SpatialDataServiceType/discovery" ],
-    "contactPoint" : "http://dcat.example.org/EEA",
+    "type" : [ "http://inspire.ec.europa.eu/metadata-codelist/SpatialDataServiceType/discovery", "http://inspire.ec.europa.eu/metadata-codelist/ResourceType/service" ],
+    "contactPoint" : "ex:EEA",
     "endPointLocation" : "http://sdi.eea.europa.eu/catalogue/"
   }, {
-    "@id" : "http://dcat.example.org/EEA-CSW-Endpoint-Record",
+    "@id" : "ex:EEA-CSW-Endpoint-Record",
     "@type" : "dcat:CatalogRecord",
     "conformsTo" : "http://data.europa.eu/930",
     "dcterms:identifier" : "4be5cb08-e082-426a-9c57-8a53d7cd3f65",
     "language" : "http://publications.europa.eu/resource/authority/language/ENG",
     "modified" : "2012-05-21",
-    "source" : "http://dcat.example.org/EEA-CSW-Endpoint-SourceRecord",
-    "contactPoint" : "http://dcat.example.org/EEA",
-    "primaryTopic" : "http://dcat.example.org/EEA-CSW-Endpoint"
+    "source" : "ex:EEA-CSW-Endpoint-SourceRecord",
+    "contactPoint" : "ex:EEA",
+    "primaryTopic" : "ex:EEA-CSW-Endpoint"
   }, {
-    "@id" : "http://dcat.example.org/EEA-CSW-Endpoint-SourceRecord",
+    "@id" : "ex:EEA-CSW-Endpoint-SourceRecord",
     "conformsTo" : "http://www.isotc211.org/2005/gmd"
   }, {
-    "@id" : "http://dcat.example.org/MyCatalog",
+    "@id" : "ex:MyCatalog",
     "@type" : "dcat:Catalog",
-    "record" : "http://dcat.example.org/EEA-CSW-Endpoint-Record",
+    "record" : "ex:EEA-CSW-Endpoint-Record",
     "service" : "http://sdi.eea.europa.eu/catalogue/srv/eng/csw"
   } ],
   "@context" : {
-    "service" : {
-      "@id" : "http://www.w3.org/ns/dcat#service",
-      "@type" : "@id"
-    },
-    "record" : {
-      "@id" : "http://www.w3.org/ns/dcat#record",
-      "@type" : "@id"
-    },
     "primaryTopic" : {
       "@id" : "http://xmlns.com/foaf/0.1/primaryTopic",
       "@type" : "@id"
@@ -116,45 +108,53 @@
       "@id" : "http://www.w3.org/2002/07/owl#imports",
       "@type" : "@id"
     },
+    "service" : {
+      "@id" : "http://www.w3.org/ns/dcat#service",
+      "@type" : "@id"
+    },
+    "record" : {
+      "@id" : "http://www.w3.org/ns/dcat#record",
+      "@type" : "@id"
+    },
     "geometry" : {
       "@id" : "http://www.w3.org/ns/locn#geometry",
       "@type" : "http://www.opengis.net/ont/geosparql#wktLiteral"
-    },
-    "description" : {
-      "@id" : "http://purl.org/dc/terms/description",
-      "@type" : "http://www.w3.org/1999/02/22-rdf-syntax-ns#langString"
-    },
-    "accessRights" : {
-      "@id" : "http://purl.org/dc/terms/accessRights",
-      "@type" : "@id"
-    },
-    "issued" : {
-      "@id" : "http://purl.org/dc/terms/issued",
-      "@type" : "http://www.w3.org/2001/XMLSchema#date"
-    },
-    "subject" : {
-      "@id" : "http://purl.org/dc/elements/1.1/subject",
-      "@type" : "http://www.w3.org/1999/02/22-rdf-syntax-ns#langString"
-    },
-    "spatial" : {
-      "@id" : "http://purl.org/dc/terms/spatial",
-      "@type" : "@id"
-    },
-    "type" : {
-      "@id" : "http://purl.org/dc/terms/type",
-      "@type" : "@id"
-    },
-    "license" : {
-      "@id" : "http://purl.org/dc/terms/license",
-      "@type" : "@id"
     },
     "endPointLocation" : {
       "@id" : "http://www.w3.org/ns/dcat#endPointLocation",
       "@type" : "@id"
     },
+    "description" : {
+      "@id" : "http://purl.org/dc/terms/description",
+      "@type" : "http://www.w3.org/1999/02/22-rdf-syntax-ns#langString"
+    },
+    "type" : {
+      "@id" : "http://purl.org/dc/terms/type",
+      "@type" : "@id"
+    },
     "title" : {
       "@id" : "http://purl.org/dc/terms/title",
       "@type" : "http://www.w3.org/1999/02/22-rdf-syntax-ns#langString"
+    },
+    "subject" : {
+      "@id" : "http://purl.org/dc/elements/1.1/subject",
+      "@type" : "http://www.w3.org/1999/02/22-rdf-syntax-ns#langString"
+    },
+    "issued" : {
+      "@id" : "http://purl.org/dc/terms/issued",
+      "@type" : "http://www.w3.org/2001/XMLSchema#date"
+    },
+    "accessRights" : {
+      "@id" : "http://purl.org/dc/terms/accessRights",
+      "@type" : "@id"
+    },
+    "spatial" : {
+      "@id" : "http://purl.org/dc/terms/spatial",
+      "@type" : "@id"
+    },
+    "license" : {
+      "@id" : "http://purl.org/dc/terms/license",
+      "@type" : "@id"
     },
     "schema" : "http://schema.org/",
     "gsp" : "http://www.opengis.net/ont/geosparql#",
@@ -164,6 +164,7 @@
     "voaf" : "http://purl.org/vocommons/voaf#",
     "rdfs" : "http://www.w3.org/2000/01/rdf-schema#",
     "vcard" : "http://www.w3.org/2006/vcard/ns#",
+    "ex" : "http://dcat.example.org/",
     "rdf" : "http://www.w3.org/1999/02/22-rdf-syntax-ns#",
     "dctype" : "http://purl.org/dc/dcmitype/",
     "dcterms" : "http://purl.org/dc/terms/",

--- a/dcat/examples/vocab-dcat-3/service1.rdf
+++ b/dcat/examples/vocab-dcat-3/service1.rdf
@@ -1,6 +1,5 @@
 <rdf:RDF
     xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-    xmlns="http://dcat.example.org/"
     xmlns:locn="http://www.w3.org/ns/locn#"
     xmlns:schema="http://schema.org/"
     xmlns:voaf="http://purl.org/vocommons/voaf#"
@@ -14,6 +13,7 @@
     xmlns:gsp="http://www.opengis.net/ont/geosparql#"
     xmlns:dcat="http://www.w3.org/ns/dcat#"
     xmlns:vann="http://purl.org/vocab/vann/"
+    xmlns:ex="http://dcat.example.org/"
     xmlns:foaf="http://xmlns.com/foaf/0.1/"
     xmlns:xsd="http://www.w3.org/2001/XMLSchema#">
   <owl:Ontology rdf:about="http://dcat.example.org/">
@@ -25,11 +25,23 @@
       <dcat:CatalogRecord rdf:about="http://dcat.example.org/EEA-CSW-Endpoint-Record">
         <foaf:primaryTopic>
           <dcat:DataService rdf:about="http://dcat.example.org/EEA-CSW-Endpoint">
+            <dcat:endPointLocation rdf:resource="http://sdi.eea.europa.eu/catalogue/"/>
             <dcterms:description xml:lang="en">The EEA public catalogue of spatial datasets references the spatial datasets used by the European Environment Agency as well as the spatial datasets produced by or for the EEA. In the latter case, when datasets are publicly available, a link to the location from where they can be downloaded is included in the dataset's metadata. The catalogue has been initially populated with the most important spatial datasets already available on the data&amp;maps section of the EEA website and is currently updated with any newly published spatial dataset.</dcterms:description>
-            <dcterms:identifier>eea-sdi-public-catalogue</dcterms:identifier>
-            <dcterms:accessRights rdf:resource="http://publications.europa.eu/resource/authority/access-right/PUBLIC"/>
+            <dcat:contactPoint>
+              <foaf:Organization rdf:about="http://dcat.example.org/EEA">
+                <vcard:organization-name xml:lang="en">European Environment Agency</vcard:organization-name>
+                <vcard:hasURL rdf:resource="http://www.eea.europa.eu"/>
+                <vcard:hasEmail rdf:resource="mailto:info@eea.europa.eu"/>
+              </foaf:Organization>
+            </dcat:contactPoint>
+            <dcterms:type rdf:resource="http://inspire.ec.europa.eu/metadata-codelist/SpatialDataServiceType/discovery"/>
+            <dcterms:title xml:lang="en">European Environment Agency's public catalogue of spatial datasets.</dcterms:title>
+            <dc:subject xml:lang="en">infoCatalogueService</dc:subject>
             <dcterms:issued rdf:datatype="http://www.w3.org/2001/XMLSchema#date"
             >2012-01-01</dcterms:issued>
+            <dcterms:accessRights rdf:resource="http://publications.europa.eu/resource/authority/access-right/PUBLIC"/>
+            <dcterms:type rdf:resource="http://inspire.ec.europa.eu/metadata-codelist/ResourceType/service"/>
+            <dcterms:conformsTo rdf:resource="http://www.opengis.net/def/serviceType/ogc/csw"/>
             <dcterms:spatial>
               <dcterms:Location>
                 <locn:geometry rdf:datatype="http://www.opengis.net/ont/geosparql#wktLiteral"
@@ -38,20 +50,8 @@
                 >&lt;gml:Envelope srsName="http://www.opengis.net/def/crs/OGC/1.3/CRS84"&gt;&lt;gml:lowerCorner&gt;-180 -90&lt;/gml:lowerCorner&gt;&lt;gml:upperCorner&gt;180 90&lt;/gml:upperCorner&gt;&lt;/gml:Envelope&gt;</locn:geometry>
               </dcterms:Location>
             </dcterms:spatial>
-            <dc:subject xml:lang="en">infoCatalogueService</dc:subject>
-            <dcterms:type rdf:resource="http://inspire.ec.europa.eu/metadata-codelist/ResourceType/service"/>
-            <dcterms:conformsTo rdf:resource="http://www.opengis.net/def/serviceType/ogc/csw"/>
-            <dcterms:type rdf:resource="http://inspire.ec.europa.eu/metadata-codelist/SpatialDataServiceType/discovery"/>
+            <dcterms:identifier>eea-sdi-public-catalogue</dcterms:identifier>
             <dcterms:license rdf:resource="https://creativecommons.org/licenses/by/2.5/dk/"/>
-            <dcat:endPointLocation rdf:resource="http://sdi.eea.europa.eu/catalogue/"/>
-            <dcat:contactPoint>
-              <foaf:Organization rdf:about="http://dcat.example.org/EEA">
-                <vcard:organization-name xml:lang="en">European Environment Agency</vcard:organization-name>
-                <vcard:hasURL rdf:resource="http://www.eea.europa.eu"/>
-                <vcard:hasEmail rdf:resource="mailto:info@eea.europa.eu"/>
-              </foaf:Organization>
-            </dcat:contactPoint>
-            <dcterms:title xml:lang="en">European Environment Agency's public catalogue of spatial datasets.</dcterms:title>
           </dcat:DataService>
         </foaf:primaryTopic>
         <dcat:contactPoint rdf:resource="http://dcat.example.org/EEA"/>

--- a/dcat/examples/vocab-dcat-3/service1.ttl
+++ b/dcat/examples/vocab-dcat-3/service1.ttl
@@ -1,7 +1,7 @@
 # baseURI: http://dcat.example.org/
 # imports: http://www.w3.org/ns/dcat
 
-@prefix : <http://dcat.example.org/> .
+@prefix ex: <http://dcat.example.org/> .
 @prefix dc: <http://purl.org/dc/elements/1.1/> .
 @prefix dcat: <http://www.w3.org/ns/dcat#> .
 @prefix dcterms: <http://purl.org/dc/terms/> .
@@ -19,21 +19,21 @@
 @prefix voaf: <http://purl.org/vocommons/voaf#> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
-:
+ex:
   rdf:type owl:Ontology ;
   owl:imports <http://www.w3.org/ns/dcat> ;
 .
 
 # The catalog  containing the service record
 
-:MyCatalog a dcat:Catalog ;
-  dcat:record :EEA-CSW-Endpoint-Record ;
+ex:MyCatalog a dcat:Catalog ;
+  dcat:record ex:EEA-CSW-Endpoint-Record ;
   dcat:service <http://sdi.eea.europa.eu/catalogue/srv/eng/csw> ;
 .
 
 # The EEA CSW public endpoint
 
-:EEA-CSW-Endpoint a dcat:DataService ;
+ex:EEA-CSW-Endpoint a dcat:DataService ;
   dc:subject "infoCatalogueService"@en ;
   dcterms:accessRights <http://publications.europa.eu/resource/authority/access-right/PUBLIC> ;
   dcterms:conformsTo <http://www.opengis.net/def/serviceType/ogc/csw> ;
@@ -49,31 +49,31 @@
   dcterms:title "European Environment Agency's public catalogue of spatial datasets."@en ;
   dcterms:type <http://inspire.ec.europa.eu/metadata-codelist/ResourceType/service> ;
   dcterms:type <http://inspire.ec.europa.eu/metadata-codelist/SpatialDataServiceType/discovery> ;
-  dcat:contactPoint :EEA ;
+  dcat:contactPoint ex:EEA ;
   dcat:endPointLocation <http://sdi.eea.europa.eu/catalogue/> ;
 .
 
 # The record about the EEA CSW public endpoint (a service)
 
-:EEA-CSW-Endpoint-Record a dcat:CatalogRecord ;
+ex:EEA-CSW-Endpoint-Record a dcat:CatalogRecord ;
   dcterms:conformsTo <http://data.europa.eu/930> ;
   dcterms:identifier "4be5cb08-e082-426a-9c57-8a53d7cd3f65" ;
   dcterms:language <http://publications.europa.eu/resource/authority/language/ENG> ;
   dcterms:modified "2012-05-21"^^xsd:date ;
-  dcterms:source :EEA-CSW-Endpoint-SourceRecord ;
-  dcat:contactPoint :EEA ;
-  foaf:primaryTopic :EEA-CSW-Endpoint ;
+  dcterms:source ex:EEA-CSW-Endpoint-SourceRecord ;
+  dcat:contactPoint ex:EEA ;
+  foaf:primaryTopic ex:EEA-CSW-Endpoint ;
 .
 
 # The ISO 19119 record from which the GeoDCAT-AP catalog record has been derived
 
-:EEA-CSW-Endpoint-SourceRecord
+ex:EEA-CSW-Endpoint-SourceRecord
   dcterms:conformsTo <http://www.isotc211.org/2005/gmd> ;
 .
 
 # The point of contact for both the catalog record and the service
 
-:EEA a foaf:Organization ;
+ex:EEA a foaf:Organization ;
   vcard:hasEmail <mailto:info@eea.europa.eu> ;
   vcard:hasURL <http://www.eea.europa.eu> ;
   vcard:organization-name "European Environment Agency"@en ;

--- a/dcat/index.html
+++ b/dcat/index.html
@@ -392,7 +392,7 @@ table.simple {width:100%;}
 
 <aside id="ex-catalog" class="example">
 <pre class="nohighlight turtle">
-:catalog
+ex:catalog
   a dcat:Catalog&nbsp;;
   dcterms:title "Imaginary Catalog"@en&nbsp;;
   dcterms:title "Catálogo imaginario"@es&nbsp;;
@@ -401,12 +401,12 @@ table.simple {width:100%;}
   foaf:homepage &lt;http://dcat.example.org/catalog&gt;&nbsp;;
   dcterms:publisher&nbsp;ex:transparency-office&nbsp;;
   dcterms:language &lt;http://id.loc.gov/vocabulary/iso639-1/en&gt; &nbsp;;
-  dcat:dataset&nbsp;:dataset-001&nbsp; , :dataset-002 , :dataset-003 ;
+  dcat:dataset&nbsp; ex:dataset-001&nbsp;, ex:dataset-002, ex:dataset-003 ;
   .
 </pre>
 </aside>
 
-        <p>The publisher of the catalog has the relative IRI&nbsp;<code>:transparency-office</code>. Further description of the publisher can be provided as in <a href="#ex-publisher"></a>:
+        <p>The publisher of the catalog has the relative IRI&nbsp;<code>ex:transparency-office</code>. Further description of the publisher can be provided as in <a href="#ex-publisher"></a>:
         </p>
 
 <aside id="ex-publisher" class="example">
@@ -418,7 +418,7 @@ ex:transparency-office
   .
 </pre>
 </aside>
-        <p>The catalog lists each of its datasets via the <code>dcat:dataset</code> property. In <a href="#ex-catalog"></a>, an example dataset was mentioned with the relative IRI&nbsp;<code>:dataset-001</code>. A possible description of it using DCAT is shown below:
+        <p>The catalog lists each of its datasets via the <code>dcat:dataset</code> property. In <a href="#ex-catalog"></a>, an example dataset was mentioned with the relative IRI&nbsp;<code>ex:dataset-001</code>. A possible description of it using DCAT is shown below:
         </p>
 
 <aside id="ex-dataset" class="example">
@@ -443,7 +443,7 @@ ex:dataset-001
   dcterms:publisher&nbsp;ex:finance-ministry&nbsp;;
   dcterms:language &lt;http://id.loc.gov/vocabulary/iso639-1/en&gt; &nbsp;;
   dcterms:accrualPeriodicity &lt;http://purl.org/linked-data/sdmx/2009/code#freq-W&gt; &nbsp;;
-  dcat:distribution&nbsp;:dataset-001-csv&nbsp;;
+  dcat:distribution&nbsp;ex:dataset-001-csv&nbsp;;
   .
 </pre>
 </aside>
@@ -464,13 +464,13 @@ ex:dataset-001
           Further details about the contact point, such as email address or telephone number, can be provided using vCard [[?VCARD-RDF]].
         </p>
 
-        <p>One representation of the dataset <code>:dataset-001-csv</code> can be downloaded as a 5kB CSV file. This is
+        <p>One representation of the dataset <code>ex:dataset-001-csv</code> can be downloaded as a 5kB CSV file. This is
             represented as an RDF resource of type <code>dcat:Distribution</code>.
         </p>
 
 <aside id="ex-distribution" class="example">
 <pre class="nohighlight turtle">
-:dataset-001-csv
+ex:dataset-001-csv
   a dcat:Distribution&nbsp;;
   dcat:downloadURL &lt;http://dcat.example.org/files/001.csv&gt; ;
   dcterms:title "CSV distribution of imaginary dataset 001"@en ;
@@ -485,23 +485,23 @@ ex:dataset-001
 
     <section id="classifying-datasets">
         <h3>Classifying datasets thematically</h3>
-        <p>The catalog classifies its datasets according to a set of domains represented by the relative IRI&nbsp;<code>:themes</code>. SKOS [[?SKOS-REFERENCE]] can be used to describe the domains used:
+        <p>The catalog classifies its datasets according to a set of domains represented by the relative IRI&nbsp;<code>ex:themes</code>. SKOS [[?SKOS-REFERENCE]] can be used to describe the domains used:
         </p>
 
 <aside id="ex-thematic-classification" class="example">
 <pre class="nohighlight turtle">
-:catalog&nbsp;dcat:themeTaxonomy&nbsp;:themes&nbsp;.
+ex:catalog&nbsp;dcat:themeTaxonomy&nbsp;ex:themes&nbsp;.
 
-:themes
+ex:themes
   a skos:ConceptScheme&nbsp;;
   skos:prefLabel "A set of domains to classify documents"@en&nbsp;;
   .
 
-:dataset-001 dcat:theme&nbsp;ex:accountability&nbsp; .</pre>
+ex:dataset-001 dcat:theme&nbsp;ex:accountability&nbsp; .</pre>
 </aside>
 
-        <p>Notice that this dataset is classified under the domain represented by the relative IRI&nbsp;<code>:accountability</code>.
-            It is recommended to define the concept as part of the concept scheme identified by the IRI&nbsp;<code>:themes</code> that was used to describe the catalog domains. An example SKOS description:
+        <p>Notice that this dataset is classified under the domain represented by the relative IRI&nbsp;<code>ex:accountability</code>.
+            It is recommended to define the concept as part of the concept scheme identified by the IRI&nbsp;<code>ex:themes</code> that was used to describe the catalog domains. An example SKOS description:
         </p>
 
 <aside id="ex-theme-accountability" class="example">
@@ -533,12 +533,12 @@ ex:accountability
 
 <aside id="ex-dataset-type" class="example">
 <pre class="nohighlight turtle">
-:dataset-001
+ex:dataset-001
   rdf:type  dcat:Dataset ;
   dcterms:type  &lt;http://purl.org/dc/dcmitype/Dataset&gt; ;
   .
 
-:dataset-001
+ex:dataset-001
   rdf:type  dcat:Dataset ;
   dcterms:type  &lt;http://id.loc.gov/vocabulary/marcgt/dtb&gt; ;
   .</pre>
@@ -550,7 +550,7 @@ ex:accountability
 
 <aside id="ex-dataset-multiple-types" class="example">
 <pre class="nohighlight turtle">
-:dataset-001
+ex:dataset-001
   rdf:type  dcat:Dataset ;
   dcterms:type  &lt;http://purl.org/dc/dcmitype/Dataset&gt; ;
   dcterms:type  &lt;http://id.loc.gov/vocabulary/marcgt/dtb&gt; ;
@@ -576,16 +576,16 @@ ex:accountability
         <p>If the catalog publisher decides to keep metadata
             describing its records (i.e., the records containing metadata
             describing the datasets), <code>dcat:CatalogRecord</code> can be used. For example,
-            while <code>:dataset-001</code> was issued on 2011-12-05, its description on Imaginary Catalog was added on 2011-12-11. This can be represented by DCAT as in <a href="#ex-catalog-record"></a>:
+            while <code>ex:dataset-001</code> was issued on 2011-12-05, its description on Imaginary Catalog was added on 2011-12-11. This can be represented by DCAT as in <a href="#ex-catalog-record"></a>:
         </p>
 
 <aside id="ex-catalog-record" class="example">
 <pre class="nohighlight turtle">
-:catalog dcat:record :record-001 .
+ex:catalog dcat:record ex:record-001 .
 
-:record-001
+ex:record-001
   a dcat:CatalogRecord ;
-  foaf:primaryTopic :dataset-001 ;
+  foaf:primaryTopic ex:dataset-001 ;
   dcterms:issued "2011-12-11"^^xsd:date ;
   .
 </pre>
@@ -595,18 +595,18 @@ ex:accountability
 
     <section id="example-landing-page">
         <h3>Dataset available only behind some Web page</h3>
-        <p><code>:dataset-002</code> is available as a CSV file. However <code>:dataset-002</code> can only be obtained through some Web page
+        <p><code>ex:dataset-002</code> is available as a CSV file. However <code>ex:dataset-002</code> can only be obtained through some Web page
             where the user needs to follow some links, provide some information and check some boxes
             before accessing the data.</p>
 
 <aside id="ex-landing-page" class="example">
 <pre class="nohighlight turtle">
-:dataset-002
+ex:dataset-002
   a dcat:Dataset ;
   dcat:landingPage &lt;http://dcat.example.org/dataset-002.html&gt; ;
-  dcat:distribution :dataset-002-csv ;
+  dcat:distribution ex:dataset-002-csv ;
   .
-:dataset-002-csv
+ex:dataset-002-csv
   a dcat:Distribution ;
   dcat:accessURL &lt;http://dcat.example.org/dataset-002.html&gt; ;
   dcat:mediaType &lt;http://www.iana.org/assignments/media-types/text/csv&gt; ;
@@ -618,17 +618,17 @@ ex:accountability
 
     <section id="a-dataset-available-as-download-and-behind-some-web-page">
         <h3>A dataset available as a download and behind some Web page</h3>
-        <p>On the other hand, <code>:dataset-003</code> can be obtained through some landing page but also can be downloaded from a known URL.
+        <p>On the other hand, <code>ex:dataset-003</code> can be obtained through some landing page but also can be downloaded from a known URL.
         </p>
 
 <aside id="ex-access-and-download-url" class="example">
 <pre class="nohighlight turtle">
-:dataset-003
+ex:dataset-003
   a dcat:Dataset ;
   dcat:landingPage &lt;http://dcat.example.org/dataset-003.html&gt; ;
-  dcat:distribution :dataset-003-csv ;
+  dcat:distribution ex:dataset-003-csv ;
   .
-:dataset-003-csv
+ex:dataset-003-csv
   a dcat:Distribution ;
   dcat:downloadURL &lt;http://dcat.example.org/dataset-003.csv&gt; ;
   dcat:mediaType &lt;http://www.iana.org/assignments/media-types/text/csv&gt; ;
@@ -641,7 +641,7 @@ ex:accountability
 
     <section id="a-dataset-available-from-a-service">
         <h3>A dataset available through a service</h3>
-        <p><code>:dataset-004</code> is distributed in different representations from different services.
+        <p><code>ex:dataset-004</code> is distributed in different representations from different services.
           The <code>dcat:accessURL</code> for each <code>dcat:Distribution</code> corresponds with the <code>dcat:endpointURL</code> of the service.
           Each service is characterized by its general type using <code>dcterms:type</code> (here using values from the INSPIRE spatial data service type vocabulary),
           its specific API definition using <code>dcterms:conformsTo</code>,
@@ -650,42 +650,42 @@ ex:accountability
 
 <aside id="ex-access-service" class="example">
 <pre class="nohighlight turtle">
-:dataset-004
+ex:dataset-004
   rdf:type dcat:Dataset ;
-  dcat:distribution :dataset-004-csv ;
-  dcat:distribution :dataset-004-png ;
+  dcat:distribution ex:dataset-004-csv ;
+  dcat:distribution ex:dataset-004-png ;
   .
 
-:dataset-004-csv
+ex:dataset-004-csv
   rdf:type dcat:Distribution ;
-  dcat:accessService :table-service-005 ;
+  dcat:accessService ex:table-service-005 ;
   dcat:accessURL &lt;http://dcat.example.org/api/table-005&gt; ;
   dcat:mediaType &lt;http://www.iana.org/assignments/media-types/text/csv&gt; ;
   .
 
-:dataset-004-png
+ex:dataset-004-png
   rdf:type dcat:Distribution ;
-  dcat:accessService :figure-service-006 ;
+  dcat:accessService ex:figure-service-006 ;
   dcat:accessURL &lt;http://dcat.example.org/api/figure-006&gt; ;
   dcat:mediaType &lt;http://www.iana.org/assignments/media-types/image/png&gt; ;
   .
 
-:figure-service-006
+ex:figure-service-006
   rdf:type dcat:DataService ;
   dcterms:conformsTo &lt;http://dcat.example.org/apidef/figure/v1.0&gt; ;
   dcterms:type &lt;https://inspire.ec.europa.eu/metadata-codelist/SpatialDataServiceType/view&gt; ;
   dcat:endpointDescription &lt;http://dcat.example.org/api/figure-006/params&gt; ;
   dcat:endpointURL &lt;http://dcat.example.org/api/figure-006&gt; ;
-  dcat:servesDataset :dataset-004 ;
+  dcat:servesDataset ex:dataset-004 ;
   .
 
-:table-service-005
+ex:table-service-005
   rdf:type dcat:DataService ;
   dcterms:conformsTo &lt;http://dcat.example.org/apidef/table/v2.2&gt; ;
   dcterms:type &lt;https://inspire.ec.europa.eu/metadata-codelist/SpatialDataServiceType/download&gt; ;
   dcat:endpointDescription &lt;http://dcat.example.org/api/table-005/capability&gt; ;
   dcat:endpointURL &lt;http://dcat.example.org/api/table-005&gt; ;
-  dcat:servesDataset :dataset-003, :dataset-004 ;
+  dcat:servesDataset ex:dataset-003, ex:dataset-004 ;
   .</pre>
 </aside>
 
@@ -4221,7 +4221,7 @@ ex:InternationalDOIFundation a foaf:Organization ;
 <aside class="example" id="ex-license-and-access-rights" title="License, access rights, and copyright statement">
 <p>The following example is about a dataset publicly available (with no access restriction) and whose distribution is released by using a standard license - namely, the Creative Commons Attribution (CC-BY) 4.0 license. Access rights are specified by using the [[?EUV-AR]] code list. Property <code>dcterms:rights</code> is used for the copyright statement, which is specified with a textual description, by using property <code>rdfs:label</code> (following the <a href="https://www.dublincore.org/resources/userguide/publishing_metadata/">Dublin Core™ User Guide</a>).</p>
 <pre>
-:ds7890 a dcat:Dataset ;
+ex:ds7890 a dcat:Dataset ;
 # other dataset properties...
   dcterms:accessRights 
     &lt;http://publications.europa.eu/resource/authority/access-right/PUBLIC&gt; ;
@@ -4251,7 +4251,7 @@ ex:InternationalDOIFundation a foaf:Organization ;
 <aside class="example" id="ex-odrl-policy" title="ODRL policy">
 <p>This example shows how to use [[ODRL-VOCAB]] for a dataset with very specific usage rules. In this case, the data can be read and derivatives can be created, but no commercial use of the dataset is allowed. In addition, it is a requirement to register before the permissions are granted.</p>
 <pre>
-:ds4242 a dcat:Dataset ;
+ex:ds4242 a dcat:Dataset ;
 # other dataset properties...
   dcat:distribution [ a dcat:Distribution ;
 # other distribution properties...
@@ -4313,7 +4313,7 @@ ex:InternationalDOIFundation a foaf:Organization ;
 
 <aside class="example" id="ex-time-series-1" title="15-minute time-series published daily">
 <pre class="nohighlight turtle">
-:ds913
+ex:ds913
   a dcat:Dataset ;
   dcterms:accrualPeriodicity &lt;http://purl.org/cld/freq/daily&gt; ;
   dcat:temporalResolution "PT15M"^^xsd:duration ;
@@ -4323,7 +4323,7 @@ ex:InternationalDOIFundation a foaf:Organization ;
 
 <aside class="example" id="ex-time-series-2" title="Hourly data published immediately">
 <pre class="nohighlight turtle">
-:ds782
+ex:ds782
   a dcat:Dataset ;
   dcterms:accrualPeriodicity &lt;http://purl.org/cld/freq/continuous&gt; ;
   dcat:temporalResolution "PT1H"^^xsd:duration ;
@@ -4333,7 +4333,7 @@ ex:InternationalDOIFundation a foaf:Organization ;
 
 <aside class="example" id="ex-temporal-coverage-closed-interval" title="Temporal coverage as closed interval">
 <pre class="nohighlight turtle">
-:ds257 a dcat:Dataset ;
+ex:ds257 a dcat:Dataset ;
   dcterms:temporal [ a dcterms:PeriodOfTime ;
     dcat:startDate "2016-03-04"^^xsd:date ;
     dcat:endDate   "2018-08-05"^^xsd:date ;
@@ -4344,7 +4344,7 @@ ex:InternationalDOIFundation a foaf:Organization ;
 <aside class="example" id="ex-temporal-coverage-closed-proper-interval" title="Temporal coverage as closed interval, using time:ProperInterval">
 <p>The following dataset specification is equivalent to the one in <a href="#ex-temporal-coverage-closed-interval"></a>, but it uses [[OWL-TIME]]:</p>
 <pre class="nohighlight turtle">
-:ds348 a dcat:Dataset ;
+ex:ds348 a dcat:Dataset ;
   dcterms:temporal [ a dcterms:PeriodOfTime , time:ProperInterval ;
     time:hasBeginning [ a time:Instant ;
       time:inXSDDate "2016-03-04"^^xsd:date ;
@@ -4358,7 +4358,7 @@ ex:InternationalDOIFundation a foaf:Organization ;
 
 <aside class="example" id="ex-temporal-coverage-closed-proper-interval-gyear" title="Temporal coverage as proper interval using gYear">
 <pre class="nohighlight turtle">
-:ds429 a dcat:Dataset ;
+ex:ds429 a dcat:Dataset ;
   dcterms:temporal [ a dcterms:PeriodOfTime , time:ProperInterval ;
     time:hasBeginning [ a time:Instant ;
       time:inXSDgYear "1914"^^xsd:gYear ;
@@ -4372,7 +4372,7 @@ ex:InternationalDOIFundation a foaf:Organization ;
 
 <aside class="example" id="ex-temporal-coverage-geologic" title="Temporal coverage for a geologic dataset">
 <pre class="nohighlight turtle">
-:ds850 a dcat:Dataset ;
+ex:ds850 a dcat:Dataset ;
   dcterms:temporal [ a dcterms:PeriodOfTime , time:ProperInterval ;
     time:hasBeginning [ a time:Instant ;
       time:inTimePosition [ a time:TimePosition ;
@@ -4392,7 +4392,7 @@ ex:InternationalDOIFundation a foaf:Organization ;
 
 <aside class="example" id="ex-temporal-coverage-open-end-interval" title="Temporal coverage as open interval (no end date)">
 <pre class="nohighlight turtle">
-:ds127 a dcat:Dataset ;
+ex:ds127 a dcat:Dataset ;
   dcterms:temporal [ a dcterms:PeriodOfTime ;
     dcat:startDate "2016-03-04"^^xsd:date ;
   ] .
@@ -4401,7 +4401,7 @@ ex:InternationalDOIFundation a foaf:Organization ;
 
 <aside class="example" id="ex-temporal-coverage-open-begin-interval" title="Temporal coverage as open interval (no beginning)">
 <pre class="nohighlight turtle">
-:ds586 a dcat:Dataset ;
+ex:ds586 a dcat:Dataset ;
   dcterms:temporal [ a dcterms:PeriodOfTime , time:ProperInterval ;
     time:hasEnd [ time:inXSDDate "2018-08-05"^^xsd:date ] ;
   ] .
@@ -4503,7 +4503,7 @@ If it is required to provide the <code>w3cgeo:Point</code> formulation, then it 
 This ensures interoperability with other DCAT dataset descriptions. 
 For example:</p>
 <pre class="nohighlight turtle">
-:AnneFrank_3 a dcat:Dataset ;
+ex:AnneFrank_3 a dcat:Dataset ;
   dcterms:spatial [
     a dcterms:Location , w3cgeo:Point ;
     dcat:centroid "POINT(4.88412 52.37509)"^^geosparql:wktLiteral ;
@@ -4518,7 +4518,7 @@ For example:</p>
 <aside class="example" id="ex-spatial-coverage-bbox" title="Spatial coverage as bounding box">
 <p>The Dutch dataset of postal addresses, with its spatial coverage (Netherlands) specified as a bounding box.</p>
 <pre class="nohighlight turtle">
-:Dutch-postal a dcat:Dataset ;
+ex:Dutch-postal a dcat:Dataset ;
   dcterms:title "Adressen"@nl ;
   dcterms:title "Addresses"@en ;
   dcterms:description """INSPIRE Adressen afkomstig uit de basisregistratie Adressen,
@@ -5359,27 +5359,27 @@ ex:budget-2018-it a dcat:Dataset ;
         <h2>Providing quality information</h2>
 
         <p>
-        A data consumer (<code>:consumer1</code>)  describes the quality of the dataset <code>:genoaBusStopsDataset</code>
+        A data consumer (<code>ex:consumer1</code>)  describes the quality of the dataset <code>ex:genoaBusStopsDataset</code>
   that includes a georeferenced list of bus stops in Genoa. He/she annotates the dataset with a DQV quality note
-  (<code>:genoaBusStopsDatasetCompletenessNote</code>) about data completeness (<code>ldqd:completeness</code>) to
+  (<code>ex:genoaBusStopsDatasetCompletenessNote</code>) about data completeness (<code>ldqd:completeness</code>) to
   warn that the dataset includes only 20500 out of the 30000 stops.
         </p>
 
 <aside class="example" id="ex-genoa-bus-stops-dataset-completeness-note">
 <pre class="nohighlight turtle">
-:genoaBusStopsDataset a dcat:Dataset ;
-  dqv:hasQualityAnnotation :genoaBusStopsDatasetCompletenessNote .
+ex:genoaBusStopsDataset a dcat:Dataset ;
+  dqv:hasQualityAnnotation ex:genoaBusStopsDatasetCompletenessNote .
 
-:genoaBusStopsDatasetCompletenessNote a dqv:UserQualityFeedback ;
-  oa:hasTarget :genoaBusStopsDataset ;
-  oa:hasBody :textBody ;
+ex:genoaBusStopsDatasetCompletenessNote a dqv:UserQualityFeedback ;
+  oa:hasTarget ex:genoaBusStopsDataset ;
+  oa:hasBody ex:textBody ;
   oa:motivatedBy dqv:qualityAssessment ;
-  prov:wasAttributedTo :consumer1 ;
+  prov:wasAttributedTo ex:consumer1 ;
   prov:generatedAtTime "2018-05-27T02:52:02Z"^^xsd:dateTime ;
   dqv:inDimension ldqd:completeness
   .
 
-:textBody a oa:TextualBody ;
+ex:textBody a oa:TextualBody ;
   rdf:value "Incomplete dataset: it contains only 20500 out of 30000 existing bus stops" ;
   dc:language "en" ;
   dc:format "text/plain"
@@ -5387,44 +5387,44 @@ ex:budget-2018-it a dcat:Dataset ;
 </aside>
 
   <p>
-  The activity <code>:myQualityChecking</code> employs the service <code>:myQualityChecker</code> to check the
-  quality of the <code>:genoaBusStopsDataset</code> dataset. The metric <code>:completenessWRTExpectedNumberOfEntities</code>
+  The activity <code>ex:myQualityChecking</code> employs the service <code>ex:myQualityChecker</code> to check the
+  quality of the <code>ex:genoaBusStopsDataset</code> dataset. The metric <code>ex:completenessWRTExpectedNumberOfEntities</code>
   is applied to measure the dataset completeness (<code>ldqd:completeness</code>) and it results in the quality measurement
-  <code>:genoaBusStopsDatasetCompletenessMeasurement</code>.
+  <code>ex:genoaBusStopsDatasetCompletenessMeasurement</code>.
   </p>
 
 <aside class="example" id="ex-genoa-bus-stops-dataset-completeness-measure">
 <pre class="nohighlight turtle">
-:genoaBusStopsDataset
-  dqv:hasQualityMeasurement :genoaBusStopsDatasetCompletenessMeasurement .
+ex:genoaBusStopsDataset
+  dqv:hasQualityMeasurement ex:genoaBusStopsDatasetCompletenessMeasurement .
 
-:genoaBusStopsDatasetCompletenessMeasurement a dqv:QualityMeasurement ;
-  dqv:computedOn :genoaBusStopsDataset ;
-  dqv:isMeasurementOf :completenessWRTExpectedNumberOfEntities ;
+ex:genoaBusStopsDatasetCompletenessMeasurement a dqv:QualityMeasurement ;
+  dqv:computedOn ex:genoaBusStopsDataset ;
+  dqv:isMeasurementOf ex:completenessWRTExpectedNumberOfEntities ;
   dqv:value "0.6833333"^^xsd:decimal  ;
-  prov:wasAttributedTo :myQualityChecker ;
+  prov:wasAttributedTo ex:myQualityChecker ;
   prov:generatedAtTime "2018-05-27T02:52:02Z"^^xsd:dateTime ;
-  prov:wasGeneratedBy :myQualityChecking
+  prov:wasGeneratedBy ex:myQualityChecking
   .
 
-:completenessWRTExpectedNumberOfEntities a dqv:Metric ;
+ex:completenessWRTExpectedNumberOfEntities a dqv:Metric ;
   skos:definition "The degree of completeness as ratio between the actual number of entities included in the dataset and the declared expected number of entities."@en ;
   dqv:expectedDataType xsd:decimal ;
   dqv:inDimension ldqd:completeness .
 
-# :myQualityChecker is a service computing some quality metrics
-:myQualityChecker a prov:SoftwareAgent ;
+# ex:myQualityChecker is a service computing some quality metrics
+ex:myQualityChecker a prov:SoftwareAgent ;
   rdfs:label "A quality assessment service"@en .
   # Further details about quality service/software can be provided, for example,
   # deploying  vocabularies such as Dataset Usage Vocabulary (DUV), Dublin Core or ADMS.SW
 
-# :myQualityChecking is the activity that has generated 
-# :genoaBusStopsDatasetCompletenessMeasurement from :genoaBusStopsDataset
-:myQualityChecking a prov:Activity ;
+# ex:myQualityChecking is the activity that has generated 
+# ex:genoaBusStopsDatasetCompletenessMeasurement from ex:genoaBusStopsDataset
+ex:myQualityChecking a prov:Activity ;
   rdfs:label "The checking of genoaBusStopsDataset's quality"@en ;
-  prov:wasAssociatedWith :myQualityChecker ;
-  prov:used :genoaBusStopsDataset ;
-  prov:generated :genoaBusStopsDatasetCompletenessMeasurement ;
+  prov:wasAssociatedWith ex:myQualityChecker ;
+  prov:used ex:genoaBusStopsDataset ;
+  prov:generated ex:genoaBusStopsDatasetCompletenessMeasurement ;
   prov:endedAtTime "2018-05-27T02:52:02Z"^^xsd:dateTime ;
   prov:startedAtTime "2018-05-27T00:52:02Z"^^xsd:dateTime .</pre>
 </aside>
@@ -5450,7 +5450,7 @@ ex:budget-2018-it a dcat:Dataset ;
 
 <aside class="example" id="ex-inspire-conformant-dataset">
 <pre class="nohighlight turtle">
-:Dataset-1 a dcat:Dataset;
+ex:Dataset-1 a dcat:Dataset;
   dcterms:conformsTo &lt;http://data.europa.eu/eli/reg/2014/1312/oj&gt; .
 
 # Reference standard / specification
@@ -5465,7 +5465,7 @@ ex:budget-2018-it a dcat:Dataset ;
 
 <aside class="example" id="ex-dataset-crs">
 <pre class="nohighlight turtle">
-:Dataset-2 a dcat:Dataset;
+ex:Dataset-2 a dcat:Dataset;
   dcterms:conformsTo &lt;http://www.opengis.net/def/crs/EPSG/0/28992&gt; .</pre>
 </aside>
 
@@ -5491,11 +5491,11 @@ ex:budget-2018-it a dcat:Dataset ;
 
 <aside class="example" id="ex-catalog-record-schema">
 <pre class="nohighlight turtle">
-:catalog dcat:record :record-001 .
+ex:catalog dcat:record ex:record-001 .
 
-:record-001
+ex:record-001
   a dcat:CatalogRecord ;
-  foaf:primaryTopic :dataset-001 ;
+  foaf:primaryTopic ex:dataset-001 ;
   dcterms:issued "2011-12-11"^^xsd:date ;
   dcterms:conformsTo &lt;https://www.w3.org/TR/vocab-dcat/&gt; ;
   .
@@ -5599,8 +5599,8 @@ ex:budget-2018-it a dcat:Dataset ;
       <p><a href="#ex-conformance-degree"></a> specifies some newly minted concepts representing the degree of conformance (i.e., conformant, not conformant) and  declares the
       <a href="https://www.dublincore.org/specifications/dublin-core/dcmi-terms/#http://purl.org/dc/terms/type"><code>dcterms:type</code></a> for indicating
       the result of conformance test. Following a pattern used in [[?GeoDCAT-AP]], the example uses a <code>prov:Entity</code> to model the  conformance test (e.g.,
-      <code>a:testResult</code>), a <code>prov:Activity</code> to model the testing activity (e.g.,
-      <code>a:testingActivity</code>), a <code>prov:Plan</code> derived from the Data on the Web Best Practices [[?DWBP]] (e.g., <code>a:conformanceTest</code>) to check for the whole set of best practices. A qualified PROV association binds the testing activity to the conformance test.</p>
+      <code>ex:testResult</code>), a <code>prov:Activity</code> to model the testing activity (e.g.,
+      <code>ex:testingActivity</code>), a <code>prov:Plan</code> derived from the Data on the Web Best Practices [[?DWBP]] (e.g., <code>ex:conformanceTest</code>) to check for the whole set of best practices. A qualified PROV association binds the testing activity to the conformance test.</p>
 
       <aside class="note">
       <p>Depending on the kind of dataset, other best practices and standards, such as the FAIR Principles [[?FAIR]] or the Spatial Data on the Web Best Practices [[?SDW-BP]], can be considered as a replacement or used in combination with [[?DWBP]].</p>
@@ -5608,35 +5608,35 @@ ex:budget-2018-it a dcat:Dataset ;
 
 <aside class="example" id="ex-conformance-degree">
 <pre class="nohighlight turtle">
-:Dataset-3 a dcat:Dataset ;
-  prov:wasUsedBy :testingActivity .
+ex:Dataset-3 a dcat:Dataset ;
+  prov:wasUsedBy ex:testingActivity .
 
-:testingActivity a prov:Activity ;
-  prov:generated :testResult ;
+ex:testingActivity a prov:Activity ;
+  prov:generated ex:testResult ;
   prov:qualifiedAssociation [
     a prov:Association ;
     # http://validator.example.org/ is the agent who ran the test.
     prov:agent  &lt;http://validator.example.org/&gt;
-    # following the plan a:conformanceTest
-    prov:hadPlan :conformanceTest
+    # following the plan ex:conformanceTest
+    prov:hadPlan ex:conformanceTest
   ] .
 
 # Conformance test result
-:testResult a prov:Entity ;
-  prov:wasGeneratedBy :testingActivity;
-  # :notConformant belongs to a SKOS concept scheme about conformance
-  dcterms:type :notConformant .
+ex:testResult a prov:Entity ;
+  prov:wasGeneratedBy ex:testingActivity;
+  # ex:notConformant belongs to a SKOS concept scheme about conformance
+  dcterms:type ex:notConformant .
 
-:conformanceTest a prov:Plan ;
+ex:conformanceTest a prov:Plan ;
   # Here one can specify additional information on the test, which in the example is derived by the W3C Data on the Web Best Practices
   prov:wasDerivedFrom &lt;https://www.w3.org/TR/dwbp/&gt; .</pre>
 </aside>
   
-            <p>Also, [[?VOCAB-DQV]] can be deployed to  measure the compliance to a specific standard. In <a href="#ex-conformance-degree-percentage"></a>, the <code>:levelOfComplianceToDWBP</code> is a quality metrics which measures the compliance of a dataset to [[?DWBP]] in terms of the percentage of passed compliance tests. <a href="#ex-conformance-degree-percentage"></a> assumes <code>iso</code> as a namespace prefix representing the quality dimensions and categories defined in the ISO/IEC 25012 [[?ISO-IEC-25012]].</p>
+            <p>Also, [[?VOCAB-DQV]] can be deployed to  measure the compliance to a specific standard. In <a href="#ex-conformance-degree-percentage"></a>, the <code>ex:levelOfComplianceToDWBP</code> is a quality metrics which measures the compliance of a dataset to [[?DWBP]] in terms of the percentage of passed compliance tests. <a href="#ex-conformance-degree-percentage"></a> assumes <code>iso</code> as a namespace prefix representing the quality dimensions and categories defined in the ISO/IEC 25012 [[?ISO-IEC-25012]].</p>
 
 <aside class="example" id="ex-conformance-degree-percentage">
 <pre class="nohighlight turtle">
-:levelOfComplianceToDWBP a dqv:Metric ;
+ex:levelOfComplianceToDWBP a dqv:Metric ;
   skos:definition "The degree of compliance to DWBP defined as the percentage of passed compliance tests."@en ;
   dqv:expectedDataType xsd:double ;
   dqv:inDimension  iso:compliance .
@@ -5650,16 +5650,16 @@ iso:inherentAndSystemDependentDataQuality a dqv:Category ;
   skos:prefLabel "Inherent and System-Dependent Data Quality"@en .</pre>
 </aside>
 
-            <p>The quality measurement <code>:measurement_complianceToDWBP</code> represents the level of compliance for dataset <code>a:Dataset</code>, namely, measurement of the metric <code>:levelOfComplianceToDWBP</code>. If only a part of the compliance tests succeeds (e.g., half of the compliance tests), the measurement would look like in <a href="#ex-conformance-test-partial-success"></a>.</p>
+            <p>The quality measurement <code>ex:measurement_complianceToDWBP</code> represents the level of compliance for dataset <code>ex:Dataset</code>, namely, measurement of the metric <code>ex:levelOfComplianceToDWBP</code>. If only a part of the compliance tests succeeds (e.g., half of the compliance tests), the measurement would look like in <a href="#ex-conformance-test-partial-success"></a>.</p>
 
 <aside class="example" id="ex-conformance-test-partial-success">
 <pre class="nohighlight turtle">
-:measurement_complianceToDWBP a dqv:QualityMeasurement ;
-  dqv:computedOn a:Dataset ;
+ex:measurement_complianceToDWBP a dqv:QualityMeasurement ;
+  dqv:computedOn ex:Dataset ;
   dqv:value "50"^^xsd:double ;
   sdmx-attribute:unitMeasure &lt;http://www.wurvoc.org/vocabularies/om-1.8/Percentage&gt; ;
   dcterms:date "2018-01-10"^^xsd:date ;
-  dqv:isMeasurementOf :levelOfComplianceToDWBP .</pre>
+  dqv:isMeasurementOf ex:levelOfComplianceToDWBP .</pre>
 </aside>
 
         </section>
@@ -5667,34 +5667,34 @@ iso:inherentAndSystemDependentDataQuality a dqv:Category ;
             <h3>Conformance test results</h3>
             <p> Further information about the tests can be provided using EARL [[?EARL10-Schema]]. EARL provides specific
       classes to describe the testing activity, which can be adopted in conjunction with [[?PROV-O]].
-      <a href="#ex-conformance-test-results-earl"></a> describes the Testing activity <code>a:testingActivity</code> as an <code>earl:Assertion</code>
+      <a href="#ex-conformance-test-results-earl"></a> describes the Testing activity <code>ex:testingActivity</code> as an <code>earl:Assertion</code>
       instead of a qualified association on the <code>prov:Activity</code>. The <code>earl:Assertion</code> states
-      that dataset <code>a:Dataset</code> has been tested with the conformance test <code>a:conformanceTest</code>, and it
-        has passed the test as described in <code>a:testResult</code>.
+      that dataset <code>ex:Dataset</code> has been tested with the conformance test <code>ex:conformanceTest</code>, and it
+        has passed the test as described in <code>ex:testResult</code>.
             </p>
 
 <aside class="example" id="ex-conformance-test-results-earl">
 <pre class="nohighlight turtle">
-a:assertion a earl:Assertion ;
-  earl:subject a:Dataset ;
-  earl:test a:conformanceTest ;
-  earl:result a:testResult ;
+ex:assertion a earl:Assertion ;
+  earl:subject ex:Dataset ;
+  earl:test ex:conformanceTest ;
+  earl:result ex:testResult ;
   # let's indicate if the test was manual, automatic, or what ..
   earl:mode earl:automatic ;
   earl:assertedBy &lt;http://validator.example.org/&gt; ;
   prov:wasAttributedTo  &lt;http://validator.example.org/&gt; .
 
-a:conformanceTest a earl:TestRequirement, prov:Plan ;
+ex:conformanceTest a earl:TestRequirement, prov:Plan ;
   dcterms:title "Set of conformance test derived from the W3C Data on the Web Best Practices"@en ;
   # it includes different subtests
-  dcterms:hasPart a:testBP1, a:testBP2, ...,  a:testBP35 ;
+  dcterms:hasPart ex:testBP1, ex:testBP2, ...,  ex:testBP35 ;
   #It is derived  by the reference standard
   prov:wasDerivedFrom  &lt;https://www.w3.org/TR/dwbp/&gt; .
 
-a:testResult a earl:TestResult ;
+ex:testResult a earl:TestResult ;
   #  results in conformancy .
-  dcterms:type  a:conformant ;
-  prov:wasGeneratedBy a:testingActivity;
+  dcterms:type  ex:conformant ;
+  prov:wasGeneratedBy ex:testingActivity;
   #the overall set of tests have been passed
   earl:outcome earl:passed .
 
@@ -5704,23 +5704,23 @@ a:testResult a earl:TestResult ;
   dcterms:title "Validator"@en .
 
 #the testing activity
-a:testingActivity a prov:Activity ;
-  prov:generated a:assertion, a:testResult ;
-  prov:use a:Dataset ;
+ex:testingActivity a prov:Activity ;
+  prov:generated ex:assertion, ex:testResult ;
+  prov:use ex:Dataset ;
   prov:wasAssociatedWith &lt;http://validator.example.org/&gt; .</pre>
 </aside>
 
-<p><a href="#ex-conformance-test-earl-fail"></a> shows how the description would have looked like if the subtest <code>a:testq1</code> had failed. In particular, <code>dcterms:description</code> and <code>earl:info</code> provide additional warnings or error messages in a human-readable form.</p>
+<p><a href="#ex-conformance-test-earl-fail"></a> shows how the description would have looked like if the subtest <code>ex:testq1</code> had failed. In particular, <code>dcterms:description</code> and <code>earl:info</code> provide additional warnings or error messages in a human-readable form.</p>
 
 <aside class="example" id="ex-conformance-test-earl-fail">
 <pre class="nohighlight turtle">
-a:assertion1 a earl:Assertion ;
-  earl:subject a:Dataset ;
-  earl:test a:testq1 ;
+ex:assertion1 a earl:Assertion ;
+  earl:subject ex:Dataset ;
+  earl:test ex:testq1 ;
   earl:result [
     a earl:TestResult ;
     #  results in no conformancy
-    dcterms:type a:nonConformant ;
+    dcterms:type ex:nonConformant ;
     #the overall set of tests have not been passed (!?)
     dcterms:date "2015-09-29T11:50:00+00:00"^^xsd:dateTime ;
     # Some XML encoding of the error
@@ -5744,15 +5744,15 @@ a:assertion1 a earl:Assertion ;
   earl:mode earl:automatic.</pre>
 </aside>
 
-            <p>Depending on the details required about tests, [[?VOCAB-DQV]] can express the testing activity and errors as well. In <a href="#ex-conformance-test-error"></a>, <code>:error</code> is a quality annotation that represents the previous error, and  <code>a:testResult</code> is defined as a <code>dqv:QualityMetadata</code> to  collect the above annotations and the compliance measurements providing  provenance information.
+            <p>Depending on the details required about tests, [[?VOCAB-DQV]] can express the testing activity and errors as well. In <a href="#ex-conformance-test-error"></a>, <code>ex:error</code> is a quality annotation that represents the previous error, and  <code>ex:testResult</code> is defined as a <code>dqv:QualityMetadata</code> to  collect the above annotations and the compliance measurements providing  provenance information.
 
 <aside class="example" id="ex-conformance-test-error">
 <pre class="nohighlight turtle">
-:errors
+ex:errors
   a dqv:QualityAnnotation ;
   #this annotation is derived by the measurement
-  prov:wasGeneratedBy  a:testingActivity;
-  oa:hasTarget a:Dataset ;
+  prov:wasGeneratedBy  ex:testingActivity;
+  oa:hasTarget ex:Dataset ;
   oa:hasBody [
     #errors/failed test description
     a oa:TextualBody ;
@@ -5773,26 +5773,26 @@ a:assertion1 a earl:Assertion ;
   dqv:inDimension iso:compliance ;
   .
 
-a:testResult
+ex:testResult
   a dqv:QualityMetadata ;
   #  change the the dcterms:type according to the resulted compliance
   dcterms:type &lt;http://inspire.ec.europa.eu/metadata-codelist/DegreeOfConformity/conformant&gt; ;
   prov:wasAttributedTo &lt;http://validator.example.org/&gt; ;
   prov:generatedAtTime "2018-05-27T02:52:02Z"^^xsd:dateTime ;
-  prov:wasGeneratedBy a:testingActivity .
+  prov:wasGeneratedBy ex:testingActivity .
 
 # The graph contains the rest of the statements presented in the previous examples.
 # The graph is expressed according to TRIG syntax not TTL (see https://www.w3.org/TR/trig/)
-a:testResult {
+ex:testResult {
   a dcat:Dataset ;
-  dqv:hasQualityMeasurement :measurement_complianceToDWBP ;
-  dqv:hasQualityAnnotation :errors .
+  dqv:hasQualityMeasurement ex:measurement_complianceToDWBP ;
+  dqv:hasQualityAnnotation ex:errors .
 }
 
 #the testing activity
-a:testingActivity a prov:Activity ;
-  prov:generated  a:testResult ;
-  prov:use a:Dataset ;
+ex:testingActivity a prov:Activity ;
+  prov:generated  ex:testResult ;
+  prov:use ex:Dataset ;
   prov:wasAssociatedWith &lt;http://validator.example.org/&gt; ;
   .</pre>
 </aside>
@@ -6295,17 +6295,17 @@ ex:Test543L
 
 <aside id="ex-dataset-as-bag-of-files" class="example">
 <pre class="nohighlight turtle">
-:d33937
+ex:d33937
   dcterms:description "A set of RDF graphs representing the International [Chrono]stratigraphic Chart, ..."@en ;
   dcterms:identifier "https://doi.org/10.25919/5b4d2b83cbf2d"^^xsd:anyURI ;
   dcterms:creator &lt;https://orcid.org/0000-0002-3884-3420&gt; ;
-  dcterms:relation :ChronostratChart2017-02.pdf  ;
-  dcterms:relation :ChronostratChart2017-02.jpg ;
-  dcterms:hasPart :timescale.zip ;
-  dcterms:hasPart :d33937-jsonld ;
-  dcterms:hasPart :d33937-nt ;
-  dcterms:hasPart :d33937-rdf ;
-  dcterms:hasPart :d33937-ttl ;
+  dcterms:relation ex:ChronostratChart2017-02.pdf  ;
+  dcterms:relation ex:ChronostratChart2017-02.jpg ;
+  dcterms:hasPart ex:timescale.zip ;
+  dcterms:hasPart ex:d33937-jsonld ;
+  dcterms:hasPart ex:d33937-nt ;
+  dcterms:hasPart ex:d33937-rdf ;
+  dcterms:hasPart ex:d33937-ttl ;
 .
 </pre>
 </aside>
@@ -6316,35 +6316,35 @@ ex:Test543L
 
 <aside id="ex-when-using-distribution" class="example">
 <pre class="nohighlight turtle">
-:d33937
+ex:d33937
   rdf:type dcat:Dataset ;
   dcterms:description "A set of RDF graphs representing the International [Chrono]stratigraphic Chart, ..."@en ;
   dcterms:identifier "https://doi.org/10.25919/5b4d2b83cbf2d"^^xsd:anyURI ;
-  dcterms:hasFormat :ChronostratChart2017-02.pdf  ;
-  dcterms:hasFormat :ChronostratChart2017-02.jpg ;
-  dcat:distribution :timescale.zip ;
-  dcat:distribution :d33937-jsonld ;
-  dcat:distribution :d33937-nt ;
-  dcat:distribution :d33937-rdf ;
-  dcat:distribution :d33937-ttl ;
+  dcterms:hasFormat ex:ChronostratChart2017-02.pdf  ;
+  dcterms:hasFormat ex:ChronostratChart2017-02.jpg ;
+  dcat:distribution ex:timescale.zip ;
+  dcat:distribution ex:d33937-jsonld ;
+  dcat:distribution ex:d33937-nt ;
+  dcat:distribution ex:d33937-rdf ;
+  dcat:distribution ex:d33937-ttl ;
 .
-:d33937-jsonld  rdf:type dcat:Distribution ;
-  dcat:downloadURL :isc2017.jsonld ;
+ex:d33937-jsonld  rdf:type dcat:Distribution ;
+  dcat:downloadURL ex:isc2017.jsonld ;
   dcat:byteSize "698039"^^xsd:nonNegativeInteger ;
   dcat:mediaType &lt;http://www.iana.org/assignments/media-types/application/ld+json&gt; ;
 .
-:d33937-nt  rdf:type dcat:Distribution ;
-  dcat:downloadURL :isc2017.nt ;
+ex:d33937-nt  rdf:type dcat:Distribution ;
+  dcat:downloadURL ex:isc2017.nt ;
   dcat:byteSize "2047874"^^xsd:nonNegativeInteger ;
   dcat:mediaType &lt;http://www.iana.org/assignments/media-types/application/n-triples&gt; ;
 .
-:d33937-rdf  rdf:type dcat:Distribution ;
-  dcat:downloadURL :isc2017.rdf ;
+ex:d33937-rdf  rdf:type dcat:Distribution ;
+  dcat:downloadURL ex:isc2017.rdf ;
   dcat:byteSize "1600569"^^xsd:nonNegativeInteger ;
   dcat:mediaType &lt;http://www.iana.org/assignments/media-types/application/rdf+xml&gt; ;
 .
-:d33937-ttl  rdf:type dcat:Distribution ;
-  dcat:downloadURL :isc2017.ttl ;
+ex:d33937-ttl  rdf:type dcat:Distribution ;
+  dcat:downloadURL ex:isc2017.ttl ;
   dcat:byteSize "531703"^^xsd:nonNegativeInteger ;
   dcat:mediaType &lt;http://www.iana.org/assignments/media-types/text/turtle&gt; ;
 .
@@ -6530,7 +6530,7 @@ dap:P366
 
 <aside id="dataset-publication" class="example">
 <pre class="nohighlight turtle">
-:globtherm
+ex:globtherm
   dcterms:title "Data from: GlobTherm, a global database on thermal tolerances for aquatic and terrestrial organisms"@en ;
   dcterms:description "How climate affects species distributions is a longstanding question receiving renewed interest owing to the need to predict the impacts of global warming on biodiversity. Is climate change forcing species to live near their critical thermal limits? Are these limits likely to change through natural selection? These and other important questions can be addressed with models relating geographical distributions of species with climate data, but inferences made with these models are highly contingent on non-climatic factors such as biotic interactions. Improved understanding of climate change effects on species will require extensive analysis of thermal physiological traits, but such data are scarce and scattered. To overcome current limitations, we created the GlobTherm database. The database contains experimentally derived species’ thermal tolerance data currently comprising over 2,000 species of terrestrial, freshwater, intertidal and marine multicellular algae, plants, fungi, and animals. The GlobTherm database will be maintained and curated by iDiv with the aim of expanding it, and enable further investigations on the effects of climate on the distribution of life on Earth."@en ;
   dcterms:identifier "https://doi.org/10.5061/dryad.1cv08"^^xsd:anyURI ;
@@ -6563,7 +6563,7 @@ dap:P366
 
 <aside id="ex-service-eea" class="example">
 <pre class="nohighlight turtle">
-a:EEA-CSW-Endpoint
+ex:EEA-CSW-Endpoint
   rdf:type dcat:DataService ;
   dcterms:type &lt;http://inspire.ec.europa.eu/metadata-codelist/SpatialDataServiceCategory/infoCatalogueService&gt; ;
   dcterms:accessRights &lt;http://publications.europa.eu/resource/authority/access-right/PUBLIC&gt; ;
@@ -6588,7 +6588,7 @@ a:EEA-CSW-Endpoint
   dcterms:title "European Environment Agency's public catalogue of spatial datasets."@en ;
   dcterms:type &lt;http://inspire.ec.europa.eu/metadata-codelist/ResourceType/service&gt; ;
   dcterms:type &lt;http://inspire.ec.europa.eu/metadata-codelist/SpatialDataServiceType/discovery&gt; ;
-  dcat:contactPoint a:EEA ;
+  dcat:contactPoint ex:EEA ;
   dcat:endpointDescription &lt;https://sdi.eea.europa.eu/catalogue/srv/eng/csw?service=CSW&request=GetCapabilities&gt; ;
   dcat:endpointURL &lt;http://sdi.eea.europa.eu/catalogue/srv/eng/csw&gt; ;
 .</pre>


### PR DESCRIPTION
This PR removes the namespace ':'  and "a:"  in all the HTML and RDFS examples and replaces them with "ex:". 
 
That should fix inconsistencies still present, for example, dataset-001 which is referred by :dataset-001 and ex:dataset-001.

@agbeltran: Please consider merging this in your branch dcat-issue-1476 and  PR #1487   