### PR TITLE
Adding aligment to sdo:CreativeWorkSeries

### DIFF
--- a/dcat/index.html
+++ b/dcat/index.html
@@ -6178,6 +6178,10 @@ ex:Test543L
                 <td>sdo:contactPoint</td>
             </tr>
             <tr>
+                <td>dcat:version</td>
+                <td>sdo:version</td>
+            </tr>
+            <tr>
                 <td><b>dcat:Catalog</b></td>
                 <td><b>sdo:DataCatalog</b></td>
             </tr>
@@ -6216,6 +6220,14 @@ ex:Test543L
             <tr>
                 <td>prov:wasGeneratedBy</td>
                 <td>[ owl:inverseOf sdo:result ]</td>
+            </tr>
+            <tr>
+              <td>dcat:inSeries</td>
+              <td>sdo:isPartOf</td>
+            </tr>
+            <tr>
+              <td><b>dcat:DatasetSeries</b></td>
+              <td><b>sdo:CreativeWorkSeries</b></td>
             </tr>
             <tr>
                 <td><b>dcat:Distribution</b></td>
@@ -6269,14 +6281,6 @@ ex:Test543L
                 <td><b>dcat:Relationship</b></td>
                 <td><b>sdo:Role</b></td>
             </tr>
-            <tr>
-              <td><b>dcat:DatasetSeries</b></td>
-              <td><b>sdo:CreativeWorkSeries</b></td>
-           </tr>
-           <tr>
-            <td>dcat:inSeries</td>
-            <td>sdo:isPartOf</td>
-          </tr>
           </tbody>
         </table>
 

--- a/dcat/index.html
+++ b/dcat/index.html
@@ -6269,6 +6269,14 @@ ex:Test543L
                 <td><b>dcat:Relationship</b></td>
                 <td><b>sdo:Role</b></td>
             </tr>
+            <tr>
+              <td><b>dcat:DatasetSeries</b></td>
+              <td><b>sdo:CreativeWorkSeries</b></td>
+           </tr>
+           <tr>
+            <td>dcat:inSeries</td>
+            <td>sdo:isPartOf</td>
+          </tr>
           </tbody>
         </table>
 


### PR DESCRIPTION
Preview: https://raw.githack.com/w3c/dxwg/dcat-issue-1398/dcat/index.html#dcat-sdo

only the class and the dcat:inSeries property can be matched; don't think there is equivalents to dcat:prev, dcat:next; specific subclasses such as https://schema.org/TVSeries have more details but still no ways of linking previous/next item

closes #1398 