### PR TITLE
Create explainer document of DCAT 3 for TAG review

### DIFF
--- a/docs/explainer.md
+++ b/docs/explainer.md
@@ -1,0 +1,1 @@
+# Data Catalog Vocabulary (DCAT) - Version 3

--- a/docs/explainer.md
+++ b/docs/explainer.md
@@ -1,1 +1,15 @@
 # Data Catalog Vocabulary (DCAT) - Version 3
+
+## What is DCAT
+
+DCAT is an RDF vocabulary designed to facilitate interoperability between data catalogs published on the Web.
+
+DCAT enables a publisher to describe datasets and data services in a catalog using a standard model and vocabulary that facilitates the consumption and aggregation of metadata from multiple catalogs. This can increase the discoverability of datasets and data services. It also makes it possible to have a decentralized approach to publishing data catalogs and makes federated search for datasets across catalogs in multiple sites possible using the same query mechanism and structure. Aggregated DCAT metadata can serve as a manifest file as part of the digital preservation process.
+
+## DCAT history
+
+The original DCAT vocabulary was developed and hosted at the Digital Enterprise Research Institute (DERI) (now [Data Science Institute at NUI Galway](https://dsi.nuigalway.ie/)), then refined by the [eGov Interest Group](https://www.w3.org/egov/), and finally standardized in 2014 [[VOCAB-DCAT-1](https://www.w3.org/TR/vocab-dcat-1/)] by the [Government Linked Data (GLD) Working Group](http://www.w3.org/2011/gld/).
+
+A second recommended revision of DCAT, DCAT 2 [[VOCAB-DCAT-2](https://www.w3.org/TR/vocab-dcat-2/)], was developed by the [Dataset Exchange Working Group (DXWG)](https://www.w3.org/2017/dxwg/) in response to a new set of Use Cases and Requirements [[DCAT-UCR](https://www.w3.org/TR/dcat-ucr/)] gathered from peoples' experience with the DCAT vocabulary from the time of the original version, and new applications that were not considered in the first version.
+
+This version of DCAT, DCAT 3 [[VOCAB-DCAT-3](https://www.w3.org/TR/vocab-dcat-3/)], was developed by the [Dataset Exchange Working Group (DXWG)](https://www.w3.org/2017/dxwg/), considering some of the more pressing use cases and requests among those left unaddressed in the previous standardization round. A summary of the changes from [[VOCAB-DCAT-2](https://www.w3.org/TR/vocab-dcat-2/)] is provided in [the change history section](https://www.w3.org/TR/vocab-dcat-3/#changes) of [[VOCAB-DCAT-3](https://www.w3.org/TR/vocab-dcat-3/)].

--- a/docs/explainer.md
+++ b/docs/explainer.md
@@ -13,3 +13,7 @@ The original DCAT vocabulary was developed and hosted at the Digital Enterprise 
 A second recommended revision of DCAT, DCAT 2 [[VOCAB-DCAT-2](https://www.w3.org/TR/vocab-dcat-2/)], was developed by the [Dataset Exchange Working Group (DXWG)](https://www.w3.org/2017/dxwg/) in response to a new set of Use Cases and Requirements [[DCAT-UCR](https://www.w3.org/TR/dcat-ucr/)] gathered from peoples' experience with the DCAT vocabulary from the time of the original version, and new applications that were not considered in the first version.
 
 This version of DCAT, DCAT 3 [[VOCAB-DCAT-3](https://www.w3.org/TR/vocab-dcat-3/)], was developed by the [Dataset Exchange Working Group (DXWG)](https://www.w3.org/2017/dxwg/), considering some of the more pressing use cases and requests among those left unaddressed in the previous standardization round. A summary of the changes from [[VOCAB-DCAT-2](https://www.w3.org/TR/vocab-dcat-2/)] is provided in [the change history section](https://www.w3.org/TR/vocab-dcat-3/#changes) of [[VOCAB-DCAT-3](https://www.w3.org/TR/vocab-dcat-3/)].
+
+## DCAT Examples
+
+The DCAT 3 [[VOCAB-DCAT-3](https://www.w3.org/TR/vocab-dcat-3/)] specification includes different examples of use which are also accessible as RDF code at the [GitHub directory](https://github.com/w3c/dxwg/tree/gh-pages/dcat/examples/vocab-dcat-3).


### PR DESCRIPTION
Draft of the explainer document of DCAT 3 for TAG review.

Preview: https://github.com/w3c/dxwg/blob/dcat-explainer-doc/docs/explainer.md