### PR TITLE
Complementing PR #1512 already merged.

### DIFF
--- a/dcat/index.html
+++ b/dcat/index.html
@@ -6777,6 +6777,9 @@ ga-courts:jc-wms
 
 <ul>
 <li>
+<p>Added health warning related to BCP 47 - see Issue <a href="https://github.com/w3c/dxwg/issues/959">#959</a>.</p>
+</li>    
+<li>
 <p>Updated <a href="#ex-versioning-with-dcat-and-owl"></a> (<a href="#versioning-complementary-approaches"></a>) to illustrate how to use OWL and DCAT to version DCAT 3.</p>
 </li>
 <li>

--- a/dcat/index.html
+++ b/dcat/index.html
@@ -1274,7 +1274,7 @@ ex:table-service-005
                 <tr><th class="prop">Usage note:</th><td>If representations of a dataset are available for each language separately, define an instance of <code>dcat:Distribution</code> for each language and describe the specific language of each distribution using <code>dcterms:language</code> (i.e., the dataset will have multiple <code>dcterms:language</code> values and each distribution will have just one as the value of its <code>dcterms:language</code> property).</td></tr>
                 </table>
             <aside class="note"> 
-            Requirements for identification of natural language in linked data specifications are evolving. Many applications use <a href="https://datatracker.ietf.org/doc/html/bcp47">BCP47</a> language tags for this purpose. ISO 639 also provides additional codes in ISO 639-3 which might be required for some uses. 
+            Requirements for identification of natural language in linked data specifications are evolving. Many applications use <!--a href="https://datatracker.ietf.org/doc/html/bcp47">BCP47</a-->[[BCP47]] language tags for this purpose. ISO 639 also provides additional codes in ISO 639-3 which might be required for some uses. 
             </aside>
         </section>
 


### PR DESCRIPTION
This PR is adding the BCP47 reference from specref (see https://github.com/w3c/dxwg/pull/1512#discussion_r892453684) and an entry related to  #959 in the history of change. 

Diff: https://services.w3.org/htmldiff?doc1=https://w3c.github.io/dxwg/dcat/&doc2=https://raw.githack.com/w3c/dxwg/DCAT-issue-959/dcat/index.html