### PR TITLE
Properties without specified domains

### DIFF
--- a/dcat/index.html
+++ b/dcat/index.html
@@ -744,7 +744,12 @@ ex:table-service-005
         <!--NoBacklogNorCR p class="issue" data-number="144">
             The implementation of a DCAT 1 profile of the revised DCAT is being considered.
         </p -->
-
+	    
+	<aside class="note">
+		<p>Where possible, properties defined by DCAT do not have specified domains in order to leave the property open for use with any kind of resources. 
+			The intention is that such properties can be reused in any suitable circumstance where they make sense.
+		</p>
+	    </aside>
 
 
     </section>

--- a/dcat/index.html
+++ b/dcat/index.html
@@ -745,11 +745,10 @@ ex:table-service-005
             The implementation of a DCAT 1 profile of the revised DCAT is being considered.
         </p -->
 	    
-	<aside class="note">
-		<p>Where possible, properties defined by DCAT do not have specified domains in order to leave the property open for use with any kind of resources. 
-			The intention is that such properties can be reused in any suitable circumstance where they make sense.
-		</p>
-	    </aside>
+<aside class="note">
+	<p>Where possible, properties defined by DCAT do not have specified domains in order to leave the property open for use with any kind of resources. 
+	The intention is that such properties can be reused in any suitable circumstance where they make sense.	</p>
+	</aside>
 
 
     </section>


### PR DESCRIPTION
Add clarifying note to explain that in general `dcat:` properties without specified domains are open to use where appropriate (Motivated by #1534).

See new note in https://raw.githack.com/w3c/dxwg/dcat-issue-1534/dcat/index.html#vocabulary-specification . (I thought that a  NOTE was more appropriate than an editorial note though if anyone feels strongly......) 

