### PR TITLE
Addressing 1539

### DIFF
--- a/dcat/index.html
+++ b/dcat/index.html
@@ -171,6 +171,7 @@ table.simple {width:100%;}
           <table id="table-namespaces" class="simple">
             <thead><tr><th>Prefix</th><th>Namespace IRI</th><th>Source</th></tr></thead>
             <tbody>
+            <tr><td><code>adms</code></td><td><code>http://www.w3.org/ns/adms#</code></td><td>[[?VOCAB-ADMS]]</td></tr>
             <tr><td><code>dc</code></td><td><code>http://purl.org/dc/elements/1.1/</code></td><td>[[DCTERMS]]</td></tr>
             <tr><td><code>dcat</code></td><td><code>http://www.w3.org/ns/dcat#</code></td><td>[[VOCAB-DCAT]]</td></tr>
             <tr><td><code>dcterms</code></td><td><code>http://purl.org/dc/terms/</code></td><td>[[DCTERMS]]</td></tr>
@@ -200,7 +201,6 @@ table.simple {width:100%;}
           <table id="table-namespaces-examples" class="simple">
             <thead><tr><th>Prefix</th><th>Namespace IRI</th><th>Source</th></tr></thead>
             <tbody>
-            <tr><td><code>adms</code></td><td><code>https://www.w3.org/ns/adms#</code></td><td>[[?VOCAB-ADMS]]</td></tr>
             <tr><td><code>dqv</code></td><td><code>http://www.w3.org/ns/dqv#</code></td><td>[[?VOCAB-DQV]]</td></tr>
             <tr><td><code>earl</code></td><td><code>http://www.w3.org/ns/earl#</code></td><td>[[?EARL10-Schema]]</td></tr>
             <tr><td><code>geosparql</code></td><td><code>http://www.opengis.net/ont/geosparql#</code></td><td>[[?GeoSPARQL]]</td></tr>


### PR DESCRIPTION
adding adms namespace in the normative namespaces ( we use adms:versionNotes and adms:status) and dropped the s from https in the name space

PREVIEW: https://raw.githack.com/w3c/dxwg/dcat-issue-1539/dcat/index.html#namespaces

DIFF: https://services.w3.org/htmldiff?doc1=https://w3c.github.io/dxwg/dcat/&doc2=https://raw.githack.com/w3c/dxwg/dcat-issue-1539/dcat/index.html#namespaces

Closes #1539 