### PR TITLE
adding  the inverse for dcat:distribution  

### DIFF
--- a/dcat/index.html
+++ b/dcat/index.html
@@ -3977,19 +3977,16 @@ The interval can also be open - i.e., it can have just a start or just an end.</
 <td><a href="#Property:resource_previous_version"><code>dcat:previousVersion</code></a></td>
 <td id="inverse_of_resource_previous_version"><code>dcat:nextVersion</code></td>
 </tr>
-<!--
 <tr>
 <td><a href="#Property:dataset_distribution"><code>dcat:distribution</code></a></td>
-<td id="inverse_of_dataset_distribution"><code>dcat:distributionOf</code></td>
+<td id="inverse_of_dataset_distribution"><code>dcat:isDistributionOf</code></td>
 </tr>
--->
 <!-- DCAT 2
 <tr>
 <td><a href="#Property:catalog_has_part"><code>dcterms:hasPart</code></a></td>
 <td id="inverse_of_catalog_has_part"><a href="https://www.dublincore.org/specifications/dublin-core/dcmi-terms/#http://purl.org/dc/terms/isPartOf"><code>dcterms:isPartOf</code></a></td>
 </tr>
 -->
-
 <tr>
 <td><a href="#Property:resource_has_part"><code>dcterms:hasPart</code></a></td>
 <td id="inverse_of_resource_has_part"><a href="https://www.dublincore.org/specifications/dublin-core/dcmi-terms/#http://purl.org/dc/terms/isPartOf"><code>dcterms:isPartOf</code></a></td>

--- a/dcat/rdf/dcat3.jsonld
+++ b/dcat/rdf/dcat3.jsonld
@@ -1,110 +1,110 @@
 {
   "@graph" : [ {
     "@id" : "_:b0",
+    "homepage" : "https://www.csiro.au",
+    "foaf:name" : "Commonwealth Scientific and Industrial Research Organisation"
+  }, {
+    "@id" : "_:b1",
     "@type" : "foaf:Person",
     "seeAlso" : "https://orcid.org/0000-0003-3499-8262",
-    "memberOf" : "_:b1",
+    "memberOf" : "_:b2",
     "homepage" : "https://agbeltran.github.io",
     "foaf:name" : "Alejandra Gonzalez-Beltran"
   }, {
-    "@id" : "_:b1",
-    "homepage" : "http://stfc.ac.uk",
-    "foaf:name" : "Science and Technology Facilities Council, UK"
-  }, {
-    "@id" : "_:b10",
-    "@type" : "owl:Restriction",
-    "allValuesFrom" : "dcat:Resource",
-    "onProperty" : "foaf:primaryTopic"
-  }, {
-    "@id" : "_:b13",
-    "@type" : "foaf:Person",
-    "memberOf" : "_:b5",
-    "foaf:name" : "Vassilios Peristeras"
-  }, {
-    "@id" : "_:b14",
-    "homepage" : "http://www.deri.ie/",
-    "foaf:name" : "DERI, NUI Galway"
-  }, {
-    "@id" : "_:b15",
+    "@id" : "_:b11",
     "@type" : "org:Organization",
     "seeAlso" : "https://www.wikidata.org/entity/Q37033",
     "homepage" : "https://www.w3.org/",
     "foaf:name" : "World Wide Web Consortium (W3C)"
   }, {
-    "@id" : "_:b16",
+    "@id" : "_:b12",
     "@type" : "foaf:Person",
-    "memberOf" : "_:b14",
+    "memberOf" : "_:b13",
     "foaf:name" : "Fadi Maali"
   }, {
-    "@id" : "_:b17",
-    "@type" : "foaf:Person",
-    "foaf:name" : "Peter Winstanley"
+    "@id" : "_:b13",
+    "homepage" : "http://www.deri.ie/",
+    "foaf:name" : "DERI, NUI Galway"
   }, {
-    "@id" : "_:b18",
-    "@type" : "foaf:Person",
-    "seeAlso" : "https://orcid.org/0000-0002-3884-3420",
-    "memberOf" : "_:b23",
-    "foaf:name" : "Simon J D Cox",
-    "workInfoHomepage" : "http://people.csiro.au/Simon-Cox"
-  }, {
-    "@id" : "_:b19",
-    "@type" : "foaf:Person",
-    "seeAlso" : "https://orcid.org/0000-0001-5648-2713",
-    "homepage" : "https://w3id.org/people/ralbertoni/",
-    "foaf:name" : "Riccardo Albertoni"
-  }, {
-    "@id" : "_:b2",
+    "@id" : "_:b14",
     "@type" : "owl:Restriction",
-    "cardinality" : "1",
+    "allValuesFrom" : "dcat:Resource",
     "onProperty" : "foaf:primaryTopic"
   }, {
-    "@id" : "_:b20",
-    "@type" : "foaf:Person",
-    "seeAlso" : "https://jakub.klímek.com/#me",
-    "homepage" : "https://jakub.klímek.com/",
-    "foaf:name" : "Jakub Klímek"
-  }, {
-    "@id" : "_:b21",
+    "@id" : "_:b15",
     "@type" : "foaf:Person",
     "seeAlso" : "http://makxdekkers.com/makxdekkers.rdf#me",
     "homepage" : "http://makxdekkers.com/",
     "foaf:name" : "Makx Dekkers"
   }, {
-    "@id" : "_:b23",
-    "homepage" : "https://www.csiro.au",
-    "foaf:name" : "Commonwealth Scientific and Industrial Research Organisation"
+    "@id" : "_:b17",
+    "@type" : "foaf:Person",
+    "memberOf" : "_:b3",
+    "foaf:name" : "Vassilios Peristeras"
   }, {
-    "@id" : "_:b3",
+    "@id" : "_:b18",
+    "@type" : "foaf:Person",
+    "foaf:name" : "Peter Winstanley"
+  }, {
+    "@id" : "_:b19",
+    "@type" : "foaf:Person",
+    "seeAlso" : "https://orcid.org/0000-0001-9300-2694",
+    "foaf:name" : "Andrea Perego"
+  }, {
+    "@id" : "_:b2",
+    "homepage" : "http://stfc.ac.uk",
+    "foaf:name" : "Science and Technology Facilities Council, UK"
+  }, {
+    "@id" : "_:b20",
     "@type" : "foaf:Person",
     "homepage" : "http://www.asahi-net.or.jp/~ax2s-kmtn/",
     "foaf:name" : "Shuji Kamitsuna"
   }, {
-    "@id" : "_:b4",
+    "@id" : "_:b21",
+    "@type" : "foaf:Person",
+    "seeAlso" : "https://orcid.org/0000-0001-5648-2713",
+    "homepage" : "https://w3id.org/people/ralbertoni/",
+    "foaf:name" : "Riccardo Albertoni"
+  }, {
+    "@id" : "_:b22",
+    "@type" : "foaf:Person",
+    "seeAlso" : "https://orcid.org/0000-0002-3884-3420",
+    "memberOf" : "_:b0",
+    "foaf:name" : "Simon J D Cox",
+    "workInfoHomepage" : "http://people.csiro.au/Simon-Cox"
+  }, {
+    "@id" : "_:b23",
     "@type" : "foaf:Person",
     "foaf:name" : "David Browning"
   }, {
-    "@id" : "_:b5",
+    "@id" : "_:b3",
     "homepage" : "http://ec.europa.eu/dgs/informatics/",
     "foaf:name" : "European Commission, DG DIGIT"
   }, {
-    "@id" : "_:b7",
-    "@type" : "foaf:Person",
-    "foaf:name" : "Anna Odgaard Ingram"
+    "@id" : "_:b4",
+    "@type" : "owl:Restriction",
+    "cardinality" : "1",
+    "onProperty" : "foaf:primaryTopic"
   }, {
-    "@id" : "_:b8",
+    "@id" : "_:b5",
     "@type" : "owl:Class",
     "unionOf" : {
       "@list" : [ "prov:Attribution", "dcat:Relationship" ]
     }
   }, {
+    "@id" : "_:b6",
+    "@type" : "foaf:Person",
+    "foaf:name" : "Anna Odgaard Ingram"
+  }, {
     "@id" : "_:b9",
     "@type" : "foaf:Person",
-    "seeAlso" : "https://orcid.org/0000-0001-9300-2694",
-    "foaf:name" : "Andrea Perego"
+    "seeAlso" : "https://jakub.klímek.com/#me",
+    "homepage" : "https://jakub.klímek.com/",
+    "foaf:name" : "Jakub Klímek"
   }, {
     "@id" : "http://www.w3.org/ns/dcat",
     "@type" : "owl:Ontology",
-    "contributor" : "_:b21",
+    "contributor" : "_:b15",
     "created" : "2020-12-17",
     "creator" : "https://www.w3.org/groups/wg/dx",
     "dcterms:description" : [ {
@@ -137,7 +137,7 @@
     } ],
     "license" : "https://creativecommons.org/licenses/by/4.0/",
     "modified" : [ "2021-04-08", "2020-11-30", "2021-06-23", "2022-05-23", "2023-01-05", "2021-03-09", "2021-09-27", "2022-03-22" ],
-    "publisher" : "_:b15",
+    "publisher" : "_:b11",
     "dcterms:title" : [ {
       "@language" : "cs",
       "@value" : "Slovník pro datové katalogy"
@@ -166,8 +166,8 @@
       "@language" : "da",
       "@value" : "Datakatalogvokabular"
     } ],
-    "editor" : [ "_:b18", "_:b4", "_:b19", "_:b9", "_:b17", "_:b0" ],
-    "translator" : [ "_:b16", "_:b13", "_:b7", "_:b20", "_:b3" ],
+    "editor" : [ "_:b18", "_:b19", "_:b21", "_:b1", "_:b22", "_:b23" ],
+    "translator" : [ "_:b9", "_:b20", "_:b17", "_:b6", "_:b12" ],
     "vann:preferredNamespacePrefix" : "dcat",
     "vann:preferredNamespaceUri" : "http://www.w3.org/ns/dcat#",
     "rdfs:comment" : [ {
@@ -431,7 +431,7 @@
       "@language" : "fr",
       "@value" : "Registre du catalogue"
     } ],
-    "subClassOf" : [ "_:b2", "_:b10" ],
+    "subClassOf" : [ "_:b4", "_:b14" ],
     "skos:definition" : [ {
       "@language" : "it",
       "@value" : "Un record in un catalogo di dati che descrive un singolo dataset o servizio di dati."
@@ -2662,7 +2662,7 @@
       "@language" : "en",
       "@value" : "The function of an entity or agent with respect to another entity or resource."
     } ],
-    "domain" : "_:b8",
+    "domain" : "_:b5",
     "isDefinedBy" : "https://www.w3.org/TR/vocab-dcat-2/",
     "rdfs:label" : [ {
       "@language" : "it",
@@ -2973,6 +2973,33 @@
     }, {
       "@language" : "es",
       "@value" : "Una serie de conjuntos de datos del cuál un conjunto de datos es parte."
+    } ]
+  }, {
+    "@id" : "dcat:isDistributionOf",
+    "isDefinedBy" : "https://www.w3.org/TR/vocab-dcat-3/",
+    "inverseOf" : "dcat:distribution",
+    "skos:changeNote" : [ {
+      "@language" : "it",
+      "@value" : "Nuova proprietà aggiunta in DCAT 3."
+    }, {
+      "@language" : "es",
+      "@value" : "Nueva propiedad agregada en DCAT 3."
+    }, {
+      "@language" : "cs",
+      "@value" : "Nová vlastnost přidaná ve verzi DCAT 3."
+    }, {
+      "@language" : "en",
+      "@value" : "New property added in DCAT 3."
+    } ],
+    "skos:scopeNote" : [ {
+      "@language" : "it",
+      "@value" : "Questa proprietà PUÒ essere usata solo insieme alla sua inversa, e NON DEVE essere usata per sostituirla."
+    }, {
+      "@language" : "es",
+      "@value" : "Esta propiedad inversa PUEDE usarse sólo en combinación con su inversa, y NO PUEDE utilizarse en su reemplazo."
+    }, {
+      "@language" : "en",
+      "@value" : "This property MAY be used only in addition to its inverse, and it MUST NOT be used to replace it."
     } ]
   }, {
     "@id" : "dcat:isVersionOf",
@@ -4705,6 +4732,14 @@
     } ]
   } ],
   "@context" : {
+    "name" : {
+      "@id" : "http://xmlns.com/foaf/0.1/name",
+      "@type" : "http://www.w3.org/2001/XMLSchema#string"
+    },
+    "homepage" : {
+      "@id" : "http://xmlns.com/foaf/0.1/homepage",
+      "@type" : "@id"
+    },
     "domain" : {
       "@id" : "http://www.w3.org/2000/01/rdf-schema#domain",
       "@type" : "@id"
@@ -4741,6 +4776,10 @@
       "@id" : "http://www.w3.org/2000/01/rdf-schema#range",
       "@type" : "@id"
     },
+    "editorialNote" : {
+      "@id" : "http://www.w3.org/2004/02/skos/core#editorialNote",
+      "@type" : "http://www.w3.org/1999/02/22-rdf-syntax-ns#langString"
+    },
     "seeAlso" : {
       "@id" : "http://www.w3.org/2000/01/rdf-schema#seeAlso",
       "@type" : "@id"
@@ -4749,12 +4788,12 @@
       "@id" : "http://www.w3.org/ns/org#memberOf",
       "@type" : "@id"
     },
-    "name" : {
-      "@id" : "http://xmlns.com/foaf/0.1/name",
-      "@type" : "http://www.w3.org/2001/XMLSchema#string"
+    "altLabel" : {
+      "@id" : "http://www.w3.org/2004/02/skos/core#altLabel",
+      "@type" : "http://www.w3.org/1999/02/22-rdf-syntax-ns#langString"
     },
-    "homepage" : {
-      "@id" : "http://xmlns.com/foaf/0.1/homepage",
+    "inverseOf" : {
+      "@id" : "http://www.w3.org/2002/07/owl#inverseOf",
       "@type" : "@id"
     },
     "onProperty" : {
@@ -4765,16 +4804,8 @@
       "@id" : "http://www.w3.org/2002/07/owl#cardinality",
       "@type" : "http://www.w3.org/2001/XMLSchema#nonNegativeInteger"
     },
-    "editorialNote" : {
-      "@id" : "http://www.w3.org/2004/02/skos/core#editorialNote",
-      "@type" : "http://www.w3.org/1999/02/22-rdf-syntax-ns#langString"
-    },
-    "altLabel" : {
-      "@id" : "http://www.w3.org/2004/02/skos/core#altLabel",
-      "@type" : "http://www.w3.org/1999/02/22-rdf-syntax-ns#langString"
-    },
-    "inverseOf" : {
-      "@id" : "http://www.w3.org/2002/07/owl#inverseOf",
+    "equivalentProperty" : {
+      "@id" : "http://www.w3.org/2002/07/owl#equivalentProperty",
       "@type" : "@id"
     },
     "rest" : {
@@ -4785,14 +4816,6 @@
       "@id" : "http://www.w3.org/1999/02/22-rdf-syntax-ns#first",
       "@type" : "@id"
     },
-    "equivalentProperty" : {
-      "@id" : "http://www.w3.org/2002/07/owl#equivalentProperty",
-      "@type" : "@id"
-    },
-    "allValuesFrom" : {
-      "@id" : "http://www.w3.org/2002/07/owl#allValuesFrom",
-      "@type" : "@id"
-    },
     "rangeIncludes" : {
       "@id" : "http://schema.org/rangeIncludes",
       "@type" : "@id"
@@ -4801,9 +4824,21 @@
       "@id" : "http://www.w3.org/2002/07/owl#unionOf",
       "@type" : "@id"
     },
+    "allValuesFrom" : {
+      "@id" : "http://www.w3.org/2002/07/owl#allValuesFrom",
+      "@type" : "@id"
+    },
+    "editor" : {
+      "@id" : "http://purl.org/ontology/bibo/editor",
+      "@type" : "@id"
+    },
     "preferredNamespacePrefix" : {
       "@id" : "http://purl.org/vocab/vann/preferredNamespacePrefix",
       "@type" : "http://www.w3.org/2001/XMLSchema#string"
+    },
+    "translator" : {
+      "@id" : "http://purl.org/ontology/bibo/translator",
+      "@type" : "@id"
     },
     "description" : {
       "@id" : "http://purl.org/dc/terms/description",
@@ -4813,6 +4848,10 @@
       "@id" : "http://purl.org/dc/terms/title",
       "@type" : "http://www.w3.org/1999/02/22-rdf-syntax-ns#langString"
     },
+    "contributor" : {
+      "@id" : "http://purl.org/dc/terms/contributor",
+      "@type" : "@id"
+    },
     "modified" : {
       "@id" : "http://purl.org/dc/terms/modified",
       "@type" : "http://www.w3.org/2001/XMLSchema#date"
@@ -4821,20 +4860,8 @@
       "@id" : "http://www.w3.org/ns/adms#versionNotes",
       "@type" : "http://www.w3.org/1999/02/22-rdf-syntax-ns#langString"
     },
-    "editor" : {
-      "@id" : "http://purl.org/ontology/bibo/editor",
-      "@type" : "@id"
-    },
     "imports" : {
       "@id" : "http://www.w3.org/2002/07/owl#imports",
-      "@type" : "@id"
-    },
-    "translator" : {
-      "@id" : "http://purl.org/ontology/bibo/translator",
-      "@type" : "@id"
-    },
-    "publisher" : {
-      "@id" : "http://purl.org/dc/terms/publisher",
       "@type" : "@id"
     },
     "hasVersion" : {
@@ -4847,6 +4874,10 @@
     },
     "previousVersion" : {
       "@id" : "http://www.w3.org/ns/dcat#previousVersion",
+      "@type" : "@id"
+    },
+    "publisher" : {
+      "@id" : "http://purl.org/dc/terms/publisher",
       "@type" : "@id"
     },
     "creator" : {
@@ -4888,10 +4919,6 @@
     "versionInfo" : {
       "@id" : "http://www.w3.org/2002/07/owl#versionInfo",
       "@type" : "http://www.w3.org/2001/XMLSchema#string"
-    },
-    "contributor" : {
-      "@id" : "http://purl.org/dc/terms/contributor",
-      "@type" : "@id"
     },
     "subClassOf" : {
       "@id" : "http://www.w3.org/2000/01/rdf-schema#subClassOf",

--- a/dcat/rdf/dcat3.rdf
+++ b/dcat/rdf/dcat3.rdf
@@ -18,22 +18,34 @@
     xmlns:foaf="http://xmlns.com/foaf/0.1/"
     xmlns:xsd="http://www.w3.org/2001/XMLSchema#">
   <owl:Ontology rdf:about="http://www.w3.org/ns/dcat">
+    <bibo:editor>
+      <foaf:Person>
+        <foaf:name>David Browning</foaf:name>
+      </foaf:Person>
+    </bibo:editor>
     <rdfs:label xml:lang="cs">Slovník pro datové katalogy</rdfs:label>
     <rdfs:label xml:lang="it">Il vocabolario del catalogo dei dati</rdfs:label>
     <vann:preferredNamespacePrefix>dcat</vann:preferredNamespacePrefix>
+    <bibo:translator>
+      <foaf:Person>
+        <rdfs:seeAlso rdf:resource="https://jakub.klímek.com/#me"/>
+        <foaf:name>Jakub Klímek</foaf:name>
+        <foaf:homepage rdf:resource="https://jakub.klímek.com/"/>
+      </foaf:Person>
+    </bibo:translator>
     <rdfs:comment xml:lang="da">DCAT er et RDF-vokabular som har til formål at understøtte interoperabilitet mellem datakataloger udgivet på nettet. Ved at anvende DCAT til at beskrive datasæt i datakataloger, kan udgivere øge findbarhed og gøre det gøre det lettere for applikationer at anvende metadata fra forskellige kataloger. Derudover understøttes decentraliseret udstilling af kataloger og fødererede datasætsøgninger på tværs af websider. Aggregerede DCAT-metadata kan fungere som fortegnelsesfiler der kan understøtte digital bevaring. DCAT er defineret på http://www.w3.org/TR/vocab-dcat/. Enhver forskel mellem det normative dokument og dette schema er en fejl i dette schema.</rdfs:comment>
     <dcterms:description xml:lang="da">DCAT er et RDF-vokabular som har til formål at understøtte interoperabilitet mellem datakataloger udgivet på nettet. Ved at anvende DCAT til at beskrive datasæt i datakataloger, kan udgivere øge findbarhed og gøre det gøre det lettere for applikationer at anvende metadata fra forskellige kataloger. Derudover understøttes decentraliseret udstilling af kataloger og fødererede datasætsøgninger på tværs af websider. Aggregerede DCAT-metadata kan fungere som fortegnelsesfiler der kan understøtte digital bevaring. DCAT er defineret på http://www.w3.org/TR/vocab-dcat/. Enhver forskel mellem det normative dokument og dette schema er en fejl i dette schema.</dcterms:description>
     <dcterms:title xml:lang="cs">Slovník pro datové katalogy</dcterms:title>
-    <dcterms:description xml:lang="ja">DCATは、ウェブ上で公開されたデータ・カタログ間の相互運用性の促進を目的とするRDFの語彙です。このドキュメントでは、その利用のために、スキーマを定義し、例を提供します。データ・カタログ内のデータセットを記述するためにDCATを用いると、公開者が、発見可能性を増加させ、アプリケーションが複数のカタログのメタデータを容易に利用できるようになります。さらに、カタログの分散公開を可能にし、複数のサイトにまたがるデータセットの統合検索を促進します。集約されたDCATメタデータは、ディジタル保存を促進するためのマニフェスト・ファイルとして使用できます。</dcterms:description>
-    <dcterms:description xml:lang="fr">DCAT est un vocabulaire développé pour faciliter l'interopérabilité entre les jeux de données publiées sur le Web. En utilisant DCAT pour décrire les jeux de données dans les catalogues de données, les fournisseurs de données facilitent leur découverte et permettent que les applications consomment facilement les métadonnées de plusieurs catalogues. Il permet de plus la publication décentralisée des catalogues et facilite la recherche fédérée des données entre plusieurs sites. Les métadonnées DCAT aggrégées peuvent servir comme un manifeste pour faciliter la préservation digitale des ressources. DCAT est définie à l'adresse http://www.w3.org/TR/vocab-dcat/. Toute différence entre ce document normatif et le présent vocabulaire est une erreur dans le vocabulaire.</dcterms:description>
-    <dcterms:title xml:lang="ar">أنطولوجية فهارس قوائم البيانات</dcterms:title>
-    <rdfs:label xml:lang="fr">Le vocabulaire des jeux de données</rdfs:label>
-    <rdfs:comment xml:lang="fr">DCAT est un vocabulaire développé pour faciliter l'interopérabilité entre les jeux de données publiées sur le Web. En utilisant DCAT pour décrire les jeux de données dans les catalogues de données, les fournisseurs de données facilitent leur découverte et permettent que les applications consomment facilement les métadonnées de plusieurs catalogues. Il permet de plus la publication décentralisée des catalogues et facilite la recherche fédérée des données entre plusieurs sites. Les métadonnées DCAT aggrégées peuvent servir comme un manifeste pour faciliter la préservation digitale des ressources. DCAT est définie à l'adresse http://www.w3.org/TR/vocab-dcat/. Toute différence entre ce document normatif et le présent vocabulaire est une erreur dans le vocabulaire.</rdfs:comment>
     <bibo:editor>
       <foaf:Person>
         <foaf:name>Peter Winstanley</foaf:name>
       </foaf:Person>
     </bibo:editor>
+    <dcterms:description xml:lang="ja">DCATは、ウェブ上で公開されたデータ・カタログ間の相互運用性の促進を目的とするRDFの語彙です。このドキュメントでは、その利用のために、スキーマを定義し、例を提供します。データ・カタログ内のデータセットを記述するためにDCATを用いると、公開者が、発見可能性を増加させ、アプリケーションが複数のカタログのメタデータを容易に利用できるようになります。さらに、カタログの分散公開を可能にし、複数のサイトにまたがるデータセットの統合検索を促進します。集約されたDCATメタデータは、ディジタル保存を促進するためのマニフェスト・ファイルとして使用できます。</dcterms:description>
+    <dcterms:description xml:lang="fr">DCAT est un vocabulaire développé pour faciliter l'interopérabilité entre les jeux de données publiées sur le Web. En utilisant DCAT pour décrire les jeux de données dans les catalogues de données, les fournisseurs de données facilitent leur découverte et permettent que les applications consomment facilement les métadonnées de plusieurs catalogues. Il permet de plus la publication décentralisée des catalogues et facilite la recherche fédérée des données entre plusieurs sites. Les métadonnées DCAT aggrégées peuvent servir comme un manifeste pour faciliter la préservation digitale des ressources. DCAT est définie à l'adresse http://www.w3.org/TR/vocab-dcat/. Toute différence entre ce document normatif et le présent vocabulaire est une erreur dans le vocabulaire.</dcterms:description>
+    <dcterms:title xml:lang="ar">أنطولوجية فهارس قوائم البيانات</dcterms:title>
+    <rdfs:label xml:lang="fr">Le vocabulaire des jeux de données</rdfs:label>
+    <rdfs:comment xml:lang="fr">DCAT est un vocabulaire développé pour faciliter l'interopérabilité entre les jeux de données publiées sur le Web. En utilisant DCAT pour décrire les jeux de données dans les catalogues de données, les fournisseurs de données facilitent leur découverte et permettent que les applications consomment facilement les métadonnées de plusieurs catalogues. Il permet de plus la publication décentralisée des catalogues et facilite la recherche fédérée des données entre plusieurs sites. Les métadonnées DCAT aggrégées peuvent servir comme un manifeste pour faciliter la préservation digitale des ressources. DCAT est définie à l'adresse http://www.w3.org/TR/vocab-dcat/. Toute différence entre ce document normatif et le présent vocabulaire est une erreur dans le vocabulaire.</rdfs:comment>
     <dcterms:publisher>
       <org:Organization>
         <rdfs:seeAlso rdf:resource="https://www.wikidata.org/entity/Q37033"/>
@@ -45,74 +57,6 @@
     >2021-04-08</dcterms:modified>
     <adms:versionNotes xml:lang="es">Esta es una copia del vocabulario DCAT 3 disponible en https://www.w3.org/ns/dcat.ttl</adms:versionNotes>
     <dcterms:description xml:lang="el">Το DCAT είναι ένα RDF λεξιλόγιο που σχεδιάσθηκε για να κάνει εφικτή τη διαλειτουργικότητα μεταξύ καταλόγων δεδομένων στον Παγκόσμιο Ιστό. Χρησιμοποιώντας το DCAT για την περιγραφή συνόλων δεδομένων, οι εκδότες αυτών αυξάνουν την ανακαλυψιμότητα και επιτρέπουν στις εφαρμογές την εύκολη κατανάλωση μεταδεδομένων από πολλαπλούς καταλόγους. Επιπλέον, δίνει τη δυνατότητα για αποκεντρωμένη έκδοση και διάθεση καταλόγων και επιτρέπει δυνατότητες ενοποιημένης αναζήτησης μεταξύ διαφορετικών πηγών. Συγκεντρωτικά μεταδεδομένα που έχουν περιγραφεί με το DCAT μπορούν να χρησιμοποιηθούν σαν ένα δηλωτικό αρχείο (manifest file) ώστε να διευκολύνουν την ψηφιακή συντήρηση.</dcterms:description>
-    <bibo:translator>
-      <foaf:Person>
-        <org:memberOf rdf:parseType="Resource">
-          <foaf:name>DERI, NUI Galway</foaf:name>
-          <foaf:homepage rdf:resource="http://www.deri.ie/"/>
-        </org:memberOf>
-        <foaf:name>Fadi Maali</foaf:name>
-      </foaf:Person>
-    </bibo:translator>
-    <bibo:editor>
-      <foaf:Person>
-        <rdfs:seeAlso rdf:resource="https://orcid.org/0000-0001-9300-2694"/>
-        <foaf:name>Andrea Perego</foaf:name>
-      </foaf:Person>
-    </bibo:editor>
-    <dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#date"
-    >2020-11-30</dcterms:modified>
-    <dcterms:description xml:lang="ar">هي أنطولوجية تسهل تبادل البيانات بين مختلف الفهارس على الوب. استخدام هذه الأنطولوجية يساعد على اكتشاف قوائم  البيانات المنشورة على الوب و يمكن التطبيقات المختلفة من الاستفادة أتوماتيكيا من البيانات المتاحة من مختلف الفهارس.</dcterms:description>
-    <rdfs:label xml:lang="es">El vocabulario de catálogo de datos</rdfs:label>
-    <owl:imports rdf:resource="http://www.w3.org/2004/02/skos/core"/>
-    <bibo:translator>
-      <foaf:Person>
-        <org:memberOf rdf:parseType="Resource">
-          <foaf:name>European Commission, DG DIGIT</foaf:name>
-          <foaf:homepage rdf:resource="http://ec.europa.eu/dgs/informatics/"/>
-        </org:memberOf>
-        <foaf:name>Vassilios Peristeras</foaf:name>
-      </foaf:Person>
-    </bibo:translator>
-    <dcterms:description xml:lang="it">DCAT è un vocabolario RDF progettato per facilitare l'interoperabilità tra i cataloghi di dati pubblicati nel Web. Utilizzando DCAT per descrivere i dataset nei cataloghi di dati, i fornitori migliorano la capacità di individuazione dei dati e abilitano le  applicazioni al consumo di dati provenienti da cataloghi differenti. DCAT permette di decentralizzare la pubblicazione di cataloghi e facilita la ricerca federata dei dataset. L'aggregazione dei metadati federati può fungere da file manifesto per facilitare la conservazione digitale. DCAT è definito all'indirizzo http://www.w3.org/TR/vocab-dcat/. Qualsiasi scostamento tra tale definizione normativa e questo schema è da considerarsi un errore di questo schema.</dcterms:description>
-    <dcterms:title xml:lang="el">Το λεξιλόγιο των καταλόγων δεδομένων</dcterms:title>
-    <rdfs:comment xml:lang="cs">DCAT je RDF slovník navržený pro zprostředkování interoperability mezi datovými katalogy publikovanými na Webu. Poskytovatelé dat používáním slovníku DCAT pro popis datových sad v datových katalozích zvyšují jejich dohledatelnost a umožňují aplikacím konzumovat metadata z více katalogů. Dále je umožňena decentralizovaná publikace katalogů a federované dotazování na datové sady napříč katalogy. Agregovaná DCAT metadata mohou také sloužit jako průvodka umožňující digitální uchování informace. DCAT je definován na http://www.w3.org/TR/vocab-dcat/. Jakýkoliv nesoulad mezi odkazovaným dokumentem a tímto schématem je chybou v tomto schématu.</rdfs:comment>
-    <bibo:translator>
-      <foaf:Person>
-        <foaf:name>Shuji Kamitsuna</foaf:name>
-        <foaf:homepage rdf:resource="http://www.asahi-net.or.jp/~ax2s-kmtn/"/>
-      </foaf:Person>
-    </bibo:translator>
-    <skos:editorialNote xml:lang="en">English language definitions updated in this revision in line with ED. Multilingual text unevenly updated.</skos:editorialNote>
-    <rdfs:comment xml:lang="ar">هي أنطولوجية تسهل تبادل البيانات بين مختلف الفهارس على الوب. استخدام هذه الأنطولوجية يساعد على اكتشاف قوائم  البيانات المنشورة على الوب و يمكن التطبيقات المختلفة من الاستفادة أتوماتيكيا من البيانات المتاحة من مختلف الفهارس.</rdfs:comment>
-    <dcterms:title xml:lang="en">The data catalog vocabulary</dcterms:title>
-    <dcat:hasVersion rdf:resource="http://www.w3.org/ns/dcat2"/>
-    <dcterms:title xml:lang="fr">Le vocabulaire des catalogues de données</dcterms:title>
-    <rdfs:label xml:lang="da">Datakatalogvokabular</rdfs:label>
-    <bibo:editor>
-      <foaf:Person>
-        <rdfs:seeAlso rdf:resource="https://orcid.org/0000-0001-5648-2713"/>
-        <foaf:name>Riccardo Albertoni</foaf:name>
-        <foaf:homepage rdf:resource="https://w3id.org/people/ralbertoni/"/>
-      </foaf:Person>
-    </bibo:editor>
-    <dcat:hasVersion rdf:resource="http://www.w3.org/ns/dcat3"/>
-    <dcat:hasCurrentVersion rdf:resource="http://www.w3.org/ns/dcat3"/>
-    <dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#date"
-    >2021-06-23</dcterms:modified>
-    <dcat:previousVersion rdf:resource="http://www.w3.org/ns/dcat2"/>
-    <bibo:editor>
-      <foaf:Person>
-        <rdfs:seeAlso rdf:resource="https://orcid.org/0000-0003-3499-8262"/>
-        <org:memberOf rdf:parseType="Resource">
-          <foaf:name>Science and Technology Facilities Council, UK</foaf:name>
-          <foaf:homepage rdf:resource="http://stfc.ac.uk"/>
-        </org:memberOf>
-        <foaf:name>Alejandra Gonzalez-Beltran</foaf:name>
-        <foaf:homepage rdf:resource="https://agbeltran.github.io"/>
-      </foaf:Person>
-    </bibo:editor>
-    <dcterms:description xml:lang="en">DCAT is an RDF vocabulary designed to facilitate interoperability between data catalogs published on the Web. By using DCAT to describe datasets in data catalogs, publishers increase discoverability and enable applications easily to consume metadata from multiple catalogs. It further enables decentralized publishing of catalogs and facilitates federated dataset search across sites. Aggregated DCAT metadata can serve as a manifest file to facilitate digital preservation. DCAT is defined at http://www.w3.org/TR/vocab-dcat/. Any variance between that normative document and this schema is an error in this schema.</dcterms:description>
     <bibo:editor>
       <foaf:Person>
         <rdfs:seeAlso rdf:resource="https://orcid.org/0000-0002-3884-3420"/>
@@ -124,13 +68,66 @@
         <foaf:name>Simon J D Cox</foaf:name>
       </foaf:Person>
     </bibo:editor>
-    <adms:versionNotes xml:lang="cs">Toto je aktualizovaná kopie slovníku DCAT 3, převzatá z https://www.w3.org/ns/dcat.ttl</adms:versionNotes>
-    <owl:imports rdf:resource="http://www.w3.org/ns/prov-o#"/>
+    <dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#date"
+    >2020-11-30</dcterms:modified>
+    <dcterms:description xml:lang="ar">هي أنطولوجية تسهل تبادل البيانات بين مختلف الفهارس على الوب. استخدام هذه الأنطولوجية يساعد على اكتشاف قوائم  البيانات المنشورة على الوب و يمكن التطبيقات المختلفة من الاستفادة أتوماتيكيا من البيانات المتاحة من مختلف الفهارس.</dcterms:description>
+    <bibo:editor>
+      <foaf:Person>
+        <rdfs:seeAlso rdf:resource="https://orcid.org/0000-0001-9300-2694"/>
+        <foaf:name>Andrea Perego</foaf:name>
+      </foaf:Person>
+    </bibo:editor>
+    <rdfs:label xml:lang="es">El vocabulario de catálogo de datos</rdfs:label>
+    <owl:imports rdf:resource="http://www.w3.org/2004/02/skos/core"/>
+    <dcterms:description xml:lang="it">DCAT è un vocabolario RDF progettato per facilitare l'interoperabilità tra i cataloghi di dati pubblicati nel Web. Utilizzando DCAT per descrivere i dataset nei cataloghi di dati, i fornitori migliorano la capacità di individuazione dei dati e abilitano le  applicazioni al consumo di dati provenienti da cataloghi differenti. DCAT permette di decentralizzare la pubblicazione di cataloghi e facilita la ricerca federata dei dataset. L'aggregazione dei metadati federati può fungere da file manifesto per facilitare la conservazione digitale. DCAT è definito all'indirizzo http://www.w3.org/TR/vocab-dcat/. Qualsiasi scostamento tra tale definizione normativa e questo schema è da considerarsi un errore di questo schema.</dcterms:description>
+    <dcterms:title xml:lang="el">Το λεξιλόγιο των καταλόγων δεδομένων</dcterms:title>
+    <rdfs:comment xml:lang="cs">DCAT je RDF slovník navržený pro zprostředkování interoperability mezi datovými katalogy publikovanými na Webu. Poskytovatelé dat používáním slovníku DCAT pro popis datových sad v datových katalozích zvyšují jejich dohledatelnost a umožňují aplikacím konzumovat metadata z více katalogů. Dále je umožňena decentralizovaná publikace katalogů a federované dotazování na datové sady napříč katalogy. Agregovaná DCAT metadata mohou také sloužit jako průvodka umožňující digitální uchování informace. DCAT je definován na http://www.w3.org/TR/vocab-dcat/. Jakýkoliv nesoulad mezi odkazovaným dokumentem a tímto schématem je chybou v tomto schématu.</rdfs:comment>
+    <skos:editorialNote xml:lang="en">English language definitions updated in this revision in line with ED. Multilingual text unevenly updated.</skos:editorialNote>
+    <bibo:editor>
+      <foaf:Person>
+        <rdfs:seeAlso rdf:resource="https://orcid.org/0000-0001-5648-2713"/>
+        <foaf:name>Riccardo Albertoni</foaf:name>
+        <foaf:homepage rdf:resource="https://w3id.org/people/ralbertoni/"/>
+      </foaf:Person>
+    </bibo:editor>
+    <rdfs:comment xml:lang="ar">هي أنطولوجية تسهل تبادل البيانات بين مختلف الفهارس على الوب. استخدام هذه الأنطولوجية يساعد على اكتشاف قوائم  البيانات المنشورة على الوب و يمكن التطبيقات المختلفة من الاستفادة أتوماتيكيا من البيانات المتاحة من مختلف الفهارس.</rdfs:comment>
+    <dcterms:title xml:lang="en">The data catalog vocabulary</dcterms:title>
+    <bibo:editor>
+      <foaf:Person>
+        <rdfs:seeAlso rdf:resource="https://orcid.org/0000-0003-3499-8262"/>
+        <org:memberOf rdf:parseType="Resource">
+          <foaf:name>Science and Technology Facilities Council, UK</foaf:name>
+          <foaf:homepage rdf:resource="http://stfc.ac.uk"/>
+        </org:memberOf>
+        <foaf:name>Alejandra Gonzalez-Beltran</foaf:name>
+        <foaf:homepage rdf:resource="https://agbeltran.github.io"/>
+      </foaf:Person>
+    </bibo:editor>
+    <dcat:hasVersion rdf:resource="http://www.w3.org/ns/dcat2"/>
     <bibo:translator>
       <foaf:Person>
         <foaf:name>Anna Odgaard Ingram</foaf:name>
       </foaf:Person>
     </bibo:translator>
+    <dcterms:title xml:lang="fr">Le vocabulaire des catalogues de données</dcterms:title>
+    <rdfs:label xml:lang="da">Datakatalogvokabular</rdfs:label>
+    <dcat:hasVersion rdf:resource="http://www.w3.org/ns/dcat3"/>
+    <dcat:hasCurrentVersion rdf:resource="http://www.w3.org/ns/dcat3"/>
+    <dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#date"
+    >2021-06-23</dcterms:modified>
+    <dcat:previousVersion rdf:resource="http://www.w3.org/ns/dcat2"/>
+    <bibo:translator>
+      <foaf:Person>
+        <org:memberOf rdf:parseType="Resource">
+          <foaf:name>European Commission, DG DIGIT</foaf:name>
+          <foaf:homepage rdf:resource="http://ec.europa.eu/dgs/informatics/"/>
+        </org:memberOf>
+        <foaf:name>Vassilios Peristeras</foaf:name>
+      </foaf:Person>
+    </bibo:translator>
+    <dcterms:description xml:lang="en">DCAT is an RDF vocabulary designed to facilitate interoperability between data catalogs published on the Web. By using DCAT to describe datasets in data catalogs, publishers increase discoverability and enable applications easily to consume metadata from multiple catalogs. It further enables decentralized publishing of catalogs and facilitates federated dataset search across sites. Aggregated DCAT metadata can serve as a manifest file to facilitate digital preservation. DCAT is defined at http://www.w3.org/TR/vocab-dcat/. Any variance between that normative document and this schema is an error in this schema.</dcterms:description>
+    <adms:versionNotes xml:lang="cs">Toto je aktualizovaná kopie slovníku DCAT 3, převzatá z https://www.w3.org/ns/dcat.ttl</adms:versionNotes>
+    <owl:imports rdf:resource="http://www.w3.org/ns/prov-o#"/>
     <dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#date"
     >2022-05-23</dcterms:modified>
     <rdfs:comment xml:lang="ja">DCATは、ウェブ上で公開されたデータ・カタログ間の相互運用性の促進を目的とするRDFの語彙です。このドキュメントでは、その利用のために、スキーマを定義し、例を提供します。データ・カタログ内のデータセットを記述するためにDCATを用いると、公開者が、発見可能性を増加させ、アプリケーションが複数のカタログのメタデータを容易に利用できるようになります。さらに、カタログの分散公開を可能にし、複数のサイトにまたがるデータセットの統合検索を促進します。集約されたDCATメタデータは、ディジタル保存を促進するためのマニフェスト・ファイルとして使用できます。</rdfs:comment>
@@ -144,11 +141,25 @@
     <owl:versionIRI rdf:resource="http://www.w3.org/ns/dcat3"/>
     <dcterms:title xml:lang="ja">データ・カタログ語彙（DCAT）</dcterms:title>
     <owl:imports rdf:resource="http://purl.org/dc/terms/"/>
+    <bibo:translator>
+      <foaf:Person>
+        <org:memberOf rdf:parseType="Resource">
+          <foaf:name>DERI, NUI Galway</foaf:name>
+          <foaf:homepage rdf:resource="http://www.deri.ie/"/>
+        </org:memberOf>
+        <foaf:name>Fadi Maali</foaf:name>
+      </foaf:Person>
+    </bibo:translator>
     <foaf:depiction rdf:resource="https://www.w3.org/TR/vocab-dcat-3/images/dcat-all-attributes.svg"/>
     <dcterms:created rdf:datatype="http://www.w3.org/2001/XMLSchema#date"
     >2020-12-17</dcterms:created>
     <dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#date"
     >2021-09-27</dcterms:modified>
+    <rdfs:comment xml:lang="es">DCAT es un vocabulario RDF diseñado para facilitar la interoperabilidad entre catálogos de datos publicados en la Web. Utilizando DCAT para describir datos disponibles en catálogos se aumenta la posibilidad de que sean descubiertos y se permite que las aplicaciones consuman fácilmente los metadatos de varios catálogos.</rdfs:comment>
+    <dcat:version>3</dcat:version>
+    <adms:versionNotes xml:lang="da">Dette er en opdateret kopi af DCAT 3 som er tilgænglig på https://www.w3.org/ns/dcat.ttl</adms:versionNotes>
+    <owl:priorVersion rdf:resource="http://www.w3.org/ns/dcat2"/>
+    <vann:preferredNamespaceUri>http://www.w3.org/ns/dcat#</vann:preferredNamespaceUri>
     <dcterms:contributor>
       <foaf:Person>
         <rdfs:seeAlso rdf:resource="http://makxdekkers.com/makxdekkers.rdf#me"/>
@@ -156,11 +167,6 @@
         <foaf:homepage rdf:resource="http://makxdekkers.com/"/>
       </foaf:Person>
     </dcterms:contributor>
-    <rdfs:comment xml:lang="es">DCAT es un vocabulario RDF diseñado para facilitar la interoperabilidad entre catálogos de datos publicados en la Web. Utilizando DCAT para describir datos disponibles en catálogos se aumenta la posibilidad de que sean descubiertos y se permite que las aplicaciones consuman fácilmente los metadatos de varios catálogos.</rdfs:comment>
-    <dcat:version>3</dcat:version>
-    <adms:versionNotes xml:lang="da">Dette er en opdateret kopi af DCAT 3 som er tilgænglig på https://www.w3.org/ns/dcat.ttl</adms:versionNotes>
-    <owl:priorVersion rdf:resource="http://www.w3.org/ns/dcat2"/>
-    <vann:preferredNamespaceUri>http://www.w3.org/ns/dcat#</vann:preferredNamespaceUri>
     <rdfs:label xml:lang="ar">أنطولوجية فهارس قوائم البيانات</rdfs:label>
     <rdfs:label xml:lang="el">Το λεξιλόγιο των καταλόγων δεδομένων</rdfs:label>
     <adms:versionNotes xml:lang="en">This is an updated copy of the DCAT 3 vocabulary, taken from https://www.w3.org/ns/dcat.ttl</adms:versionNotes>
@@ -171,24 +177,18 @@
     <rdfs:label xml:lang="ja">データ・カタログ語彙（DCAT）</rdfs:label>
     <dcterms:description xml:lang="es">DCAT es un vocabulario RDF diseñado para facilitar la interoperabilidad entre catálogos de datos publicados en la Web. Utilizando DCAT para describir datos disponibles en catálogos se aumenta la posibilidad de que sean descubiertos y se permite que las aplicaciones consuman fácilmente los metadatos de varios catálogos.</dcterms:description>
     <dcterms:description xml:lang="cs">DCAT je RDF slovník navržený pro zprostředkování interoperability mezi datovými katalogy publikovanými na Webu. Poskytovatelé dat používáním slovníku DCAT pro popis datových sad v datových katalozích zvyšují jejich dohledatelnost a umožňují aplikacím konzumovat metadata z více katalogů. Dále je umožňena decentralizovaná publikace katalogů a federované dotazování na datové sady napříč katalogy. Agregovaná DCAT metadata mohou také sloužit jako průvodka umožňující digitální uchování informace. DCAT je definován na http://www.w3.org/TR/vocab-dcat/. Jakýkoliv nesoulad mezi odkazovaným dokumentem a tímto schématem je chybou v tomto schématu.</dcterms:description>
-    <owl:backwardCompatibleWith rdf:resource="http://www.w3.org/ns/dcat2014"/>
     <bibo:translator>
       <foaf:Person>
-        <rdfs:seeAlso rdf:resource="https://jakub.klímek.com/#me"/>
-        <foaf:name>Jakub Klímek</foaf:name>
-        <foaf:homepage rdf:resource="https://jakub.klímek.com/"/>
+        <foaf:name>Shuji Kamitsuna</foaf:name>
+        <foaf:homepage rdf:resource="http://www.asahi-net.or.jp/~ax2s-kmtn/"/>
       </foaf:Person>
     </bibo:translator>
+    <owl:backwardCompatibleWith rdf:resource="http://www.w3.org/ns/dcat2014"/>
     <owl:backwardCompatibleWith rdf:resource="http://www.w3.org/ns/dcat2"/>
     <dcterms:title xml:lang="da">Datakatalogvokabular</dcterms:title>
     <rdfs:comment xml:lang="it">DCAT è un vocabolario RDF progettato per facilitare l'interoperabilità tra i cataloghi di dati pubblicati nel Web. Utilizzando DCAT per descrivere i dataset nei cataloghi di dati, i fornitori migliorano la capacità di individuazione dei dati e abilitano le  applicazioni al consumo di dati provenienti da cataloghi differenti. DCAT permette di decentralizzare la pubblicazione di cataloghi e facilita la ricerca federata dei dataset. L'aggregazione dei metadati federati può fungere da file manifesto per facilitare la conservazione digitale. DCAT è definito all'indirizzo http://www.w3.org/TR/vocab-dcat/. Qualsiasi scostamento tra tale definizione normativa e questo schema è da considerarsi un errore di questo schema.</rdfs:comment>
     <adms:versionNotes xml:lang="it">Questa è una copia aggiornata del vocabolario DCAT 3 disponibile in https://www.w3.org/ns/dcat.ttl</adms:versionNotes>
     <owl:versionInfo>3</owl:versionInfo>
-    <bibo:editor>
-      <foaf:Person>
-        <foaf:name>David Browning</foaf:name>
-      </foaf:Person>
-    </bibo:editor>
     <dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#date"
     >2022-03-22</dcterms:modified>
     <rdfs:label xml:lang="en">The data catalog vocabulary</rdfs:label>
@@ -377,19 +377,20 @@
     <skos:scopeNote xml:lang="ja">このクラスはオプションで、すべてのカタログがそれを用いるとは限りません。これは、データセットに関するメタデータとカタログ内のデータセットのエントリーに関するメタデータとで区別が行われるカタログのために存在しています。例えば、データセットの公開日プロパティーは、公開機関が情報を最初に利用可能とした日付を示しますが、カタログ・レコードの公開日は、データセットがカタログに追加された日付です。両方の日付が異っていたり、後者だけが分かっている場合は、カタログ・レコードに対してのみ公開日を指定すべきです。W3CのPROVオントロジー[prov-o]を用いれば、データセットに対する特定の変更に関連するプロセスやエージェントの詳細などの、さらに詳しい来歴情報の記述が可能となることに注意してください。</skos:scopeNote>
     <rdfs:label xml:lang="ja">カタログ・レコード</rdfs:label>
     <rdfs:label xml:lang="el">Καταγραφή καταλόγου</rdfs:label>
-    <skos:definition xml:lang="cs">Záznam v datovém katalogu popisující jednu datovou sadu či datovou službu.</skos:definition>
-    <skos:definition xml:lang="it">Un record in un catalogo di dati che descrive un singolo dataset o servizio di dati.</skos:definition>
-    <rdfs:comment xml:lang="en">A record in a data catalog, describing the registration of a single dataset or data service.</rdfs:comment>
-    <rdfs:comment xml:lang="ja">1つのデータセットを記述したデータ・カタログ内のレコード。</rdfs:comment>
-    <rdfs:label xml:lang="ar">سجل</rdfs:label>
     <rdfs:subClassOf>
       <owl:Restriction>
         <owl:onProperty>
           <owl:ObjectProperty rdf:about="http://xmlns.com/foaf/0.1/primaryTopic"/>
         </owl:onProperty>
-        <owl:allValuesFrom rdf:resource="http://www.w3.org/ns/dcat#Resource"/>
+        <owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger"
+        >1</owl:cardinality>
       </owl:Restriction>
     </rdfs:subClassOf>
+    <skos:definition xml:lang="it">Un record in un catalogo di dati che descrive un singolo dataset o servizio di dati.</skos:definition>
+    <rdfs:comment xml:lang="en">A record in a data catalog, describing the registration of a single dataset or data service.</rdfs:comment>
+    <rdfs:comment xml:lang="ja">1つのデータセットを記述したデータ・カタログ内のレコード。</rdfs:comment>
+    <rdfs:label xml:lang="ar">سجل</rdfs:label>
+    <skos:definition xml:lang="cs">Záznam v datovém katalogu popisující jednu datovou sadu či datovou službu.</skos:definition>
     <rdfs:label xml:lang="es">Registro del catálogo</rdfs:label>
     <rdfs:label xml:lang="it">Record di catalogo</rdfs:label>
     <skos:scopeNote xml:lang="it">Questa classe è opzionale e non tutti i cataloghi la utilizzeranno. Esiste per cataloghi in cui si opera una distinzione tra i metadati relativi al dataset ed i metadati relativi alla gestione del dataset nel catalogo. Ad esempio, la  proprietà per indicare la data di pubblicazione del dataset rifletterà la data in cui l'informazione è stata originariamente messa a disposizione dalla casa editrice, mentre la data di pubblicazione per il record nel catalogo rifletterà la data in cui il dataset è stato aggiunto al catalogo. Nei casi dove solo quest'ultima sia nota, si utilizzerà esclusivamente la data di  pubblicazione relativa al record del catalogo. Si noti che l'Ontologia W3C PROV permette di descrivere ulteriori informazioni sulla provenienza, quali i dettagli del processo, la procedura e l'agente coinvolto in una particolare modifica di un dataset.</skos:scopeNote>
@@ -411,16 +412,15 @@
     <rdfs:isDefinedBy rdf:resource="http://www.w3.org/TR/vocab-dcat/"/>
     <rdfs:comment xml:lang="es">Un registro en un catálogo de datos que describe un solo conjunto de datos o un servicio de datos.</rdfs:comment>
     <skos:scopeNote xml:lang="en">This class is optional and not all catalogs will use it. It exists for catalogs where a distinction is made between metadata about a dataset or data service and metadata about the entry for the dataset or data service in the catalog. For example, the publication date property of the dataset reflects the date when the information was originally made available by the publishing agency, while the publication date of the catalog record is the date when the dataset was added to the catalog. In cases where both dates differ, or where only the latter is known, the publication date should only be specified for the catalog record. Notice that the W3C PROV Ontology allows describing further provenance information such as the details of the process and the agent involved in a particular change to a dataset.</skos:scopeNote>
-    <skos:scopeNote xml:lang="el">Αυτή η κλάση είναι προαιρετική και δεν χρησιμοποιείται από όλους τους καταλόγους. Υπάρχει για τις περιπτώσεις καταλόγων όπου γίνεται διαχωρισμός μεταξύ των μεταδεδομένων για το σύνολο των δεδομένων και των μεταδεδομένων για την καταγραφή του συνόλου δεδομένων εντός του καταλόγου. Για παράδειγμα, η ιδιότητα της ημερομηνίας δημοσίευσης του συνόλου δεδομένων δείχνει την ημερομηνία κατά την οποία οι πληροφορίες έγιναν διαθέσιμες από τον φορέα δημοσίευσης, ενώ η ημερομηνία δημοσίευσης της καταγραφής του καταλόγου δείχνει την ημερομηνία που το σύνολο δεδομένων προστέθηκε στον κατάλογο. Σε περιπτώσεις που οι δύο ημερομηνίες διαφέρουν, ή που μόνο η τελευταία είναι γνωστή, η ημερομηνία δημοσίευσης θα πρέπει να δίνεται για την καταγραφή του καταλόγου. Να σημειωθεί πως η οντολογία W3C PROV επιτρέπει την περιγραφή επιπλέον πληροφοριών ιστορικού όπως λεπτομέρειες για τη διαδικασία και τον δράστη που εμπλέκονται σε μία συγκεκριμένη αλλαγή εντός του συνόλου δεδομένων.</skos:scopeNote>
     <rdfs:subClassOf>
       <owl:Restriction>
         <owl:onProperty>
           <owl:ObjectProperty rdf:about="http://xmlns.com/foaf/0.1/primaryTopic"/>
         </owl:onProperty>
-        <owl:cardinality rdf:datatype="http://www.w3.org/2001/XMLSchema#nonNegativeInteger"
-        >1</owl:cardinality>
+        <owl:allValuesFrom rdf:resource="http://www.w3.org/ns/dcat#Resource"/>
       </owl:Restriction>
     </rdfs:subClassOf>
+    <skos:scopeNote xml:lang="el">Αυτή η κλάση είναι προαιρετική και δεν χρησιμοποιείται από όλους τους καταλόγους. Υπάρχει για τις περιπτώσεις καταλόγων όπου γίνεται διαχωρισμός μεταξύ των μεταδεδομένων για το σύνολο των δεδομένων και των μεταδεδομένων για την καταγραφή του συνόλου δεδομένων εντός του καταλόγου. Για παράδειγμα, η ιδιότητα της ημερομηνίας δημοσίευσης του συνόλου δεδομένων δείχνει την ημερομηνία κατά την οποία οι πληροφορίες έγιναν διαθέσιμες από τον φορέα δημοσίευσης, ενώ η ημερομηνία δημοσίευσης της καταγραφής του καταλόγου δείχνει την ημερομηνία που το σύνολο δεδομένων προστέθηκε στον κατάλογο. Σε περιπτώσεις που οι δύο ημερομηνίες διαφέρουν, ή που μόνο η τελευταία είναι γνωστή, η ημερομηνία δημοσίευσης θα πρέπει να δίνεται για την καταγραφή του καταλόγου. Να σημειωθεί πως η οντολογία W3C PROV επιτρέπει την περιγραφή επιπλέον πληροφοριών ιστορικού όπως λεπτομέρειες για τη διαδικασία και τον δράστη που εμπλέκονται σε μία συγκεκριμένη αλλαγή εντός του συνόλου δεδομένων.</skos:scopeNote>
     <skos:scopeNote xml:lang="da">Denne klasse er valgfri og ikke alle kataloger vil anvende denne klasse. Den kan anvendes i de kataloger hvor der skelnes mellem metadata om datasættet eller datatjenesten og metadata om selve posten til registreringen af datasættet eller datatjenesten i kataloget. Udgivelsesdatoen for datasættet afspejler for eksempel den dato hvor informationerne oprindeligt blev gjort tilgængelige af udgiveren, hvorimod udgivelsesdatoen for katalogposten er den dato hvor datasættet blev føjet til kataloget. I de tilfælde hvor de to datoer er forskellige eller hvor blot sidstnævnte er kendt, bør udgivelsesdatoen kun angives for katalogposten. Bemærk at W3Cs PROV ontologi gør til muligt at tilføje yderligere proveniensoplysninger eksempelvis om processen eller aktøren involveret i en given ændring af datasættet.</skos:scopeNote>
     <skos:definition xml:lang="el">Μία καταγραφή ενός καταλόγου, η οποία περιγράφει ένα συγκεκριμένο σύνολο δεδομένων.</skos:definition>
     <rdfs:label xml:lang="fr">Registre du catalogue</rdfs:label>
@@ -973,14 +973,6 @@
     <skos:editorialNote xml:lang="cs">Přidáno do DCAT pro doplnění vlastnosti prov:hadRole (jejíž užití je omezeno na role v kontextu aktivity, s definičním oborem prov:Association).</skos:editorialNote>
     <skos:changeNote xml:lang="it">Nuova proprietà aggiunta in DCAT 2.</skos:changeNote>
     <skos:definition xml:lang="da">Den funktion en entitet eller aktør har i forhold til en anden ressource.</skos:definition>
-    <rdfs:domain>
-      <owl:Class>
-        <owl:unionOf rdf:parseType="Collection">
-          <rdf:Description rdf:about="http://www.w3.org/ns/prov#Attribution"/>
-          <rdfs:Class rdf:about="http://www.w3.org/ns/dcat#Relationship"/>
-        </owl:unionOf>
-      </owl:Class>
-    </rdfs:domain>
     <rdfs:isDefinedBy rdf:resource="https://www.w3.org/TR/vocab-dcat-2/"/>
     <skos:editorialNote xml:lang="da">Introduceret i DCAT for at supplere prov:hadRole (hvis anvendelse er begrænset til roller i forbindelse med en aktivitet med domænet prov:Association).</skos:editorialNote>
     <rdfs:comment xml:lang="it">La funzione di un'entità o un agente rispetto ad un'altra entità o risorsa.</rdfs:comment>
@@ -1008,6 +1000,14 @@
     <rdfs:range rdf:resource="http://www.w3.org/ns/dcat#Role"/>
     <skos:scopeNote xml:lang="es">Puede usarse en una atribución cualificada para especificar el rol de un Agente con respecto a una Entidad. Se recomienda que el valor sea de un vocabulario controlado de roles de agentes, como por ejemplo http://registry.it.csiro.au/def/isotc211/CI_RoleCode.</skos:scopeNote>
     <skos:editorialNote xml:lang="es">Agregada en DCAT para complementar prov:hadRole (cuyo uso está limitado a roles en el contexto de una actividad, con dominio prov:Association.</skos:editorialNote>
+    <rdfs:domain>
+      <owl:Class>
+        <owl:unionOf rdf:parseType="Collection">
+          <rdf:Description rdf:about="http://www.w3.org/ns/prov#Attribution"/>
+          <rdfs:Class rdf:about="http://www.w3.org/ns/dcat#Relationship"/>
+        </owl:unionOf>
+      </owl:Class>
+    </rdfs:domain>
     <skos:scopeNote xml:lang="da">Kan vendes ved kvalificerede krediteringer til at angive en aktørs rolle i forhold en entitet. Det anbefales at værdierne styres som et kontrolleret udfaldsrum med aktørroller, såsom http://registry.it.csiro.au/def/isotc211/CI_RoleCode.</skos:scopeNote>
     <skos:scopeNote xml:lang="es">Puede usarse en una atribución cualificada para especificar el rol de una Entidad con respecto a otra Entidad. Se recomienda que su valor se tome de un vocabulario controlado de roles de entidades como por ejemplo: ISO 19115 DS_AssociationTypeCode http://registry.it.csiro.au/def/isotc211/DS_AssociationTypeCode; IANA Registry of Link Relations https://www.iana.org/assignments/link-relation; esquema de metadatos de DataCite; MARC relators https://id.loc.gov/vocabulary/relators.</skos:scopeNote>
     <skos:changeNote xml:lang="cs">Nová vlastnost přidaná ve verzi DCAT 2.</skos:changeNote>
@@ -1199,12 +1199,12 @@
     <rdfs:domain rdf:resource="http://www.w3.org/ns/dcat#Distribution"/>
     <skos:editorialNote xml:lang="en">rdfs:label, rdfs:comment and skos:scopeNote have been modified. Non-english versions except for Italian must be updated.</skos:editorialNote>
     <skos:scopeNote xml:lang="da">Hvis en eller flere distributioner kun er tilgængelige via en destinationsside (dvs. en URL til direkte download er ikke kendt), så bør destinationssidelinket gentages som adgangsadresse for distributionen.</skos:scopeNote>
-    <rdfs:comment xml:lang="es">Puede ser cualquier tipo de URL que de acceso a una distribución del conjunto de datos, e.g., página de destino, descarga, URL feed, punto de acceso SPARQL. Esta propriedad se debe usar cuando su catálogo de datos no tiene información sobre donde está o cuando no se puede descargar.</rdfs:comment>
-    <rdfs:label xml:lang="fr">URL d'accès</rdfs:label>
     <owl:propertyChainAxiom rdf:parseType="Collection">
       <owl:ObjectProperty rdf:about="http://www.w3.org/ns/dcat#accessService"/>
       <owl:ObjectProperty rdf:about="http://www.w3.org/ns/dcat#endpointURL"/>
     </owl:propertyChainAxiom>
+    <rdfs:comment xml:lang="es">Puede ser cualquier tipo de URL que de acceso a una distribución del conjunto de datos, e.g., página de destino, descarga, URL feed, punto de acceso SPARQL. Esta propriedad se debe usar cuando su catálogo de datos no tiene información sobre donde está o cuando no se puede descargar.</rdfs:comment>
+    <rdfs:label xml:lang="fr">URL d'accès</rdfs:label>
     <skos:definition xml:lang="it">Un URL di una risorsa che consente di accedere a una distribuzione del set di dati. Per esempio, pagina di destinazione, feed, endpoint SPARQL. Da utilizzare per tutti i casi, tranne  quando  si tratta di un semplice link per il download nel qual caso è preferito downloadURL.</skos:definition>
     <skos:scopeNote xml:lang="cs">Pokud jsou distribuce přístupné pouze přes vstupní stránku (tj. URL pro přímé stažení nejsou známa), pak by URL přístupové stránky mělo být duplikováno ve vlastnosti distribuce accessURL.</skos:scopeNote>
     <rdfs:comment xml:lang="da">En URL for en ressource som giver adgang til en repræsentation af datsættet. Fx destinationsside, feed, SPARQL-endpoint. Anvendes i alle sammenhænge undtagen til angivelse af et simpelt download link hvor anvendelse af egenskaben downloadURL foretrækkes.</rdfs:comment>
@@ -1782,6 +1782,17 @@
     <skos:changeNote xml:lang="en">New property added in DCAT 3.</skos:changeNote>
     <rdfs:isDefinedBy rdf:resource="https://www.w3.org/TR/vocab-dcat-3/"/>
     <owl:inverseOf rdf:resource="http://www.w3.org/ns/dcat#prev"/>
+  </rdf:Description>
+  <rdf:Description rdf:about="http://www.w3.org/ns/dcat#isDistributionOf">
+    <skos:scopeNote xml:lang="it">Questa proprietà PUÒ essere usata solo insieme alla sua inversa, e NON DEVE essere usata per sostituirla.</skos:scopeNote>
+    <skos:scopeNote xml:lang="es">Esta propiedad inversa PUEDE usarse sólo en combinación con su inversa, y NO PUEDE utilizarse en su reemplazo.</skos:scopeNote>
+    <skos:scopeNote xml:lang="en">This property MAY be used only in addition to its inverse, and it MUST NOT be used to replace it.</skos:scopeNote>
+    <skos:changeNote xml:lang="it">Nuova proprietà aggiunta in DCAT 3.</skos:changeNote>
+    <skos:changeNote xml:lang="es">Nueva propiedad agregada en DCAT 3.</skos:changeNote>
+    <skos:changeNote xml:lang="cs">Nová vlastnost přidaná ve verzi DCAT 3.</skos:changeNote>
+    <skos:changeNote xml:lang="en">New property added in DCAT 3.</skos:changeNote>
+    <rdfs:isDefinedBy rdf:resource="https://www.w3.org/TR/vocab-dcat-3/"/>
+    <owl:inverseOf rdf:resource="http://www.w3.org/ns/dcat#distribution"/>
   </rdf:Description>
   <rdf:Description rdf:about="http://www.w3.org/ns/dcat#isVersionOf">
     <skos:scopeNote xml:lang="it">Questa proprietà PUÒ essere usata solo insieme alla sua inversa, e NON DEVE essere usata per sostituirla.</skos:scopeNote>

--- a/dcat/rdf/dcat3.ttl
+++ b/dcat/rdf/dcat3.ttl
@@ -892,6 +892,7 @@ dcat:distribution
   skos:definition "En tilgængelig repræsentation af datasættet."@da ;
   skos:editorialNote "Status: English Definition text modified by DCAT revision team, translations pending (except for Italian, Spanish and Czech)."@en ;
 .
+
 dcat:downloadURL
   a rdf:Property ;
   a owl:ObjectProperty ;
@@ -1153,6 +1154,16 @@ dcat:hadRole
   skos:scopeNote "Può essere utilizzata in una relazione qualificata per specificare il ruolo di un'entità rispetto a un'altra entità. Si raccomanda che il valore sia preso da un vocabolario controllato di ruoli di entità come ISO 19115 DS_AssociationTypeCode http://registry.it.csiro.au/def/isotc211/DS_AssociationTypeCode, IANA Registry of Link Relations https://www.iana.org/assignments/link-relation, DataCite metadata schema, o MARC relators https://id.loc.gov/vocabulary/relators."@it ;
   skos:scopeNote "Può essere utilizzato in un'attribuzione qualificata per specificare il ruolo di un agente rispetto a un'entità. Si raccomanda che il valore sia preso da un vocabolario controllato di ruoli di agente, come ad esempio http://registry.it.csiro.au/def/isotc211/CI_RoleCode."@it ;
   skos:scopeNote "Kan vendes ved kvalificerede krediteringer til at angive en aktørs rolle i forhold en entitet. Det anbefales at værdierne styres som et kontrolleret udfaldsrum med aktørroller, såsom http://registry.it.csiro.au/def/isotc211/CI_RoleCode."@da ;
+.
+dcat:isDistributionOf owl:inverseOf dcat:distribution ;
+  rdfs:isDefinedBy <https://www.w3.org/TR/vocab-dcat-3/> ;
+  skos:changeNote "New property added in DCAT 3."@en ;
+  skos:changeNote "Nová vlastnost přidaná ve verzi DCAT 3."@cs ;
+  skos:changeNote "Nueva propiedad agregada en DCAT 3."@es ;
+  skos:changeNote "Nuova proprietà aggiunta in DCAT 3."@it ;
+  skos:scopeNote "This property MAY be used only in addition to its inverse, and it MUST NOT be used to replace it."@en ;
+  skos:scopeNote "Esta propiedad inversa PUEDE usarse sólo en combinación con su inversa, y NO PUEDE utilizarse en su reemplazo."@es ;
+  skos:scopeNote "Questa proprietà PUÒ essere usata solo insieme alla sua inversa, e NON DEVE essere usata per sostituirla."@it ;
 .
 dcat:isVersionOf owl:inverseOf dcat:hasVersion ;
   rdfs:isDefinedBy <https://www.w3.org/TR/vocab-dcat-3/> ;


### PR DESCRIPTION
Closes #1322

Following up on the discussion in #1322, we add dcat:isDistributionOf in the table of inverse property and in the RDF serialization. So that the inverse of dcat:distribution property can be used when in dire need.
