### PR TITLE
fixing inconsistent property label for language in catalog

### DIFF
--- a/dcat/index.html
+++ b/dcat/index.html
@@ -838,7 +838,7 @@ ex:table-service-005
             <li><a href="#Property:resource_keyword">keyword/tag</a></li>
             <li><a href="#Property:resource_landing_page">landing page</a></li>
             <li><a href="#Property:resource_license">license</a></li>
-            <li><a href="#Property:resource_language">catalog language</a></li>
+            <li><a href="#Property:resource_language">language</a></li>
             <li><a href="#Property:resource_relation">relation</a></li>
             <li><a href="#Property:resource_rights">rights</a></li>
             <li><a href="#Property:resource_qualified_relation">qualified relation</a></li>


### PR DESCRIPTION
This PR closes #1350 

I have checked that no reference to the subclass label occurs in the list of inherited properties, nor do class labels appear in the properties paragraph title defined in the "superclass".
I could find only "catalog language" as inconsistent.

Shall we merge this PR and close the issue?