### PR TITLE
PR to fix 1517

### DIFF
--- a/dcat/examples/vocab-dcat-3/classifying-types.jsonld
+++ b/dcat/examples/vocab-dcat-3/classifying-types.jsonld
@@ -1,25 +1,5 @@
 {
   "@graph" : [ {
-    "@id" : "http://registry.it.csiro.au/def/datacite/resourceType/Text",
-    "dcterms:source" : {
-      "@language" : "en",
-      "@value" : "DataCite resource types"
-    },
-    "rdfs:label" : {
-      "@language" : "en",
-      "@value" : "Text"
-    }
-  }, {
-    "@id" : "http://registry.it.csiro.au/def/re3data/contentType/doc",
-    "dcterms:source" : {
-      "@language" : "en",
-      "@value" : "Re3data content types"
-    },
-    "rdfs:label" : {
-      "@language" : "en",
-      "@value" : "Standard office documents"
-    }
-  }, {
     "@id" : "ex:classifying-types",
     "@type" : "owl:Ontology",
     "imports" : "http://www.w3.org/ns/dcat"
@@ -34,7 +14,27 @@
   }, {
     "@id" : "ex:dataset-001-3",
     "@type" : "dcat:Dataset",
-    "type" : [ "http://registry.it.csiro.au/def/re3data/contentType/database", "http://registry.it.csiro.au/def/datacite/resourceType/Dataset", "http://id.loc.gov/vocabulary/marcgt/dtb", "http://purl.org/dc/dcmitype/Dataset" ]
+    "type" : [ "urn:example:re3data/contentType/database", "urn:example:datacite/resourceType/Dataset", "http://id.loc.gov/vocabulary/marcgt/dtb", "http://purl.org/dc/dcmitype/Dataset" ]
+  }, {
+    "@id" : "urn:example:datacite/resourceType/Text",
+    "dcterms:source" : {
+      "@language" : "en",
+      "@value" : "DataCite resource types"
+    },
+    "rdfs:label" : {
+      "@language" : "en",
+      "@value" : "Text"
+    }
+  }, {
+    "@id" : "urn:example:re3data/contentType/doc",
+    "dcterms:source" : {
+      "@language" : "en",
+      "@value" : "Re3data content types"
+    },
+    "rdfs:label" : {
+      "@language" : "en",
+      "@value" : "Standard office documents"
+    }
   } ],
   "@context" : {
     "label" : {

--- a/dcat/examples/vocab-dcat-3/classifying-types.rdf
+++ b/dcat/examples/vocab-dcat-3/classifying-types.rdf
@@ -19,21 +19,21 @@
   <dcat:Dataset rdf:about="https://dcat.example.org/dataset-001-2">
     <dcterms:type rdf:resource="http://id.loc.gov/vocabulary/marcgt/dtb"/>
   </dcat:Dataset>
-  <rdf:Description rdf:about="http://registry.it.csiro.au/def/datacite/resourceType/Text">
-    <rdfs:label xml:lang="en">Text</rdfs:label>
-    <dcterms:source xml:lang="en">DataCite resource types</dcterms:source>
-  </rdf:Description>
   <dcat:Dataset rdf:about="https://dcat.example.org/dataset-001-3">
-    <dcterms:type rdf:resource="http://registry.it.csiro.au/def/re3data/contentType/database"/>
-    <dcterms:type rdf:resource="http://registry.it.csiro.au/def/datacite/resourceType/Dataset"/>
+    <dcterms:type rdf:resource="urn:example:re3data/contentType/database"/>
+    <dcterms:type rdf:resource="urn:example:datacite/resourceType/Dataset"/>
     <dcterms:type rdf:resource="http://id.loc.gov/vocabulary/marcgt/dtb"/>
     <dcterms:type rdf:resource="http://purl.org/dc/dcmitype/Dataset"/>
   </dcat:Dataset>
-  <rdf:Description rdf:about="http://registry.it.csiro.au/def/re3data/contentType/doc">
-    <rdfs:label xml:lang="en">Standard office documents</rdfs:label>
-    <dcterms:source xml:lang="en">Re3data content types</dcterms:source>
-  </rdf:Description>
   <dcat:Dataset rdf:about="https://dcat.example.org/dataset-001-1">
     <dcterms:type rdf:resource="http://purl.org/dc/dcmitype/Dataset"/>
   </dcat:Dataset>
+  <rdf:Description rdf:about="urn:example:datacite/resourceType/Text">
+    <rdfs:label xml:lang="en">Text</rdfs:label>
+    <dcterms:source xml:lang="en">DataCite resource types</dcterms:source>
+  </rdf:Description>
+  <rdf:Description rdf:about="urn:example:re3data/contentType/doc">
+    <rdfs:label xml:lang="en">Standard office documents</rdfs:label>
+    <dcterms:source xml:lang="en">Re3data content types</dcterms:source>
+  </rdf:Description>
 </rdf:RDF>

--- a/dcat/examples/vocab-dcat-3/classifying-types.ttl
+++ b/dcat/examples/vocab-dcat-3/classifying-types.ttl
@@ -16,11 +16,11 @@
 @prefix w3cgeo: <http://www.w3.org/2003/01/geo/wgs84_pos#> .
 @prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
 
-<http://registry.it.csiro.au/def/datacite/resourceType/Text>
+<urn:example:datacite/resourceType/Text>
   dcterms:source "DataCite resource types"@en ;
   rdfs:label "Text"@en ;
 .
-<http://registry.it.csiro.au/def/re3data/contentType/doc>
+<urn:example:re3data/contentType/doc>
   dcterms:source "Re3data content types"@en ;
   rdfs:label "Standard office documents"@en ;
 .
@@ -40,6 +40,6 @@ ex:dataset-001-3
   a dcat:Dataset ;
   dcterms:type <http://purl.org/dc/dcmitype/Dataset> ;
   dcterms:type <http://id.loc.gov/vocabulary/marcgt/dtb> ;
-  dcterms:type <http://registry.it.csiro.au/def/datacite/resourceType/Dataset> ;
-  dcterms:type <http://registry.it.csiro.au/def/re3data/contentType/database> ;
+  dcterms:type <urn:example:datacite/resourceType/Dataset> ;
+  dcterms:type <urn:example:re3data/contentType/database> ;
 .

--- a/dcat/index.html
+++ b/dcat/index.html
@@ -563,16 +563,16 @@ ex:dataset-001
   rdf:type  dcat:Dataset ;
   dcterms:type  &lt;http://purl.org/dc/dcmitype/Dataset&gt; ;
   dcterms:type  &lt;http://id.loc.gov/vocabulary/marcgt/dtb&gt; ;
-  dcterms:type  &lt;http://registry.it.csiro.au/def/datacite/resourceType/Dataset&gt; ;
-  dcterms:type  &lt;http://registry.it.csiro.au/def/re3data/contentType/database&gt; ;
+  dcterms:type  &lt;urn:example:datacite/resourceType/Dataset&gt; ;
+  dcterms:type  &lt;urn:example:re3data/contentType/database&gt; ;
 .
 
-&lt;http://registry.it.csiro.au/def/datacite/resourceType/Dataset&gt;
+&lt;urn:example:datacite/resourceType/Dataset&gt;
   rdfs:label "Dataset"@en ;
   dcterms:source [ rdfs:label "DataCite resource types"@en ] ;
   .
 
-&lt;http://registry.it.csiro.au/def/re3data/contentType/database&gt;
+&lt;urn:example:re3data/contentType/database&gt;
   rdfs:label "Database"@en ;
   dcterms:source [ rdfs:label "Re3data content types"@en ] ;
   .</pre>
@@ -5869,19 +5869,19 @@ ex:DS987
   prov:qualifiedAttribution [
     a prov:Attribution ;
     prov:agent &lt;https://www.ala.org.au/&gt; ;
-    dcat:hadRole &lt;http://registry.it.csiro.au/def/isotc211/CI_RoleCode/distributor&gt;
+    dcat:hadRole &lt;urn:example:isotc211/CI_RoleCode/distributor&gt;
   ] ;
   prov:qualifiedAttribution [
     a prov:Attribution ;
     prov:agent &lt;https://www.education.gov.au/&gt; ;
-    dcat:hadRole &lt;http://registry.it.csiro.au/def/isotc211/CI_RoleCode/funder&gt;
+    dcat:hadRole &lt;urn:example:isotc211/CI_RoleCode/funder&gt;
   ] ;
 .
 </pre>
 </aside>
 
 <p>
-  In <a href="#ex-qualified-attribution"></a> the roles are denoted by IRIs from a (non-normative) <a href="http://registry.it.csiro.au/def/isotc211/CI_RoleCode">linked data representation</a> of the <a href="https://standards.iso.org/iso/19115/resources/Codelists/gml/CI_RoleCode.xml"><code>CI_RoleCode</code></a> codelist from [[?ISO-19115-1]].
+  In <a href="#ex-qualified-attribution"></a> the roles are denoted by IRIs from a non-normative, non-dereferenceable representation of the <a href="https://standards.iso.org/iso/19115/resources/Codelists/gml/CI_RoleCode.xml"><code>CI_RoleCode</code></a> codelist from [[?ISO-19115-1]] (e.g., URN like  <code>urn:example:isotc211/CI_RoleCode</code>). Linked data dereferenceable and normative representations should be preferred when available.
 </p>
 
 <aside class="note">
@@ -5926,7 +5926,7 @@ ex:Test543L
   dcat:qualifiedRelation [
     a dcat:Relationship ;
     dcterms:relation &lt;http://dcat.example.org/Test543R&gt; ;
-    dcat:hadRole &lt;http://registry.it.csiro.au/def/isotc211/DS_AssociationTypeCode/stereoMate&gt;
+    dcat:hadRole &lt;urn:example:isotc211/DS_AssociationTypeCode/stereoMate&gt;
   ] ;
 .
 </pre>


### PR DESCRIPTION
Closes #1517

PREV: https://raw.githack.com/w3c/dxwg/dcat-issue-1517/dcat/index.html
DIFF: https://services.w3.org/htmldiff?doc1=https://w3c.github.io/dxwg/dcat/&doc2=https://raw.githack.com/w3c/dxwg/dcat-issue-1517/dcat/index.html


Following @pchampin' suggestions, it replaces broken URI starting with http://registry.it.csiro.au to urn:example. In particular,
Current URI | replacement
-- | --
http://registry.it.csiro.au/def/datacite/resourceType/Dataset | urn:example:datacite/resourceType/Dataset
http://registry.it.csiro.au/def/re3data/contentType/database | urn:example:re3data/contentType/database
http://registry.it.csiro.au/def/isotc211/CI_RoleCode/distributor | urn:example:isotc211/CI_RoleCode/distributor 
http://registry.it.csiro.au/def/isotc211/CI_RoleCode/funder | urn:example:isotc211/CI_RoleCode/funder 
http://registry.it.csiro.au/def/isotc211/DS_AssociationTypeCode/stereoMate | urn:example:isotc211/DS_AssociationTypeCode/stereoMate

Moreover, it adjusts the comment following example [Relationships between datasets and agents](https://raw.githack.com/w3c/dxwg/dcat-issue-1517/dcat/index.html#ex-qualified-attribution).