### PR TITLE
fix issue https://github.com/w3c/dx-connegp/issues/40

### DIFF
--- a/connegp/index.html
+++ b/connegp/index.html
@@ -1,0 +1,8 @@
+<html>
+<head>
+<meta HTTP-EQUIV="refresh" CONTENT="0;url=https://w3c.github.io/dx-connegp/connegp/">
+</meta>
+<body>
+This file has moved to <a href="https://w3c.github.io/dx-connegp/connegp/">https://w3c.github.io/dx-connegp/connegp/</a>
+</body>
+</html>


### PR DESCRIPTION
the URL https://w3c.github.io/dxwg/connegp/ is used in some places to refer to the editor's draft (I assume it was first located in this repo, before being moved to its own repo).

This PR creates a "redirect" from the old URL to the new one, in order to "fix" the broken links that still exist out there.