### PR TITLE
adjusted the wrong link to spdx 2.2

### DIFF
--- a/dcat/config.js
+++ b/dcat/config.js
@@ -330,7 +330,7 @@ var respecConfig = {
 			date:"16 March 2015"
         },
         "SPDX":{
-          "href":"http://spdx.org/rdf/terms#",
+          "href":"https://spdx.org/rdf/spdx-terms-v2.2/",
           "title":"SPDX 2.2",
           "publisher":"SPDX"
         },        


### PR DESCRIPTION
Proposal to fix #1592.

This PR replaces the generic SPDX IRI pointing to the very last version (lately 2.3) with the 
ver 2.2 URL, to maintain the version we as a group considered during the specification.