### PR TITLE
adding History of changes since CR

### DIFF
--- a/dcat/index.html
+++ b/dcat/index.html
@@ -6789,7 +6789,7 @@ ga-courts:jc-wms
     <li>
 <p>Editorial fixes as suggested in Issues <a href="https://github.com/w3c/dxwg/issues/1581">#1581</a>, <a href="https://github.com/w3c/dxwg/issues/1583">#1583</a>, <a href="https://github.com/w3c/dxwg/issues/1591">#1591</a>.</p>
 </li>
-    <li><p>Fixed the wrong link to spdx 2.2 - see issue <a href="https://github.com/w3c/dxwg/issues/1592">#1592</a>.</p></li>
+    <li><p>Fixed the wrong link to SPDX 2.2 - see Issue <a href="https://github.com/w3c/dxwg/issues/1592">#1592</a>.</p></li>
     <li><p>Removed the references at risk features in status section, as implementations for those features have been collected in the implementation report.</p>
     </li>
 </ul>

--- a/dcat/index.html
+++ b/dcat/index.html
@@ -6787,7 +6787,7 @@ ga-courts:jc-wms
 
 <ul>
     <li>
-<p>Editorial fixes as suggested in issues <a href="https://github.com/w3c/dxwg/issues/1581">#1581</a>, <a href="https://github.com/w3c/dxwg/issues/1583">#1583</a>, <a href="https://github.com/w3c/dxwg/issues/1591">#1591</a>.</p>
+<p>Editorial fixes as suggested in Issues <a href="https://github.com/w3c/dxwg/issues/1581">#1581</a>, <a href="https://github.com/w3c/dxwg/issues/1583">#1583</a>, <a href="https://github.com/w3c/dxwg/issues/1591">#1591</a>.</p>
 </li>
     <li><p>Fixed the wrong link to spdx 2.2 - see issue <a href="https://github.com/w3c/dxwg/issues/1592">#1592</a>.</p></li>
     <li><p>Removed the references at risk features in status section, as implementations for those features have been collected in the implementation report.</p>

--- a/dcat/index.html
+++ b/dcat/index.html
@@ -6781,7 +6781,19 @@ ga-courts:jc-wms
 <p>A full change-log is available on <a href="https://github.com/w3c/dxwg/commits/gh-pages/dcat">GitHub</a></p>
 
 </section>
-	
+<section id="changes-since-20240118">	
+<h2>Changes since the Candidate Recommendation Snapshot 18 January 2024</h2>
+    <p>The document has undergone the following changes since the Candidate Recommendation Snapshot 18 January 2024 [[?VOCAB-DCAT-3-20240118]]:</p>
+
+<ul>
+    <li>
+<p>Editorial fixes as suggested in issues <a href="https://github.com/w3c/dxwg/issues/1581">#1581</a>, <a href="https://github.com/w3c/dxwg/issues/1583">#1583</a>, <a href="https://github.com/w3c/dxwg/issues/1591">#1591</a>.</p>
+</li>
+    <li><p>Fixed the wrong link to spdx 2.2 - see issue <a href="https://github.com/w3c/dxwg/issues/1592">#1592</a>.</p></li>
+    <li><p>Removed the references at risk features in status section, as implementations for those features have been collected in the implementation report.</p>
+    </li>
+</ul>
+</section>   
 <section id="changes-since-20220510">
 
 <h2>Changes since the fourth public working draft of 10 May 2022</h2>


### PR DESCRIPTION
Adding the new history section to track the changes since CR publication.

Preview:

https://raw.githack.com/w3c/dxwg/UpdatingHystory/dcat/index.html#changes-since-20240118

Diff:

https://services.w3.org/htmldiff?doc1=https%3A%2F%2Fw3c.github.io%2Fdxwg%2Fdcat%2F&doc2=https%3A%2F%2Fraw.githack.com%2Fw3c%2Fdxwg%2FUpdatingHystory%2Fdcat%2Findex.html